### PR TITLE
Set Vim as default editor with SUDO_EDITOR and VISUAL variables

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -32,6 +32,8 @@ source $DOTDOTFILES/lib/include/.zshrc.body ####
 ################################################
 
 # set editor to vim
+export SUDO_EDITOR=vim
+export VISUAL=vim
 export EDITOR=vim
 # enables color in ls
 export CLICOLOR=1


### PR DESCRIPTION
- Export Vim as the default editor for sudo and system-wide editing
- Ensure consistent editor configuration across different contexts