### PR TITLE
Create SSH sockets directory for connection sharing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,8 @@ chmod +x "$DOTDOTFILES/lib/install/apt.sh"
 chmod +x "$DOTDOTFILES/lib/install/mac.sh"
 chmod +x "$DOTDOTFILES/lib/install/brew.sh"
 
+mkdir -p "$HOME/.ssh/sockets"
+
 # include the global gitconfig
 git --git-dir="$DOTDOTFILES"/.git \
     --work-tree="$DOTDOTFILES" \


### PR DESCRIPTION
- Add mkdir command to create ~/.ssh/sockets directory
- Enables SSH connection multiplexing and socket reuse