### PR TITLE
Refactor Zsh plugin configuration for platform-specific plugins

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -11,7 +11,7 @@ source $DOTDOTFILES/lib/include/.zshrc.head
 # Ok to edit #########################  
 ZSH_THEME="powerlevel10k/powerlevel10k"
 common_plugins=(
-    zsh-nvm,
+    zsh-nvm
     colored-man-pages
     zsh-navigation-tools
     git

--- a/lib/include/.zshrc.body
+++ b/lib/include/.zshrc.body
@@ -12,6 +12,7 @@ fi
 
 source "$DOTDOTFILES/lib/include/.zshrc.zoxide"
 
+plugins+=( "${custom_plugins[@]}" )
 plugins+=( "${common_plugins[@]}" )
 
 source "$ZSH"/oh-my-zsh.sh

--- a/lib/include/.zshrc.mac
+++ b/lib/include/.zshrc.mac
@@ -2,7 +2,7 @@
 
 ##########################
 # macos specific plugins #
-export plugins=(vscode brew iterm2 macos)
+export custom_plugins=(vscode brew iterm2 macos)
 ##########################
 
 ########################

--- a/lib/include/.zshrc.ubuntu
+++ b/lib/include/.zshrc.ubuntu
@@ -2,7 +2,7 @@
 
 ###########################
 # ubuntu specific plugins #
-export plugins=(ubuntu)
+export custom_plugins=(ubuntu)
 ###########################
 
 ####################################


### PR DESCRIPTION
- Introduce custom_plugins array for platform-specific plugins
- Update .zshrc.mac and .zshrc.ubuntu to use custom_plugins
- Modify .zshrc.body to include custom_plugins before common_plugins
- Fix zsh-nvm plugin syntax in .zshrc