### PR TITLE
Refactor SSH config to simplify host declaration

### DIFF
--- a/home/.ssh/config
+++ b/home/.ssh/config
@@ -2,7 +2,7 @@ Include ~/.dotfiles/.ssh_config.local
 
 # Read more about SSH config files: <https://linux.die.net/man/5/ssh_config>
 
-Host home, router
+Host home router
     User agoodkind
     HostName home.goodkind.io
     LocalForward 9090 localhost:443


### PR DESCRIPTION
- Changed the format of the 'home' host entry to remove the comma, allowing for a cleaner configuration.