### PR TITLE
[codex] Update Go CI status grouping

### DIFF
--- a/.github/workflows/_go.yml
+++ b/.github/workflows/_go.yml
@@ -14,10 +14,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Install zsh
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y zsh
       - uses: actions/setup-go@v6
         with:
           go-version-file: dots/go.mod
@@ -38,6 +34,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Install zsh
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh
       - uses: actions/setup-go@v6
         with:
           go-version-file: dots/go.mod

--- a/.github/workflows/_go.yml
+++ b/.github/workflows/_go.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Install zsh
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh
       - uses: actions/setup-go@v6
         with:
           go-version-file: dots/go.mod

--- a/.github/workflows/_go.yml
+++ b/.github/workflows/_go.yml
@@ -1,0 +1,64 @@
+name: Go CI
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dots
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: dots/go.mod
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          install-only: true
+      - run: make lint
+
+  build-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dots
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: dots/go.mod
+      - run: make build
+      - run: make test
+
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dots
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: dots/go.mod
+      - run: make vet
+
+  govulncheck:
+    name: Govulncheck
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dots
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: dots/go.mod
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - run: make govulncheck

--- a/.github/workflows/_go.yml
+++ b/.github/workflows/_go.yml
@@ -12,6 +12,8 @@ jobs:
         working-directory: dots
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v6
         with:
           go-version-file: dots/go.mod
@@ -30,6 +32,8 @@ jobs:
         working-directory: dots
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v6
         with:
           go-version-file: dots/go.mod
@@ -44,6 +48,8 @@ jobs:
         working-directory: dots
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v6
         with:
           go-version-file: dots/go.mod
@@ -57,6 +63,8 @@ jobs:
         working-directory: dots
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v6
         with:
           go-version-file: dots/go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    uses: ./.github/workflows/_go.yml
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

Adds a top-level `CI` workflow with a `go` job that calls a local reusable workflow for the `dots` Go module.

## Validation

- Ran `actionlint` in this worktree.
- Ran `git diff --check` in this worktree.
- Opened as draft because this adds a subdirectory-aware local Go workflow wrapper.
