### PR TITLE
Skip git updates in fresh bootstrap smokes

### DIFF
--- a/.github/workflows/fresh-macos-bootstrap.yml
+++ b/.github/workflows/fresh-macos-bootstrap.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - uses: actions/setup-go@v6
         with:

--- a/dots/cmd/fresh-linux-bootstrap-smoke/main.go
+++ b/dots/cmd/fresh-linux-bootstrap-smoke/main.go
@@ -428,6 +428,10 @@ func runInsideContainer(ctx context.Context) error {
 	if err := cloneWorkspace(ctx); err != nil {
 		return err
 	}
+	if err := freshsmoke.AssertSmokeSubmodulesPresent(smokeRepoDir); err != nil {
+		slog.ErrorContext(ctx, "checking smoke submodules", "err", err)
+		return fmt.Errorf("checking smoke submodules: %w", err)
+	}
 	if err := freshsmoke.AssertAbsent("rg", "go", "shfmt", "ast-grep"); err != nil {
 		slog.ErrorContext(ctx, "asserting absent tools", "err", err)
 		return fmt.Errorf("asserting absent tools: %w", err)

--- a/dots/cmd/fresh-macos-bootstrap-smoke/main.go
+++ b/dots/cmd/fresh-macos-bootstrap-smoke/main.go
@@ -75,6 +75,10 @@ func runDirect(ctx context.Context, repoRoot string) error {
 	if err != nil {
 		return err
 	}
+	if err := freshsmoke.AssertSmokeSubmodulesPresent(repoRoot); err != nil {
+		slog.ErrorContext(ctx, "checking smoke submodules", "err", err)
+		return fmt.Errorf("checking smoke submodules: %w", err)
+	}
 	home, err := os.MkdirTemp("", "dotfiles-fresh-macos-*")
 	if err != nil {
 		slog.ErrorContext(ctx, "creating smoke home", "err", err)
@@ -338,6 +342,10 @@ func runInsideVM(ctx context.Context, repoRoot string, githubTokenFile string) e
 		return err
 	}
 	repoRoot = vmSmokeRepoDir
+	if err := freshsmoke.AssertSmokeSubmodulesPresent(repoRoot); err != nil {
+		slog.ErrorContext(ctx, "checking smoke submodules", "err", err)
+		return fmt.Errorf("checking smoke submodules: %w", err)
+	}
 
 	home, err := os.MkdirTemp("", "dotfiles-fresh-macos-*")
 	if err != nil {

--- a/dots/internal/freshsmoke/freshsmoke.go
+++ b/dots/internal/freshsmoke/freshsmoke.go
@@ -17,6 +17,8 @@ import (
 	"time"
 )
 
+var requiredSmokeSubmodules = []string{"lib/zinit", "lib/zsh-defer"}
+
 // HasCommand reports whether command is findable via [exec.LookPath].
 func HasCommand(command string) bool {
 	_, err := exec.LookPath(command)
@@ -91,6 +93,32 @@ func AssertCommandsOnPath(pathEnv string, commands ...string) error {
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("expected commands on PATH, missing: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// AssertSmokeSubmodulesPresent verifies that the snapshot under test includes
+// checked-out submodules. Smoke installs pass --skip-git, so install.sh will not
+// initialize submodules for the snapshot.
+func AssertSmokeSubmodulesPresent(repoRoot string) error {
+	missing := make([]string, 0)
+	for _, submodule := range requiredSmokeSubmodules {
+		gitPath := filepath.Join(repoRoot, submodule, ".git")
+		if _, err := os.Stat(gitPath); err == nil {
+			continue
+		} else if errors.Is(err, os.ErrNotExist) {
+			missing = append(missing, submodule)
+			continue
+		} else {
+			slog.Error("checking smoke submodule", "submodule", submodule, "err", err)
+			return fmt.Errorf("checking smoke submodule %s: %w", submodule, err)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"fresh smoke requires checked out submodules: %s; run git submodule update --init --recursive before smoke",
+			strings.Join(missing, ", "),
+		)
 	}
 	return nil
 }
@@ -208,15 +236,22 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
-// RunInstall runs install.sh --use-defaults from repoRoot with the given env,
-// streaming output to [os.Stdout]/[os.Stderr] and returning the combined output.
+func installArgs(installScript string, extraArgs ...string) []string {
+	args := []string{installScript, "--use-defaults", "--skip-git"}
+	args = append(args, extraArgs...)
+	return args
+}
+
+// RunInstall runs install.sh --use-defaults --skip-git from repoRoot with the
+// given env, streaming output to [os.Stdout]/[os.Stderr] and returning the
+// combined output.
 func RunInstall(ctx context.Context, repoRoot string, env []string, timeout time.Duration, extraArgs ...string) (string, error) {
 	slog.InfoContext(ctx, "running install.sh", "repoRoot", repoRoot)
 	callCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	installScript := filepath.Join(repoRoot, "install.sh")
-	args := append([]string{installScript, "--use-defaults"}, extraArgs...)
+	args := installArgs(installScript, extraArgs...)
 	cmd := exec.CommandContext(callCtx, "bash", args...)
 	cmd.Env = env
 	var output syncBuffer

--- a/dots/internal/freshsmoke/freshsmoke_test.go
+++ b/dots/internal/freshsmoke/freshsmoke_test.go
@@ -1,0 +1,49 @@
+package freshsmoke
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestInstallArgsIncludesSkipGitBeforeExtraArgs(t *testing.T) {
+	got := installArgs("/repo/install.sh", "--strict")
+	want := []string{"/repo/install.sh", "--use-defaults", "--skip-git", "--strict"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("installArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAssertSmokeSubmodulesPresentAcceptsCheckedOutSubmodules(t *testing.T) {
+	repoRoot := t.TempDir()
+	for _, submodule := range requiredSmokeSubmodules {
+		submoduleDir := filepath.Join(repoRoot, submodule)
+		if err := os.MkdirAll(submoduleDir, 0o755); err != nil {
+			t.Fatalf("creating submodule dir %s: %v", submodule, err)
+		}
+		if err := os.WriteFile(filepath.Join(submoduleDir, ".git"), []byte("gitdir: ../../.git/modules/"+submodule+"\n"), 0o600); err != nil {
+			t.Fatalf("writing submodule gitdir %s: %v", submodule, err)
+		}
+	}
+
+	if err := AssertSmokeSubmodulesPresent(repoRoot); err != nil {
+		t.Fatalf("AssertSmokeSubmodulesPresent() returned error: %v", err)
+	}
+}
+
+func TestAssertSmokeSubmodulesPresentReportsMissingSubmodules(t *testing.T) {
+	err := AssertSmokeSubmodulesPresent(t.TempDir())
+	if err == nil {
+		t.Fatal("AssertSmokeSubmodulesPresent() returned nil, want missing submodule error")
+	}
+	for _, submodule := range requiredSmokeSubmodules {
+		if !strings.Contains(err.Error(), submodule) {
+			t.Fatalf("missing submodule error did not mention %s: %v", submodule, err)
+		}
+	}
+	if !strings.Contains(err.Error(), "git submodule update --init --recursive") {
+		t.Fatalf("missing submodule error did not mention repair command: %v", err)
+	}
+}

--- a/dots/internal/sync/repository/repository_test.go
+++ b/dots/internal/sync/repository/repository_test.go
@@ -1,0 +1,66 @@
+package repository
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpdateGitRepoSyncRequiresSkipGitForDetachedHead(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	repoRoot := t.TempDir()
+	runGit(t, repoRoot, "init")
+	hooksDirectory := filepath.Join(repoRoot, ".git", "hooks-disabled")
+	if err := os.MkdirAll(hooksDirectory, 0o755); err != nil {
+		t.Fatalf("creating hooks directory: %v", err)
+	}
+	runGit(t, repoRoot, "config", "core.hooksPath", hooksDirectory)
+	runGit(t, repoRoot, "config", "user.name", "Smoke Test")
+	runGit(t, repoRoot, "config", "user.email", "smoke@example.invalid")
+	runGit(t, repoRoot, "config", "commit.gpgsign", "false")
+
+	readmePath := filepath.Join(repoRoot, "README.md")
+	if err := os.WriteFile(readmePath, []byte("smoke\n"), 0o644); err != nil {
+		t.Fatalf("writing README.md: %v", err)
+	}
+	runGit(t, repoRoot, "add", "README.md")
+	runGit(t, repoRoot, "commit", "-m", "Initial commit")
+
+	headSHA := strings.TrimSpace(runGitOutput(t, repoRoot, "rev-parse", "HEAD"))
+	runGit(t, repoRoot, "checkout", "--detach", headSHA)
+	t.Setenv("DOTDOTFILES", repoRoot)
+
+	err := UpdateGitRepoSync(context.Background(), false, nil)
+	if err == nil {
+		t.Fatal("UpdateGitRepoSync(skipGit=false) returned nil, want detached HEAD error")
+	}
+	if !strings.Contains(err.Error(), "detached HEAD") {
+		t.Fatalf("UpdateGitRepoSync(skipGit=false) error = %v, want detached HEAD", err)
+	}
+
+	if err := UpdateGitRepoSync(context.Background(), true, nil); err != nil {
+		t.Fatalf("UpdateGitRepoSync(skipGit=true) returned error: %v", err)
+	}
+}
+
+func runGit(t *testing.T, repoRoot string, args ...string) {
+	t.Helper()
+	output := runGitOutput(t, repoRoot, args...)
+	_ = output
+}
+
+func runGitOutput(t *testing.T, repoRoot string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", repoRoot}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}


### PR DESCRIPTION
### Summary

Fresh bootstrap smokes now test the checked-out repository snapshot instead of running the repository self-update path during install.

## Change

Smoke installs pass `--skip-git` while preserving `--strict`, and the smoke runners now fail clearly when required submodules are missing before install starts. The macOS smoke checkout now matches Linux by fetching submodules recursively.

The repository update path still rejects detached HEAD when `--skip-git` is false, and the new repository test covers both detached-HEAD behavior and the skip path.

## Testing

- `go test ./...`
- `make -C dots check`
- `GITHUB_TOKEN="$(gh auth token)" make -C dots smoke-linux-debian`