### PR TITLE
Add corpus rule-side Skill template rendering and skill_dest manifest config

### DIFF
--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -1,0 +1,145 @@
+---
+description: Technical documentation writing rules for scannable, plain, neutral prose
+globs: "*.md,*.mdc,*.txt"
+alwaysApply: false
+---
+
+# Technical documentation writing
+
+Help reviewers find the answer quickly.
+
+## Overview
+
+Good technical documentation feels light, precise, and easy to scan. This rule provides the model for plain language and accessibility and style guide for restrained, polished wording.
+
+A useful document includes only details that help readers understand, verify, or ship safely.
+
+## Write for review
+
+Prose for review should be clear enough for a critical Apple Marketing review.
+
+- The first sentence gives the load-bearing point.
+- Each paragraph gives the reviewer one idea to evaluate.
+- The prose fits the reviewer's context.
+- Accessible writing keeps wording simple and concrete.
+- Jargon belongs only when the reviewer needs it.
+- The wording stays clear, precise, restrained, and polished.
+- Each claim gives the reviewer enough context to verify it.
+- Ambiguous claims should become concrete behavior.
+
+## Structure the page
+
+A clear page or pull request (PR) description starts with the result.
+
+- The title names the task, topic, or change.
+- The summary sentence states the behavior or qualitative result.
+- The `Overview` section gives only the context needed to start.
+- Each later section answers one reviewer question.
+- Each task heading starts with an action verb.
+- Numbered steps describe ordered work.
+- Notes appear beside the step they clarify.
+
+## Keep detail load bearing
+
+A detail belongs when it helps the reviewer understand, verify, or ship safely.
+
+- Nonessential context stays out of the document.
+- Unasked recommendations stay out of review prose.
+- Repeated detail creates drift and should become a link or disappear.
+- Adjacent context belongs only when it changes risk or review.
+- Implementation detail stays at the system level.
+- The prose explains behavior before naming code.
+- Prose should not narrate literal code.
+- Code anchors appear only when they help the reader orient.
+- The code carries line-level detail.
+
+## Order information
+
+The most useful information belongs before supporting detail.
+
+- The first sentence gives the answer.
+- Later sentences add limits, examples, and exceptions.
+- Everyday product or system nouns introduce a concept before code names.
+- Behavioral or qualitative context comes before implementation detail.
+- The prose explains why behavior exists when the reason affects review.
+- The pattern `This behavior changes X because Y.` keeps cause and effect visible.
+
+## Write plain sentences
+
+Clear sentences can stand alone.
+
+- Each sentence has a concrete subject and a concrete verb.
+- Each sentence stays under 20 words when that preserves meaning.
+- Separate ideas work better as separate sentences.
+- Verbose, inflated, or low-substance prose should become shorter or disappear.
+- The {{.Skill "make-readable"}} rule helps remove dense or repetitive prose.
+- The {{.Skill "plain"}} rule helps define unexplained labels before use.
+- The {{.Skill "remove-emdashes"}} rule helps split interrupted sentences into separate thoughts.
+
+## Write direct instructions
+
+Direct instructions tell the reader what to do and what will happen.
+
+- Active voice works best for most instructions.
+- The word `you` can address the reader directly.
+- The word `your` works when the reader owns the object.
+- Imperative mood keeps steps direct.
+- Irreversible results belong before the action.
+- Externally visible results belong before the action.
+
+## Choose precise words
+
+Plain words and specific verbs make instructions easier to follow.
+
+- The word `use` is clearer than `utilize`.
+- The word `to` is clearer than `in order to`.
+- The word `after` is clearer than `subsequent to`.
+- Verbs such as `configure`, `delete`, `export`, and `authenticate` work well when they fit.
+- A more specific verb works better than `manage`.
+- A more specific verb works better than `process`.
+
+## Preserve exact terms
+
+System names should match the product or code.
+
+- UI element names match the interface exactly.
+- Configuration key names match the source exactly.
+- Code parameter names match the source exactly.
+- Capitalization matches the source exactly.
+- Formatting matches the source exactly.
+- Acronyms are spelled out on first use unless they are universal.
+
+## Use action language
+
+One interaction type should use one action verb.
+
+- The verb `select` fits menus.
+- The verb `click` fits desktop pointers.
+- The verb `tap` fits touch screens.
+- The verb `run` fits command lines.
+- The verb `execute` fits command lines.
+
+## Write helpful errors
+
+Helpful errors explain the cause before the cure.
+
+1. State what went wrong.
+2. State how to fix it.
+
+Neutral error text helps the reader recover.
+
+- Error text states system status calmly.
+- Error text keeps blame out of the message.
+- Error text avoids alarmist language such as `Fatal Error!`.
+- Error codes appear with a plain solution.
+
+## Use durable links
+
+Links work best when another local source is the stable home for the detail.
+
+- Link text stays free of backticks.
+- Local sources carry load-bearing details when possible.
+- Stable local files are better than copied detail.
+- Repeated detail creates drift.
+- Current behavior matters more than history.
+- Historical notes appear only when current work requires them.

--- a/corpus/targets.toml
+++ b/corpus/targets.toml
@@ -26,23 +26,26 @@ dest      = ".claude/skills"
 ref_style = "md"
 
 [[output]]
-provider = "claude"
-kind     = "rule-files"
-dest     = ".claude/rules"
-rule_ext = ".md"
+provider   = "claude"
+kind       = "rule-files"
+dest       = ".claude/rules"
+rule_ext   = ".md"
+skill_dest = ".claude/skills"
 
 [[output]]
-provider = "claude"
-kind     = "instruction-doc"
-dest     = ".claude/CLAUDE.md"
-title    = "Claude Memory"
+provider   = "claude"
+kind       = "instruction-doc"
+dest       = ".claude/CLAUDE.md"
+title      = "Claude Memory"
+skill_dest = ".claude/skills"
 
 # Cursor
 [[output]]
-provider = "cursor"
-kind     = "rule-files"
-dest     = ".cursor/rules"
-rule_ext = ".mdc"
+provider   = "cursor"
+kind       = "rule-files"
+dest       = ".cursor/rules"
+rule_ext   = ".mdc"
+skill_dest = ".agents/skills"
 
 # Shared cross-agent directory (read by Zed, VSCode, and Codex)
 [[output]]
@@ -52,10 +55,11 @@ dest      = ".agents/skills"
 ref_style = "mdc"
 
 [[output]]
-provider = "agents"
-kind     = "rule-files"
-dest     = ".agents/rules"
-rule_ext = ".mdc"
+provider   = "agents"
+kind       = "rule-files"
+dest       = ".agents/rules"
+rule_ext   = ".mdc"
+skill_dest = ".agents/skills"
 
 # Codex
 [[output]]
@@ -64,33 +68,38 @@ kind     = "codex-rules"
 dest     = ".codex/rules/dotfiles.rules"
 
 [[output]]
-provider = "codex"
-kind     = "instruction-doc"
-dest     = ".codex/AGENTS.md"
-title    = "Codex Instructions"
+provider   = "codex"
+kind       = "instruction-doc"
+dest       = ".codex/AGENTS.md"
+title      = "Codex Instructions"
+skill_dest = ".agents/skills"
 
 # Gemini
 [[output]]
-provider = "gemini"
-kind     = "instruction-doc"
-dest     = ".gemini/GEMINI.md"
-title    = "Gemini Instructions"
+provider   = "gemini"
+kind       = "instruction-doc"
+dest       = ".gemini/GEMINI.md"
+title      = "Gemini Instructions"
+skill_dest = ".agents/skills"
 
 # GitHub Copilot
 [[output]]
-provider = "copilot"
-kind     = "instruction-doc"
-dest     = ".copilot/copilot-instructions.md"
-title    = "Copilot Instructions"
+provider   = "copilot"
+kind       = "instruction-doc"
+dest       = ".copilot/copilot-instructions.md"
+title      = "Copilot Instructions"
+skill_dest = ".agents/skills"
 
 [[output]]
-provider = "copilot"
-kind     = "per-file-instructions"
-dest     = ".copilot/instructions"
+provider   = "copilot"
+kind       = "per-file-instructions"
+dest       = ".copilot/instructions"
+skill_dest = ".agents/skills"
 
 # Zed (first-party agent reads user-global rules from this doc)
 [[output]]
-provider = "zed"
-kind     = "instruction-doc"
-dest     = ".config/zed/AGENTS.md"
-title    = "Zed Instructions"
+provider   = "zed"
+kind       = "instruction-doc"
+dest       = ".config/zed/AGENTS.md"
+title      = "Zed Instructions"
+skill_dest = ".agents/skills"

--- a/dots/internal/sync/compilation/compilation.go
+++ b/dots/internal/sync/compilation/compilation.go
@@ -146,9 +146,15 @@ func CreateHushLogin(ctx context.Context, _ *telemetry.Logger) error {
 	return nil
 }
 
+// RuleRenderStyle describes how generated rule files reference generated skills.
+type RuleRenderStyle struct {
+	// SkillsRelDir is the relative directory from the rendered rule location to generated skill directories.
+	SkillsRelDir string
+}
+
 // RenderRuleFiles writes each .mdc rule file from src into dst as a marker-stamped
 // generated file with the given extension (for example ".mdc" or ".md").
-func RenderRuleFiles(src string, dst string, ext string) error {
+func RenderRuleFiles(src string, dst string, ext string, style RuleRenderStyle) error {
 	files, err := sortedFilesWithExt(src, ".mdc")
 	if err != nil {
 		return err
@@ -167,19 +173,67 @@ func RenderRuleFiles(src string, dst string, ext string) error {
 			slog.Warn("compilation: RenderRuleFiles read failed", "file", file, "err", readErr)
 			return fmt.Errorf("reading file %s: %w", file, readErr)
 		}
+		rendered, renderErr := renderRuleTemplate(string(content), style, filepath.Base(file))
+		if renderErr != nil {
+			return renderErr
+		}
 		target := filepath.Join(dst, targetName)
 		if isSymlink(target) {
 			_ = os.Remove(target)
 		}
-		if err := writeFileIfChanged(target, []byte(injectSkillMarker(string(content)))); err != nil {
+		if err := writeFileIfChanged(target, []byte(injectSkillMarker(rendered))); err != nil {
 			return err
 		}
 	}
 	return removeMissingManagedFiles(dst, ext, activeFiles)
 }
 
+// ruleTemplateData exposes skill reference helpers to a rule template as the
+// "{{.Skill \"name\"}}" method for the active RuleRenderStyle.
+type ruleTemplateData struct {
+	style   RuleRenderStyle
+	execErr *error
+}
+
+// Skill renders a single skill link for the active style.
+func (d ruleTemplateData) Skill(name string) string {
+	if d.style.SkillsRelDir == "" {
+		if d.execErr != nil {
+			*d.execErr = fmt.Errorf("skill link %q requires skill_dest in manifest", name)
+		}
+		return ""
+	}
+	return renderSkillLink(d.style, name)
+}
+
+func renderRuleTemplate(content string, style RuleRenderStyle, name string) (string, error) {
+	if !strings.Contains(content, "{{") {
+		return content, nil
+	}
+	var execErr error
+	parsed, err := template.New(name).Parse(content)
+	if err != nil {
+		slog.Warn("compilation: renderRuleTemplate parse failed", "name", name, "err", err)
+		return "", fmt.Errorf("parsing rule template %s: %w", name, err)
+	}
+	buf := bytes.NewBuffer(nil)
+	if err := parsed.Execute(buf, ruleTemplateData{style: style, execErr: &execErr}); err != nil {
+		slog.Warn("compilation: renderRuleTemplate execute failed", "name", name, "err", err)
+		return "", fmt.Errorf("executing rule template %s: %w", name, err)
+	}
+	if execErr != nil {
+		return "", execErr
+	}
+	return buf.String(), nil
+}
+
+func renderSkillLink(style RuleRenderStyle, name string) string {
+	skillPath := filepath.ToSlash(filepath.Join(style.SkillsRelDir, name, "SKILL.md"))
+	return fmt.Sprintf("[%s](%s)", name, skillPath)
+}
+
 // RenderRulesAsInstructionDoc concatenates .mdc rule files from src into a single markdown document at dst.
-func RenderRulesAsInstructionDoc(src string, dst string, title string) error {
+func RenderRulesAsInstructionDoc(src string, dst string, title string, style RuleRenderStyle) error {
 	files, err := sortedFilesWithExt(src, ".mdc")
 	if err != nil {
 		return err
@@ -213,8 +267,11 @@ func RenderRulesAsInstructionDoc(src string, dst string, title string) error {
 		if stripErr != nil {
 			return stripErr
 		}
-		body = strings.TrimSpace(body)
-		builder.WriteString(body)
+		rendered, renderErr := renderRuleTemplate(strings.TrimSpace(body), style, filepath.Base(file))
+		if renderErr != nil {
+			return renderErr
+		}
+		builder.WriteString(rendered)
 		builder.WriteString("\n")
 	}
 
@@ -222,7 +279,7 @@ func RenderRulesAsInstructionDoc(src string, dst string, title string) error {
 }
 
 // RenderCopilotInstructionFiles renders .mdc rule files from src as .instructions.md files in dst.
-func RenderCopilotInstructionFiles(src string, dst string) error {
+func RenderCopilotInstructionFiles(src string, dst string, style RuleRenderStyle) error {
 	files, err := sortedFilesWithExt(src, ".mdc")
 	if err != nil {
 		return err
@@ -247,7 +304,11 @@ func RenderCopilotInstructionFiles(src string, dst string) error {
 		if parseErr != nil {
 			return parseErr
 		}
-		rendered, renderErr := renderCopilotInstruction(baseName, frontmatter, body)
+		renderedBody, renderErr := renderRuleTemplate(strings.TrimSpace(body), style, filepath.Base(file))
+		if renderErr != nil {
+			return renderErr
+		}
+		rendered, renderErr := renderCopilotInstruction(baseName, frontmatter, renderedBody)
 		if renderErr != nil {
 			return renderErr
 		}

--- a/dots/internal/sync/compilation/skills_test.go
+++ b/dots/internal/sync/compilation/skills_test.go
@@ -227,6 +227,39 @@ func TestRenderSkillDirsTemplateParseError(t *testing.T) {
 	}
 }
 
+func TestRenderRuleTemplateSkillLink(t *testing.T) {
+	style := RuleRenderStyle{SkillsRelDir: "../skills"}
+	got, err := renderRuleTemplate("See {{.Skill \"make-readable\"}} for help.", style, "writing.mdc")
+	if err != nil {
+		t.Fatalf("renderRuleTemplate: %v", err)
+	}
+	want := "See [make-readable](../skills/make-readable/SKILL.md) for help."
+	if got != want {
+		t.Errorf("renderRuleTemplate skill link\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestRenderRuleTemplateMissingSkillDest(t *testing.T) {
+	_, err := renderRuleTemplate("See {{.Skill \"make-readable\"}}.", RuleRenderStyle{}, "writing.mdc")
+	if err == nil {
+		t.Fatal("expected error when skill_dest is not configured, got nil")
+	}
+	if !strings.Contains(err.Error(), "skill_dest") {
+		t.Errorf("expected skill_dest in error, got: %v", err)
+	}
+}
+
+func TestRenderRuleTemplatePassthrough(t *testing.T) {
+	content := "plain body without tokens\n"
+	got, err := renderRuleTemplate(content, RuleRenderStyle{}, "general.mdc")
+	if err != nil {
+		t.Fatalf("renderRuleTemplate: %v", err)
+	}
+	if got != content {
+		t.Errorf("expected passthrough, got: %q", got)
+	}
+}
+
 func TestRenderRuleFiles(t *testing.T) {
 	srcRoot := t.TempDir()
 	writeTestFile(t, filepath.Join(srcRoot, "general.mdc"), "---\ndescription: g\n---\ngeneral body\n")
@@ -236,7 +269,7 @@ func TestRenderRuleFiles(t *testing.T) {
 	stale := filepath.Join(dst, "old.mdc")
 	writeTestFile(t, stale, GeneratedAgentHTMLMarker+"\nstale\n")
 
-	if err := RenderRuleFiles(srcRoot, dst, ".mdc"); err != nil {
+	if err := RenderRuleFiles(srcRoot, dst, ".mdc", RuleRenderStyle{}); err != nil {
 		t.Fatalf("RenderRuleFiles: %v", err)
 	}
 	for _, name := range []string{"general.mdc", "code.mdc"} {

--- a/dots/internal/sync/corpus/corpus.go
+++ b/dots/internal/sync/corpus/corpus.go
@@ -157,8 +157,9 @@ func renderOutput(source compilation.CorpusPaths, output Output, home string, de
 }
 
 func resolveRuleRenderStyle(output Output, home string, dest string) (compilation.RuleRenderStyle, error) {
+	emptyStyle := compilation.RuleRenderStyle{SkillsRelDir: ""}
 	if output.SkillDest == "" {
-		return compilation.RuleRenderStyle{}, nil
+		return emptyStyle, nil
 	}
 	var linkBase string
 	switch output.Kind {
@@ -166,13 +167,14 @@ func resolveRuleRenderStyle(output Output, home string, dest string) (compilatio
 		linkBase = dest
 	case KindInstructionDoc:
 		linkBase = filepath.Dir(dest)
-	default:
-		return compilation.RuleRenderStyle{}, nil
+	case KindSkills, KindCodexRules:
+		return emptyStyle, nil
 	}
 	skillRoot := filepath.Join(home, output.SkillDest)
 	skillsRelDir, err := filepath.Rel(linkBase, skillRoot)
 	if err != nil {
-		return compilation.RuleRenderStyle{}, fmt.Errorf("computing skill link path for %s: %w", output.Provider, err)
+		slog.Error("corpus: computing skill link path", "provider", output.Provider, "err", err)
+		return emptyStyle, fmt.Errorf("computing skill link path for %s: %w", output.Provider, err)
 	}
 	return compilation.RuleRenderStyle{SkillsRelDir: filepath.ToSlash(skillsRelDir)}, nil
 }

--- a/dots/internal/sync/corpus/corpus.go
+++ b/dots/internal/sync/corpus/corpus.go
@@ -53,13 +53,14 @@ const (
 
 // Output is one declarative fan-out artifact.
 type Output struct {
-	Provider string       `toml:"provider"`
-	Kind     OutputKind   `toml:"kind"`
-	Dest     string       `toml:"dest"`
-	RefStyle RefStyleName `toml:"ref_style"`
-	RuleExt  string       `toml:"rule_ext"`
-	Title    string       `toml:"title"`
-	OS       string       `toml:"os"`
+	Provider  string       `toml:"provider"`
+	Kind      OutputKind   `toml:"kind"`
+	Dest      string       `toml:"dest"`
+	RefStyle  RefStyleName `toml:"ref_style"`
+	RuleExt   string       `toml:"rule_ext"`
+	SkillDest string       `toml:"skill_dest"`
+	Title     string       `toml:"title"`
+	OS        string       `toml:"os"`
 }
 
 // Manifest is the parsed targets.toml.
@@ -103,14 +104,14 @@ func Sync(ctx context.Context, dotfiles string, logger *telemetry.Logger) error 
 			continue
 		}
 		dest := filepath.Join(home, output.Dest)
-		if err := renderOutput(source, output, dest); err != nil {
+		if err := renderOutput(source, output, home, dest); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func renderOutput(source compilation.CorpusPaths, output Output, dest string) error {
+func renderOutput(source compilation.CorpusPaths, output Output, home string, dest string) error {
 	var err error
 	switch output.Kind {
 	case KindSkills:
@@ -123,14 +124,26 @@ func renderOutput(source compilation.CorpusPaths, output Output, dest string) er
 		if output.RuleExt == "" {
 			return fmt.Errorf("rule-files output for %s requires rule_ext", output.Provider)
 		}
-		err = compilation.RenderRuleFiles(source.Rules, dest, output.RuleExt)
+		ruleStyle, ruleStyleErr := resolveRuleRenderStyle(output, home, dest)
+		if ruleStyleErr != nil {
+			return ruleStyleErr
+		}
+		err = compilation.RenderRuleFiles(source.Rules, dest, output.RuleExt, ruleStyle)
 	case KindInstructionDoc:
 		if output.Title == "" {
 			return fmt.Errorf("instruction-doc output for %s requires title", output.Provider)
 		}
-		err = compilation.RenderRulesAsInstructionDoc(source.Rules, dest, output.Title)
+		ruleStyle, ruleStyleErr := resolveRuleRenderStyle(output, home, dest)
+		if ruleStyleErr != nil {
+			return ruleStyleErr
+		}
+		err = compilation.RenderRulesAsInstructionDoc(source.Rules, dest, output.Title, ruleStyle)
 	case KindPerFileInstructions:
-		err = compilation.RenderCopilotInstructionFiles(source.Rules, dest)
+		ruleStyle, ruleStyleErr := resolveRuleRenderStyle(output, home, dest)
+		if ruleStyleErr != nil {
+			return ruleStyleErr
+		}
+		err = compilation.RenderCopilotInstructionFiles(source.Rules, dest, ruleStyle)
 	case KindCodexRules:
 		err = compilation.RenderCodexRules(source.Rules, dest)
 	default:
@@ -141,6 +154,27 @@ func renderOutput(source compilation.CorpusPaths, output Output, dest string) er
 		return fmt.Errorf("rendering %s %s into %s: %w", output.Provider, output.Kind, dest, err)
 	}
 	return nil
+}
+
+func resolveRuleRenderStyle(output Output, home string, dest string) (compilation.RuleRenderStyle, error) {
+	if output.SkillDest == "" {
+		return compilation.RuleRenderStyle{}, nil
+	}
+	var linkBase string
+	switch output.Kind {
+	case KindRuleFiles, KindPerFileInstructions:
+		linkBase = dest
+	case KindInstructionDoc:
+		linkBase = filepath.Dir(dest)
+	default:
+		return compilation.RuleRenderStyle{}, nil
+	}
+	skillRoot := filepath.Join(home, output.SkillDest)
+	skillsRelDir, err := filepath.Rel(linkBase, skillRoot)
+	if err != nil {
+		return compilation.RuleRenderStyle{}, fmt.Errorf("computing skill link path for %s: %w", output.Provider, err)
+	}
+	return compilation.RuleRenderStyle{SkillsRelDir: filepath.ToSlash(skillsRelDir)}, nil
 }
 
 func resolveRefStyle(name RefStyleName) (compilation.SkillRefStyle, error) {

--- a/dots/internal/sync/corpus/corpus_test.go
+++ b/dots/internal/sync/corpus/corpus_test.go
@@ -49,10 +49,13 @@ func TestLoadManifest(t *testing.T) {
 func TestSyncRendersAndGatesByOS(t *testing.T) {
 	dotfiles := t.TempDir()
 	writeFile(t, filepath.Join(dotfiles, "corpus", "rules", "code.mdc"), "---\ndescription: c\n---\ncode body\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", "rules", "writing.mdc"), "---\ndescription: w\n---\nSkill: {{.Skill \"make-readable\"}}\n")
 	writeFile(t, filepath.Join(dotfiles, "corpus", "skills", "enforce-rules", "SKILL.md.tmpl"), "---\nname: enforce-rules\n---\n\nOne: {{.Rule \"code\"}}\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", "skills", "make-readable", "SKILL.md.tmpl"), "---\nname: make-readable\n---\n")
 	writeFile(t, filepath.Join(dotfiles, "corpus", ManifestName),
 		"[[output]]\nprovider=\"claude\"\nkind=\"skills\"\ndest=\".claude/skills\"\nref_style=\"md\"\n\n"+
-			"[[output]]\nprovider=\"claude\"\nkind=\"instruction-doc\"\ndest=\".claude/CLAUDE.md\"\ntitle=\"Claude Memory\"\n\n"+
+			"[[output]]\nprovider=\"claude\"\nkind=\"rule-files\"\ndest=\".claude/rules\"\nrule_ext=\".md\"\nskill_dest=\".claude/skills\"\n\n"+
+			"[[output]]\nprovider=\"claude\"\nkind=\"instruction-doc\"\ndest=\".claude/CLAUDE.md\"\ntitle=\"Claude Memory\"\nskill_dest=\".claude/skills\"\n\n"+
 			"[[output]]\nprovider=\"never\"\nkind=\"instruction-doc\"\ndest=\".never/NEVER.md\"\ntitle=\"Never\"\nos=\"plan9\"\n")
 
 	home := t.TempDir()
@@ -70,8 +73,21 @@ func TestSyncRendersAndGatesByOS(t *testing.T) {
 	if want := "[code.md](../../rules/code.md)"; !strings.Contains(string(got), want) {
 		t.Errorf("rendered skill missing expanded rule link %q:\n%s", want, string(got))
 	}
-	if _, err := os.Stat(filepath.Join(home, ".claude", "CLAUDE.md")); err != nil {
-		t.Errorf("expected CLAUDE.md to be written: %v", err)
+
+	rule, err := os.ReadFile(filepath.Join(home, ".claude", "rules", "writing.md"))
+	if err != nil {
+		t.Fatalf("reading rendered rule: %v", err)
+	}
+	if want := "[make-readable](../skills/make-readable/SKILL.md)"; !strings.Contains(string(rule), want) {
+		t.Errorf("rendered rule missing expanded skill link %q:\n%s", want, string(rule))
+	}
+
+	doc, err := os.ReadFile(filepath.Join(home, ".claude", "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("reading CLAUDE.md: %v", err)
+	}
+	if want := "[make-readable](skills/make-readable/SKILL.md)"; !strings.Contains(string(doc), want) {
+		t.Errorf("instruction doc missing expanded skill link %q:\n%s", want, string(doc))
 	}
 	if _, err := os.Stat(filepath.Join(home, ".never", "NEVER.md")); !os.IsNotExist(err) {
 		t.Errorf("expected os-gated output to be skipped, stat err: %v", err)


### PR DESCRIPTION
### Summary

Corpus rule source files can reference generated skills with `{{.Skill "name"}}` tokens instead of hard-coded paths to `SKILL.md.tmpl`. The corpus fan-out layer expands those tokens into relative links to generated `SKILL.md` files for each provider output.

## Why

Skill templates already use `{{.Rule "name"}}` to link back to generated rule files, but rule files had no matching helper. Source rules that linked directly to template paths would break after fan-out because generated outputs live in different directories per provider.

## Change

The compilation layer adds a rule-side `{{.Skill "name"}}` template helper and threads it through rule file rendering, instruction document rendering, and Copilot per-file instruction rendering. The corpus manifest gains an explicit `skill_dest` field on rule-based outputs, and the fan-out layer computes relative skill link paths from each output location.

The new `writing.mdc` rule uses skill tokens for the make-readable, plain, and remove-emdashes skills. `targets.toml` sets `skill_dest` for Claude (`.claude/skills`) and shared providers (`.agents/skills`). Missing `skill_dest` when a rule uses `{{.Skill}}` returns a clear error.

## Testing

Ran `go test ./internal/sync/compilation ./internal/sync/corpus` and `go test ./...` in the dots module; both passed.