### PR TITLE
Add neutral RuleSource model and provider-specific corpus rule front matter rendering

### DIFF
--- a/corpus/rules/code.mdc
+++ b/corpus/rules/code.mdc
@@ -1,7 +1,16 @@
 ---
 description: Code style conventions for JavaScript, TypeScript, Ruby, and Shell
-globs: "*.js,*.jsx,*.ts,*.tsx,*.rb,*.sh,*.zsh,*.bash,*.go"
-alwaysApply: false
+applies_to:
+  - "*.js"
+  - "*.jsx"
+  - "*.ts"
+  - "*.tsx"
+  - "*.rb"
+  - "*.sh"
+  - "*.zsh"
+  - "*.bash"
+  - "*.go"
+always: false
 ---
 
 JavaScript/TypeScript: Use function definitions for top-level functions, not arrow functions (e.g. `function handleClick(event: FullyQualifiedType) { ... }`). All JSDoc must include types exhaustively.

--- a/corpus/rules/general.mdc
+++ b/corpus/rules/general.mdc
@@ -1,7 +1,8 @@
 ---
 description: Response behavior, writing style, and investigatory framing
-globs: "**/*"
-alwaysApply: true
+applies_to:
+  - "**/*"
+always: true
 ---
 
 Accuracy: All responses are uncertain by default. For every sentence, line of code, and piece of reasoning, state all assumptions explicitly and inline, provide a concrete user-verifiable source (a specific documentation page, paper, standard, or reproducible test), and if no verifiable source exists, explicitly state that no verifiable source is available. Replace generic references ("studies show," "it is known") with specific, traceable sources. State certainty level explicitly and act on tasks where you are 99.99% confident. When the user corrects you, fix the issue, show concrete proof (a test or lint result), then stop. Get explicit permission for destructive git operations like force pushing or hard resetting.

--- a/corpus/rules/python.mdc
+++ b/corpus/rules/python.mdc
@@ -1,7 +1,8 @@
 ---
 description: Python code style, typing, toolchain, and project conventions
-globs: "*.py"
-alwaysApply: false
+applies_to:
+  - "*.py"
+always: false
 ---
 
 Python version: Use the latest stable Python release for all repos. Set `requires-python`, `mypy python_version`, `basedpyright pythonVersion`, and `ruff target-version` to match in `pyproject.toml`.

--- a/corpus/rules/security.mdc
+++ b/corpus/rules/security.mdc
@@ -1,7 +1,8 @@
 ---
 description: Sensitive data handling - store keys/tokens in env or files only
-globs: "**/*"
-alwaysApply: true
+applies_to:
+  - "**/*"
+always: true
 ---
 
 # Security - Sensitive Data Handling

--- a/corpus/rules/semantic.mdc
+++ b/corpus/rules/semantic.mdc
@@ -1,7 +1,8 @@
 ---
 description: Use the semantic MCP server first for conceptual code discovery
-globs: "**/*"
-alwaysApply: true
+applies_to:
+  - "**/*"
+always: true
 ---
 
 Prefer the semantic MCP server's `search_code` for conceptual repo-wide discovery, but do not use it blindly.

--- a/corpus/rules/shell.mdc
+++ b/corpus/rules/shell.mdc
@@ -1,7 +1,8 @@
 ---
 description: Shell and command execution mechanics
-globs: "**/*"
-alwaysApply: true
+applies_to:
+  - "**/*"
+always: true
 ---
 
 File editing: Read the current state of a file immediately before editing it. The user may have made changes since the file was last read, and edits should reflect the actual current content.

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -1,7 +1,10 @@
 ---
 description: Technical documentation writing rules for scannable, plain, neutral prose
-globs: "*.md,*.mdc,*.txt"
-alwaysApply: false
+applies_to:
+  - "*.md"
+  - "*.mdc"
+  - "*.txt"
+always: false
 ---
 
 # Technical documentation writing

--- a/dots/internal/sync/compilation/compilation.go
+++ b/dots/internal/sync/compilation/compilation.go
@@ -17,7 +17,6 @@ import (
 	"goodkind.io/.dotfiles/internal/runner"
 	"goodkind.io/.dotfiles/internal/sync/common"
 	"goodkind.io/.dotfiles/internal/telemetry"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -34,18 +33,6 @@ type CorpusPaths struct {
 	Root   string
 	Rules  string
 	Skills string
-}
-
-type agentRuleFrontmatter struct {
-	Description string `yaml:"description,omitempty"`
-	Globs       string `yaml:"globs,omitempty"`
-	AlwaysApply bool   `yaml:"alwaysApply,omitempty"`
-}
-
-type frontmatterMetadata struct {
-	Name        string `yaml:"name,omitempty"`
-	Description string `yaml:"description,omitempty"`
-	ApplyTo     string `yaml:"applyTo,omitempty"`
 }
 
 // ResolveCorpusSource returns the CorpusPaths for the given dotfiles root.
@@ -154,7 +141,7 @@ type RuleRenderStyle struct {
 
 // RenderRuleFiles writes each .mdc rule file from src into dst as a marker-stamped
 // generated file with the given extension (for example ".mdc" or ".md").
-func RenderRuleFiles(src string, dst string, ext string, style RuleRenderStyle) error {
+func RenderRuleFiles(src string, dst string, ext string, format RuleTargetFormat, style RuleRenderStyle) error {
 	files, err := sortedFilesWithExt(src, ".mdc")
 	if err != nil {
 		return err
@@ -173,7 +160,16 @@ func RenderRuleFiles(src string, dst string, ext string, style RuleRenderStyle) 
 			slog.Warn("compilation: RenderRuleFiles read failed", "file", file, "err", readErr)
 			return fmt.Errorf("reading file %s: %w", file, readErr)
 		}
-		rendered, renderErr := renderRuleTemplate(string(content), style, filepath.Base(file))
+		rule, parseErr := ParseRuleSource(string(content))
+		if parseErr != nil {
+			return parseErr
+		}
+		renderedBody, renderErr := renderRuleTemplate(strings.TrimSpace(rule.Body), style, filepath.Base(file))
+		if renderErr != nil {
+			return renderErr
+		}
+		rule.Body = renderedBody
+		rendered, renderErr := rule.RenderForTarget(format)
 		if renderErr != nil {
 			return renderErr
 		}
@@ -263,11 +259,11 @@ func RenderRulesAsInstructionDoc(src string, dst string, title string, style Rul
 			slog.Warn("compilation: RenderRulesAsInstructionDoc read failed", "file", file, "err", readErr)
 			return fmt.Errorf("reading file %s: %w", file, readErr)
 		}
-		body, stripErr := stripFrontmatter(string(content))
-		if stripErr != nil {
-			return stripErr
+		rule, parseErr := ParseRuleSource(string(content))
+		if parseErr != nil {
+			return parseErr
 		}
-		rendered, renderErr := renderRuleTemplate(strings.TrimSpace(body), style, filepath.Base(file))
+		rendered, renderErr := renderRuleTemplate(strings.TrimSpace(rule.Body), style, filepath.Base(file))
 		if renderErr != nil {
 			return renderErr
 		}
@@ -300,15 +296,16 @@ func RenderCopilotInstructionFiles(src string, dst string, style RuleRenderStyle
 			slog.Warn("compilation: RenderCopilotInstructionFiles read failed", "file", file, "err", readErr)
 			return fmt.Errorf("reading file %s: %w", file, readErr)
 		}
-		frontmatter, body, parseErr := parseFrontmatter(string(content))
+		rule, parseErr := ParseRuleSource(string(content))
 		if parseErr != nil {
 			return parseErr
 		}
-		renderedBody, renderErr := renderRuleTemplate(strings.TrimSpace(body), style, filepath.Base(file))
+		renderedBody, renderErr := renderRuleTemplate(strings.TrimSpace(rule.Body), style, filepath.Base(file))
 		if renderErr != nil {
 			return renderErr
 		}
-		rendered, renderErr := renderCopilotInstruction(baseName, frontmatter, renderedBody)
+		rule.Body = renderedBody
+		rendered, renderErr := rule.RenderCopilot(baseName)
 		if renderErr != nil {
 			return renderErr
 		}
@@ -587,62 +584,6 @@ func sortedFilesWithExt(src string, ext string) ([]string, error) {
 	}
 	sort.Strings(files)
 	return files, nil
-}
-
-func stripFrontmatter(content string) (string, error) {
-	_, body, err := parseFrontmatter(content)
-	return body, err
-}
-
-func renderCopilotInstruction(baseName string, frontmatter agentRuleFrontmatter, body string) (string, error) {
-	applyTo := strings.TrimSpace(frontmatter.Globs)
-	if applyTo == "" && frontmatter.AlwaysApply {
-		applyTo = "**/*"
-	}
-
-	metadata := frontmatterMetadata{
-		Name:        baseName,
-		Description: "",
-		ApplyTo:     applyTo,
-	}
-	if description := strings.TrimSpace(frontmatter.Description); description != "" {
-		metadata.Description = description
-	}
-	renderedFrontmatter, err := renderFrontmatter(metadata)
-	if err != nil {
-		return "", err
-	}
-	return renderedFrontmatter + "\n" + GeneratedAgentHTMLMarker + "\n\n" + strings.TrimSpace(body) + "\n", nil
-}
-
-func parseFrontmatter(content string) (agentRuleFrontmatter, string, error) {
-	var values agentRuleFrontmatter
-	if !strings.HasPrefix(content, "---\n") {
-		return values, content, nil
-	}
-	endMarker := "\n---\n"
-	frontmatterEnd := strings.Index(content[4:], endMarker)
-	if frontmatterEnd == -1 {
-		return values, content, nil
-	}
-
-	rawFrontmatter := content[4 : 4+frontmatterEnd]
-	if err := yaml.Unmarshal([]byte(rawFrontmatter), &values); err != nil {
-		slog.Warn("compilation: parseFrontmatter yaml failed", "err", err)
-		return values, content, fmt.Errorf("parsing frontmatter: %w", err)
-	}
-
-	bodyStart := 4 + frontmatterEnd + len(endMarker)
-	return values, content[bodyStart:], nil
-}
-
-func renderFrontmatter(metadata frontmatterMetadata) (string, error) {
-	content, err := yaml.Marshal(metadata)
-	if err != nil {
-		slog.Warn("compilation: renderFrontmatter yaml failed", "err", err)
-		return "", fmt.Errorf("marshaling frontmatter: %w", err)
-	}
-	return "---\n" + string(content) + "---\n", nil
 }
 
 func writeFileIfChanged(path string, content []byte) error {

--- a/dots/internal/sync/compilation/rules.go
+++ b/dots/internal/sync/compilation/rules.go
@@ -61,25 +61,26 @@ type copilotRuleFrontmatter struct {
 // ParseRuleSource reads neutral corpus rule metadata and body from file content.
 func ParseRuleSource(content string) (RuleSource, error) {
 	if !strings.HasPrefix(content, "---\n") {
-		return RuleSource{Body: content}, nil
+		return emptyRuleSource(content), nil
 	}
 	endMarker := "\n---\n"
 	frontmatterEnd := strings.Index(content[4:], endMarker)
 	if frontmatterEnd == -1 {
-		return RuleSource{Body: content}, nil
+		return emptyRuleSource(content), nil
 	}
 
 	var raw ruleSourceYAML
 	rawFrontmatter := content[4 : 4+frontmatterEnd]
 	if err := yaml.Unmarshal([]byte(rawFrontmatter), &raw); err != nil {
 		slog.Warn("compilation: ParseRuleSource yaml failed", "err", err)
-		return RuleSource{}, fmt.Errorf("parsing rule source front matter: %w", err)
+		return RuleSource{Description: "", AppliesTo: nil, Always: false, Body: ""}, fmt.Errorf("parsing rule source front matter: %w", err)
 	}
 
 	bodyStart := 4 + frontmatterEnd + len(endMarker)
 	rule := RuleSource{
 		Description: strings.TrimSpace(raw.Description),
 		AppliesTo:   append([]string(nil), raw.AppliesTo...),
+		Always:      false,
 		Body:        content[bodyStart:],
 	}
 	if raw.Always != nil {
@@ -91,6 +92,10 @@ func ParseRuleSource(content string) (RuleSource, error) {
 		rule.AppliesTo = splitGlobs(raw.Globs)
 	}
 	return rule, nil
+}
+
+func emptyRuleSource(body string) RuleSource {
+	return RuleSource{Description: "", AppliesTo: nil, Always: false, Body: body}
 }
 
 func splitGlobs(value string) []string {
@@ -196,7 +201,7 @@ func (r RuleSource) RenderCopilot(name string) (string, error) {
 	return renderedFrontmatter + "\n" + GeneratedAgentHTMLMarker + "\n\n" + body + "\n", nil
 }
 
-func marshalFrontmatter(metadata any) (string, error) {
+func marshalFrontmatter[T cursorRuleFrontmatter | claudeRuleFrontmatter | copilotRuleFrontmatter](metadata T) (string, error) {
 	content, err := yaml.Marshal(metadata)
 	if err != nil {
 		slog.Warn("compilation: marshalFrontmatter yaml failed", "err", err)

--- a/dots/internal/sync/compilation/rules.go
+++ b/dots/internal/sync/compilation/rules.go
@@ -1,0 +1,206 @@
+package compilation
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RuleTargetFormat selects provider-specific front matter for rendered rule files.
+type RuleTargetFormat string
+
+const (
+	// RuleTargetCursor renders Cursor .mdc front matter with description, globs, and alwaysApply.
+	RuleTargetCursor RuleTargetFormat = "cursor"
+	// RuleTargetClaude renders Claude .md front matter with paths for scoped rules only.
+	RuleTargetClaude RuleTargetFormat = "claude"
+)
+
+// RuleTargetFormatFromExt maps a rule file extension to the target harness format.
+func RuleTargetFormatFromExt(ext string) RuleTargetFormat {
+	if ext == ".md" {
+		return RuleTargetClaude
+	}
+	return RuleTargetCursor
+}
+
+// RuleSource is a parsed neutral corpus rule with metadata and Markdown body.
+type RuleSource struct {
+	Description string
+	AppliesTo   []string
+	Always      bool
+	Body        string
+}
+
+type ruleSourceYAML struct {
+	Description string   `yaml:"description,omitempty"`
+	AppliesTo   []string `yaml:"applies_to,omitempty"`
+	Always      *bool    `yaml:"always,omitempty"`
+	Globs       string   `yaml:"globs,omitempty"`
+	AlwaysApply *bool    `yaml:"alwaysApply,omitempty"`
+}
+
+type cursorRuleFrontmatter struct {
+	Description string `yaml:"description,omitempty"`
+	Globs       string `yaml:"globs,omitempty"`
+	AlwaysApply bool   `yaml:"alwaysApply,omitempty"`
+}
+
+type claudeRuleFrontmatter struct {
+	Paths []string `yaml:"paths,omitempty"`
+}
+
+type copilotRuleFrontmatter struct {
+	Name        string `yaml:"name,omitempty"`
+	Description string `yaml:"description,omitempty"`
+	ApplyTo     string `yaml:"applyTo,omitempty"`
+}
+
+// ParseRuleSource reads neutral corpus rule metadata and body from file content.
+func ParseRuleSource(content string) (RuleSource, error) {
+	if !strings.HasPrefix(content, "---\n") {
+		return RuleSource{Body: content}, nil
+	}
+	endMarker := "\n---\n"
+	frontmatterEnd := strings.Index(content[4:], endMarker)
+	if frontmatterEnd == -1 {
+		return RuleSource{Body: content}, nil
+	}
+
+	var raw ruleSourceYAML
+	rawFrontmatter := content[4 : 4+frontmatterEnd]
+	if err := yaml.Unmarshal([]byte(rawFrontmatter), &raw); err != nil {
+		slog.Warn("compilation: ParseRuleSource yaml failed", "err", err)
+		return RuleSource{}, fmt.Errorf("parsing rule source front matter: %w", err)
+	}
+
+	bodyStart := 4 + frontmatterEnd + len(endMarker)
+	rule := RuleSource{
+		Description: strings.TrimSpace(raw.Description),
+		AppliesTo:   append([]string(nil), raw.AppliesTo...),
+		Body:        content[bodyStart:],
+	}
+	if raw.Always != nil {
+		rule.Always = *raw.Always
+	} else if raw.AlwaysApply != nil {
+		rule.Always = *raw.AlwaysApply
+	}
+	if len(rule.AppliesTo) == 0 && strings.TrimSpace(raw.Globs) != "" {
+		rule.AppliesTo = splitGlobs(raw.Globs)
+	}
+	return rule, nil
+}
+
+func splitGlobs(value string) []string {
+	parts := strings.Split(value, ",")
+	globs := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			globs = append(globs, trimmed)
+		}
+	}
+	return globs
+}
+
+func (r RuleSource) hasMetadata() bool {
+	return r.Description != "" || len(r.AppliesTo) > 0 || r.Always
+}
+
+func (r RuleSource) isScoped() bool {
+	return len(r.AppliesTo) > 0 && !r.Always
+}
+
+func (r RuleSource) globsString() string {
+	return strings.Join(r.AppliesTo, ",")
+}
+
+func (r RuleSource) applyToString() string {
+	if r.Always {
+		return "**/*"
+	}
+	return r.globsString()
+}
+
+// RenderForTarget renders the rule for the given harness format.
+func (r RuleSource) RenderForTarget(format RuleTargetFormat) (string, error) {
+	switch format {
+	case RuleTargetClaude:
+		return r.renderClaude()
+	case RuleTargetCursor:
+		return r.renderCursor()
+	default:
+		return "", fmt.Errorf("unknown rule target format %q", format)
+	}
+}
+
+func (r RuleSource) renderCursor() (string, error) {
+	body := strings.TrimSpace(r.Body)
+	if !r.hasMetadata() {
+		if body == "" {
+			return "", nil
+		}
+		return body + "\n", nil
+	}
+	frontmatter := cursorRuleFrontmatter{
+		Description: r.Description,
+		Globs:       r.globsString(),
+		AlwaysApply: r.Always,
+	}
+	renderedFrontmatter, err := marshalFrontmatter(frontmatter)
+	if err != nil {
+		return "", err
+	}
+	if body == "" {
+		return renderedFrontmatter + "\n", nil
+	}
+	return renderedFrontmatter + "\n" + body + "\n", nil
+}
+
+func (r RuleSource) renderClaude() (string, error) {
+	body := strings.TrimSpace(r.Body)
+	if !r.isScoped() {
+		if body == "" {
+			return "", nil
+		}
+		return body + "\n", nil
+	}
+	frontmatter := claudeRuleFrontmatter{Paths: r.AppliesTo}
+	renderedFrontmatter, err := marshalFrontmatter(frontmatter)
+	if err != nil {
+		return "", err
+	}
+	if body == "" {
+		return renderedFrontmatter + "\n", nil
+	}
+	return renderedFrontmatter + "\n" + body + "\n", nil
+}
+
+// RenderCopilot renders a Copilot .instructions.md file for the named rule.
+func (r RuleSource) RenderCopilot(name string) (string, error) {
+	body := strings.TrimSpace(r.Body)
+	frontmatter := copilotRuleFrontmatter{
+		Name:        name,
+		Description: r.Description,
+		ApplyTo:     r.applyToString(),
+	}
+	renderedFrontmatter, err := marshalFrontmatter(frontmatter)
+	if err != nil {
+		return "", err
+	}
+	if body == "" {
+		return renderedFrontmatter + "\n" + GeneratedAgentHTMLMarker + "\n", nil
+	}
+	return renderedFrontmatter + "\n" + GeneratedAgentHTMLMarker + "\n\n" + body + "\n", nil
+}
+
+func marshalFrontmatter(metadata any) (string, error) {
+	content, err := yaml.Marshal(metadata)
+	if err != nil {
+		slog.Warn("compilation: marshalFrontmatter yaml failed", "err", err)
+		return "", fmt.Errorf("marshaling front matter: %w", err)
+	}
+	return "---\n" + string(content) + "---\n", nil
+}

--- a/dots/internal/sync/compilation/rules_test.go
+++ b/dots/internal/sync/compilation/rules_test.go
@@ -1,0 +1,174 @@
+package compilation
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseRuleSourceNeutralSchema(t *testing.T) {
+	content := "---\ndescription: Writing rules\napplies_to:\n  - \"*.md\"\n  - \"*.txt\"\nalways: false\n---\n\nBody text\n"
+	rule, err := ParseRuleSource(content)
+	if err != nil {
+		t.Fatalf("ParseRuleSource: %v", err)
+	}
+	if rule.Description != "Writing rules" {
+		t.Errorf("Description = %q", rule.Description)
+	}
+	if len(rule.AppliesTo) != 2 || rule.AppliesTo[0] != "*.md" {
+		t.Errorf("AppliesTo = %#v", rule.AppliesTo)
+	}
+	if rule.Always {
+		t.Error("expected Always=false")
+	}
+	if strings.TrimSpace(rule.Body) != "Body text" {
+		t.Errorf("Body = %q", rule.Body)
+	}
+}
+
+func TestParseRuleSourceLegacyCursorFields(t *testing.T) {
+	content := "---\ndescription: Legacy\nalwaysApply: true\nglobs: \"**/*\"\n---\n\nLegacy body\n"
+	rule, err := ParseRuleSource(content)
+	if err != nil {
+		t.Fatalf("ParseRuleSource: %v", err)
+	}
+	if !rule.Always {
+		t.Error("expected Always=true from legacy alwaysApply")
+	}
+	if len(rule.AppliesTo) != 1 || rule.AppliesTo[0] != "**/*" {
+		t.Errorf("AppliesTo = %#v", rule.AppliesTo)
+	}
+}
+
+func TestRenderCursorFrontmatter(t *testing.T) {
+	rule := RuleSource{
+		Description: "Writing rules",
+		AppliesTo:   []string{"*.md", "*.txt"},
+		Always:      false,
+		Body:        "Body text",
+	}
+	got, err := rule.RenderForTarget(RuleTargetCursor)
+	if err != nil {
+		t.Fatalf("RenderForTarget: %v", err)
+	}
+	for _, want := range []string{"description: Writing rules", "globs: '*.md,*.txt'", "Body text"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("cursor output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "alwaysApply:") {
+		t.Errorf("cursor output should omit alwaysApply when false:\n%s", got)
+	}
+}
+
+func TestRenderClaudeScopedFrontmatter(t *testing.T) {
+	rule := RuleSource{
+		Description: "Python rules",
+		AppliesTo:   []string{"*.py"},
+		Always:      false,
+		Body:        "Use uv.",
+	}
+	got, err := rule.RenderForTarget(RuleTargetClaude)
+	if err != nil {
+		t.Fatalf("RenderForTarget: %v", err)
+	}
+	if !strings.Contains(got, "paths:") || !strings.Contains(got, "'*.py'") {
+		t.Errorf("claude scoped output missing paths:\n%s", got)
+	}
+	if !strings.Contains(got, "Use uv.") {
+		t.Errorf("claude scoped output missing body:\n%s", got)
+	}
+}
+
+func TestRenderClaudeGlobalOmitsFrontmatter(t *testing.T) {
+	rule := RuleSource{
+		Description: "Global rules",
+		AppliesTo:   []string{"**/*"},
+		Always:      true,
+		Body:        "Global body",
+	}
+	got, err := rule.RenderForTarget(RuleTargetClaude)
+	if err != nil {
+		t.Fatalf("RenderForTarget: %v", err)
+	}
+	if strings.HasPrefix(got, "---") {
+		t.Errorf("expected no front matter for global Claude rule:\n%s", got)
+	}
+	if strings.TrimSpace(got) != "Global body" {
+		t.Errorf("unexpected body: %q", got)
+	}
+}
+
+func TestRenderCopilotFrontmatter(t *testing.T) {
+	rule := RuleSource{
+		Description: "Writing rules",
+		AppliesTo:   []string{"*.md"},
+		Always:      false,
+		Body:        "Write plainly.",
+	}
+	got, err := rule.RenderCopilot("writing")
+	if err != nil {
+		t.Fatalf("RenderCopilot: %v", err)
+	}
+	for _, want := range []string{"name: writing", "description: Writing rules", "applyTo: '*.md'", GeneratedAgentHTMLMarker, "Write plainly."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("copilot output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderCopilotGlobalApplyTo(t *testing.T) {
+	rule := RuleSource{
+		Description: "Global rules",
+		AppliesTo:   []string{"**/*"},
+		Always:      true,
+		Body:        "Global body",
+	}
+	got, err := rule.RenderCopilot("general")
+	if err != nil {
+		t.Fatalf("RenderCopilot: %v", err)
+	}
+	if !strings.Contains(got, "applyTo: '**/*'") {
+		t.Errorf("copilot global output missing applyTo:\n%s", got)
+	}
+}
+
+func TestRenderRuleFilesTargetFrontmatter(t *testing.T) {
+	srcRoot := t.TempDir()
+	writeTestFile(t, filepath.Join(srcRoot, "writing.mdc"),
+		"---\ndescription: Writing rules\napplies_to:\n  - \"*.md\"\nalways: false\n---\n\nBody text\n")
+	writeTestFile(t, filepath.Join(srcRoot, "general.mdc"),
+		"---\ndescription: Global rules\napplies_to:\n  - \"**/*\"\nalways: true\n---\n\nGlobal body\n")
+
+	cursorDir := filepath.Join(t.TempDir(), "cursor")
+	if err := RenderRuleFiles(srcRoot, cursorDir, ".mdc", RuleTargetCursor, RuleRenderStyle{}); err != nil {
+		t.Fatalf("RenderRuleFiles cursor: %v", err)
+	}
+	cursorGot, err := os.ReadFile(filepath.Join(cursorDir, "writing.mdc"))
+	if err != nil {
+		t.Fatalf("reading cursor rule: %v", err)
+	}
+	if !strings.Contains(string(cursorGot), "globs: '*.md'") {
+		t.Errorf("cursor rule missing globs:\n%s", string(cursorGot))
+	}
+
+	claudeDir := filepath.Join(t.TempDir(), "claude")
+	if err := RenderRuleFiles(srcRoot, claudeDir, ".md", RuleTargetClaude, RuleRenderStyle{}); err != nil {
+		t.Fatalf("RenderRuleFiles claude: %v", err)
+	}
+	scoped, err := os.ReadFile(filepath.Join(claudeDir, "writing.md"))
+	if err != nil {
+		t.Fatalf("reading claude scoped rule: %v", err)
+	}
+	if !strings.Contains(string(scoped), "paths:") || !strings.Contains(string(scoped), "'*.md'") {
+		t.Errorf("claude scoped rule missing paths:\n%s", string(scoped))
+	}
+	global, err := os.ReadFile(filepath.Join(claudeDir, "general.md"))
+	if err != nil {
+		t.Fatalf("reading claude global rule: %v", err)
+	}
+	if strings.Contains(string(global), "paths:") {
+		t.Errorf("claude global rule should omit paths front matter:\n%s", string(global))
+	}
+}

--- a/dots/internal/sync/compilation/skills_test.go
+++ b/dots/internal/sync/compilation/skills_test.go
@@ -269,7 +269,7 @@ func TestRenderRuleFiles(t *testing.T) {
 	stale := filepath.Join(dst, "old.mdc")
 	writeTestFile(t, stale, GeneratedAgentHTMLMarker+"\nstale\n")
 
-	if err := RenderRuleFiles(srcRoot, dst, ".mdc", RuleRenderStyle{}); err != nil {
+	if err := RenderRuleFiles(srcRoot, dst, ".mdc", RuleTargetCursor, RuleRenderStyle{}); err != nil {
 		t.Fatalf("RenderRuleFiles: %v", err)
 	}
 	for _, name := range []string{"general.mdc", "code.mdc"} {

--- a/dots/internal/sync/corpus/corpus.go
+++ b/dots/internal/sync/corpus/corpus.go
@@ -128,7 +128,7 @@ func renderOutput(source compilation.CorpusPaths, output Output, home string, de
 		if ruleStyleErr != nil {
 			return ruleStyleErr
 		}
-		err = compilation.RenderRuleFiles(source.Rules, dest, output.RuleExt, ruleStyle)
+		err = compilation.RenderRuleFiles(source.Rules, dest, output.RuleExt, compilation.RuleTargetFormatFromExt(output.RuleExt), ruleStyle)
 	case KindInstructionDoc:
 		if output.Title == "" {
 			return fmt.Errorf("instruction-doc output for %s requires title", output.Provider)

--- a/dots/internal/sync/corpus/corpus_test.go
+++ b/dots/internal/sync/corpus/corpus_test.go
@@ -48,8 +48,8 @@ func TestLoadManifest(t *testing.T) {
 
 func TestSyncRendersAndGatesByOS(t *testing.T) {
 	dotfiles := t.TempDir()
-	writeFile(t, filepath.Join(dotfiles, "corpus", "rules", "code.mdc"), "---\ndescription: c\n---\ncode body\n")
-	writeFile(t, filepath.Join(dotfiles, "corpus", "rules", "writing.mdc"), "---\ndescription: w\n---\nSkill: {{.Skill \"make-readable\"}}\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", "rules", "code.mdc"), "---\ndescription: c\napplies_to:\n  - \"*.go\"\nalways: false\n---\ncode body\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", "rules", "writing.mdc"), "---\ndescription: w\napplies_to:\n  - \"*.md\"\nalways: false\n---\nSkill: {{.Skill \"make-readable\"}}\n")
 	writeFile(t, filepath.Join(dotfiles, "corpus", "skills", "enforce-rules", "SKILL.md.tmpl"), "---\nname: enforce-rules\n---\n\nOne: {{.Rule \"code\"}}\n")
 	writeFile(t, filepath.Join(dotfiles, "corpus", "skills", "make-readable", "SKILL.md.tmpl"), "---\nname: make-readable\n---\n")
 	writeFile(t, filepath.Join(dotfiles, "corpus", ManifestName),
@@ -91,5 +91,48 @@ func TestSyncRendersAndGatesByOS(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(home, ".never", "NEVER.md")); !os.IsNotExist(err) {
 		t.Errorf("expected os-gated output to be skipped, stat err: %v", err)
+	}
+}
+
+func TestSyncRendersProviderFrontmatter(t *testing.T) {
+	dotfiles := t.TempDir()
+	writeFile(t, filepath.Join(dotfiles, "corpus", "rules", "writing.mdc"),
+		"---\ndescription: Writing rules\napplies_to:\n  - \"*.md\"\nalways: false\n---\n\nBody text\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", ManifestName),
+		"[[output]]\nprovider=\"cursor\"\nkind=\"rule-files\"\ndest=\".cursor/rules\"\nrule_ext=\".mdc\"\n\n"+
+			"[[output]]\nprovider=\"claude\"\nkind=\"rule-files\"\ndest=\".claude/rules\"\nrule_ext=\".md\"\n\n"+
+			"[[output]]\nprovider=\"copilot\"\nkind=\"per-file-instructions\"\ndest=\".copilot/instructions\"\n")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := Sync(context.Background(), dotfiles, nil); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	cursorRule, err := os.ReadFile(filepath.Join(home, ".cursor", "rules", "writing.mdc"))
+	if err != nil {
+		t.Fatalf("reading cursor rule: %v", err)
+	}
+	if !strings.Contains(string(cursorRule), "globs: '*.md'") {
+		t.Errorf("cursor rule missing globs front matter:\n%s", string(cursorRule))
+	}
+
+	claudeRule, err := os.ReadFile(filepath.Join(home, ".claude", "rules", "writing.md"))
+	if err != nil {
+		t.Fatalf("reading claude rule: %v", err)
+	}
+	if !strings.Contains(string(claudeRule), "paths:") || !strings.Contains(string(claudeRule), "'*.md'") {
+		t.Errorf("claude rule missing paths front matter:\n%s", string(claudeRule))
+	}
+
+	copilotRule, err := os.ReadFile(filepath.Join(home, ".copilot", "instructions", "writing.instructions.md"))
+	if err != nil {
+		t.Fatalf("reading copilot instruction: %v", err)
+	}
+	for _, want := range []string{"name: writing", "description: Writing rules", "applyTo: '*.md'"} {
+		if !strings.Contains(string(copilotRule), want) {
+			t.Errorf("copilot instruction missing %q:\n%s", want, string(copilotRule))
+		}
 	}
 }


### PR DESCRIPTION
### Summary

Corpus rule sources now use neutral front matter (`description`, `applies_to`, `always`) instead of Cursor field names. The compilation layer renders provider-specific metadata for Cursor, Claude, and Copilot outputs.

Depends on: https://github.com/agoodkind/.dotfiles/pull/61

## Why

The same `corpus/rules` sources fan out to Claude, Cursor, Copilot, Codex, Gemini, and Zed. Source files should not encode Cursor-only field names like `globs` and `alwaysApply` when other harnesses consume the same content through different front matter shapes.

## Change

This change adds a `RuleSource` parser and target renderers in `compilation/rules.go`. Cursor `.mdc` outputs get `description`, `globs`, and `alwaysApply`. Claude `.md` outputs get `paths` for scoped rules and omit front matter for global or body-only rules. Copilot `.instructions.md` outputs get `name`, `description`, and `applyTo`. Instruction docs still render body content only.

All existing `corpus/rules/*.mdc` sources migrate from `globs`/`alwaysApply` to `applies_to`/`always`. Legacy Cursor fields still parse during transition.

## Testing

Ran `go test ./internal/sync/compilation ./internal/sync/corpus` and `go test ./...` in the dots module.

Ran `dots sync --quick --skip-git --skip-network --skip-cursor-sync` into a temporary `HOME` and verified Cursor, Claude, and Copilot outputs carry the expected front matter.