### PR TITLE
Trust tap-qualified brew packages during macOS sync

### DIFF
--- a/dots/internal/sync/platform/macos/macos.go
+++ b/dots/internal/sync/platform/macos/macos.go
@@ -322,7 +322,7 @@ func tapQualifiedNames(names []string) []string {
 	seen := make(map[string]struct{})
 	out := make([]string, 0)
 	for _, name := range names {
-		if strings.Count(name, "/") < 2 {
+		if strings.Count(name, "/") != 2 {
 			continue
 		}
 		if _, ok := seen[name]; ok {

--- a/dots/internal/sync/platform/macos/macos.go
+++ b/dots/internal/sync/platform/macos/macos.go
@@ -300,6 +300,10 @@ func (installer *Installer) installMacPackages(ctx context.Context, strictMode b
 }
 
 func (installer *Installer) trustMacTapPackages(ctx context.Context, cfg *catalog.PackageConfig, logger *telemetry.Logger) {
+	if !installer.deps.Commands.CommandSucceeds(ctx, "brew", "trust", "--help") {
+		return
+	}
+
 	formulae := tapQualifiedNames(append(append([]string{}, cfg.CommonPackages...), cfg.BrewSpecific...))
 	for _, name := range formulae {
 		_ = installer.deps.Commands.RunWithLogger(ctx, logger, "brew", "trust", "--formula", name)
@@ -318,7 +322,7 @@ func tapQualifiedNames(names []string) []string {
 	seen := make(map[string]struct{})
 	out := make([]string, 0)
 	for _, name := range names {
-		if !strings.Contains(name, "/") {
+		if strings.Count(name, "/") < 2 {
 			continue
 		}
 		if _, ok := seen[name]; ok {

--- a/dots/internal/sync/platform/macos/macos.go
+++ b/dots/internal/sync/platform/macos/macos.go
@@ -291,10 +291,44 @@ func (installer *Installer) installMacPackages(ctx context.Context, strictMode b
 		}
 	}
 
+	installer.trustMacTapPackages(ctx, cfg, logger)
+
 	if err := installer.installMacFormulae(ctx, cfg, strictMode, logger); err != nil {
 		return err
 	}
 	return installer.installMacCasks(ctx, cfg, strictMode, logger)
+}
+
+func (installer *Installer) trustMacTapPackages(ctx context.Context, cfg *catalog.PackageConfig, logger *telemetry.Logger) {
+	formulae := tapQualifiedNames(append(append([]string{}, cfg.CommonPackages...), cfg.BrewSpecific...))
+	for _, name := range formulae {
+		_ = installer.deps.Commands.RunWithLogger(ctx, logger, "brew", "trust", "--formula", name)
+	}
+
+	caskNames := make([]string, 0, len(cfg.BrewCasks))
+	for cask := range cfg.BrewCasks {
+		caskNames = append(caskNames, cask)
+	}
+	for _, name := range tapQualifiedNames(caskNames) {
+		_ = installer.deps.Commands.RunWithLogger(ctx, logger, "brew", "trust", "--cask", name)
+	}
+}
+
+func tapQualifiedNames(names []string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, name := range names {
+		if !strings.Contains(name, "/") {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	slices.Sort(out)
+	return out
 }
 
 func (installer *Installer) installMacFormulae(ctx context.Context, cfg *catalog.PackageConfig, strictMode bool, logger *telemetry.Logger) error {

--- a/dots/internal/sync/platform/macos/macos.go
+++ b/dots/internal/sync/platform/macos/macos.go
@@ -291,7 +291,7 @@ func (installer *Installer) installMacPackages(ctx context.Context, strictMode b
 		}
 	}
 
-	installer.trustMacTapPackages(ctx, cfg, logger)
+	installer.trustMacTapPackages(ctx, cfg)
 
 	if err := installer.installMacFormulae(ctx, cfg, strictMode, logger); err != nil {
 		return err
@@ -299,14 +299,14 @@ func (installer *Installer) installMacPackages(ctx context.Context, strictMode b
 	return installer.installMacCasks(ctx, cfg, strictMode, logger)
 }
 
-func (installer *Installer) trustMacTapPackages(ctx context.Context, cfg *catalog.PackageConfig, logger *telemetry.Logger) {
+func (installer *Installer) trustMacTapPackages(ctx context.Context, cfg *catalog.PackageConfig) {
 	if !installer.deps.Commands.CommandSucceeds(ctx, "brew", "trust", "--help") {
 		return
 	}
 
 	formulae := tapQualifiedNames(append(append([]string{}, cfg.CommonPackages...), cfg.BrewSpecific...))
 	for _, name := range formulae {
-		_ = installer.deps.Commands.RunWithLogger(ctx, logger, "brew", "trust", "--formula", name)
+		installer.deps.Commands.CommandSucceeds(ctx, "brew", "trust", "--formula", name)
 	}
 
 	caskNames := make([]string, 0, len(cfg.BrewCasks))
@@ -314,7 +314,7 @@ func (installer *Installer) trustMacTapPackages(ctx context.Context, cfg *catalo
 		caskNames = append(caskNames, cask)
 	}
 	for _, name := range tapQualifiedNames(caskNames) {
-		_ = installer.deps.Commands.RunWithLogger(ctx, logger, "brew", "trust", "--cask", name)
+		installer.deps.Commands.CommandSucceeds(ctx, "brew", "trust", "--cask", name)
 	}
 }
 

--- a/dots/internal/sync/platform/macos/macos_test.go
+++ b/dots/internal/sync/platform/macos/macos_test.go
@@ -324,6 +324,7 @@ func TestTapQualifiedNamesRequiresOwnerTapNameShape(t *testing.T) {
 	got := tapQualifiedNames([]string{
 		"bat",
 		"homebrew/cask-fonts",
+		"a/b/c/d",
 		"MisterTea/et/et",
 		"someuser/some-tap/some-cask",
 	})

--- a/dots/internal/sync/platform/macos/macos_test.go
+++ b/dots/internal/sync/platform/macos/macos_test.go
@@ -241,6 +241,53 @@ func TestInstallMacPackagesStrictModeReturnsUpdateError(t *testing.T) {
 	}
 }
 
+func TestInstallMacPackagesTrustsTapQualifiedFormulae(t *testing.T) {
+	t.Parallel()
+
+	commands := &fakeCommands{
+		succeeds: map[string]bool{
+			commandKey("brew", "list", "--formula", "bat"):             true,
+			commandKey("brew", "list", "--formula", "MisterTea/et/et"): true,
+		},
+	}
+	installer := &Installer{
+		deps: Deps{
+			Commands: commands,
+			Lookup: fakeLookup{commands: map[string]bool{
+				"brew": true,
+			}},
+			Catalog: fakeCatalog{
+				packageConfig: &catalog.PackageConfig{
+					BrewSpecific: []string{"bat", "MisterTea/et/et"},
+				},
+			},
+		},
+	}
+
+	if err := installer.installMacPackages(context.Background(), false, nil); err != nil {
+		t.Fatalf("installMacPackages() returned error: %v", err)
+	}
+
+	if !containsRunCall(commands.runCalls, "brew", []string{"trust", "--formula", "MisterTea/et/et"}) {
+		t.Fatal("expected brew trust --formula MisterTea/et/et")
+	}
+	if containsRunCall(commands.runCalls, "brew", []string{"trust", "--formula", "bat"}) {
+		t.Fatal("did not expect brew trust for core formula bat")
+	}
+}
+
+func containsRunCall(calls []commandCall, command string, args []string) bool {
+	for _, call := range calls {
+		if call.command != command {
+			continue
+		}
+		if reflect.DeepEqual(call.args, args) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestInstallMacPackagesLenientModeContinuesAfterUpdateError(t *testing.T) {
 	t.Parallel()
 

--- a/dots/internal/sync/platform/macos/macos_test.go
+++ b/dots/internal/sync/platform/macos/macos_test.go
@@ -246,6 +246,7 @@ func TestInstallMacPackagesTrustsTapQualifiedFormulae(t *testing.T) {
 
 	commands := &fakeCommands{
 		succeeds: map[string]bool{
+			commandKey("brew", "trust", "--help"):                      true,
 			commandKey("brew", "list", "--formula", "bat"):             true,
 			commandKey("brew", "list", "--formula", "MisterTea/et/et"): true,
 		},
@@ -273,6 +274,60 @@ func TestInstallMacPackagesTrustsTapQualifiedFormulae(t *testing.T) {
 	}
 	if containsRunCall(commands.runCalls, "brew", []string{"trust", "--formula", "bat"}) {
 		t.Fatal("did not expect brew trust for core formula bat")
+	}
+}
+
+func TestInstallMacPackagesTrustsTapQualifiedCasks(t *testing.T) {
+	t.Parallel()
+
+	commands := &fakeCommands{
+		succeeds: map[string]bool{
+			commandKey("brew", "trust", "--help"):                               true,
+			commandKey("brew", "list", "--cask", "ghostty"):                     true,
+			commandKey("brew", "list", "--cask", "someuser/some-tap/some-cask"): true,
+		},
+	}
+	installer := &Installer{
+		deps: Deps{
+			Commands: commands,
+			Lookup: fakeLookup{commands: map[string]bool{
+				"brew": true,
+			}},
+			Catalog: fakeCatalog{
+				packageConfig: &catalog.PackageConfig{
+					BrewCasks: map[string]string{
+						"ghostty":                     "Ghostty",
+						"someuser/some-tap/some-cask": "",
+					},
+				},
+			},
+		},
+	}
+
+	if err := installer.installMacPackages(context.Background(), false, nil); err != nil {
+		t.Fatalf("installMacPackages() returned error: %v", err)
+	}
+
+	if !containsRunCall(commands.runCalls, "brew", []string{"trust", "--cask", "someuser/some-tap/some-cask"}) {
+		t.Fatal("expected brew trust --cask someuser/some-tap/some-cask")
+	}
+	if containsRunCall(commands.runCalls, "brew", []string{"trust", "--cask", "ghostty"}) {
+		t.Fatal("did not expect brew trust for core cask ghostty")
+	}
+}
+
+func TestTapQualifiedNamesRequiresOwnerTapNameShape(t *testing.T) {
+	t.Parallel()
+
+	got := tapQualifiedNames([]string{
+		"bat",
+		"homebrew/cask-fonts",
+		"MisterTea/et/et",
+		"someuser/some-tap/some-cask",
+	})
+	want := []string{"MisterTea/et/et", "someuser/some-tap/some-cask"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tapQualifiedNames() = %#v, want %#v", got, want)
 	}
 }
 

--- a/dots/internal/sync/platform/macos/macos_test.go
+++ b/dots/internal/sync/platform/macos/macos_test.go
@@ -19,9 +19,10 @@ type commandCall struct {
 }
 
 type fakeCommands struct {
-	runCalls []commandCall
-	runErrs  map[string]error
-	succeeds map[string]bool
+	runCalls     []commandCall
+	succeedCalls []commandCall
+	runErrs      map[string]error
+	succeeds     map[string]bool
 }
 
 func (commands *fakeCommands) RunWithLogger(_ context.Context, _ *telemetry.Logger, command string, args ...string) error {
@@ -33,6 +34,7 @@ func (commands *fakeCommands) RunWithLogger(_ context.Context, _ *telemetry.Logg
 }
 
 func (commands *fakeCommands) CommandSucceeds(_ context.Context, command string, args ...string) bool {
+	commands.succeedCalls = append(commands.succeedCalls, commandCall{command: command, args: append([]string{}, args...)})
 	return commands.succeeds[commandKey(command, args...)]
 }
 
@@ -269,10 +271,10 @@ func TestInstallMacPackagesTrustsTapQualifiedFormulae(t *testing.T) {
 		t.Fatalf("installMacPackages() returned error: %v", err)
 	}
 
-	if !containsRunCall(commands.runCalls, "brew", []string{"trust", "--formula", "MisterTea/et/et"}) {
+	if !containsCommandCall(commands.succeedCalls, "brew", []string{"trust", "--formula", "MisterTea/et/et"}) {
 		t.Fatal("expected brew trust --formula MisterTea/et/et")
 	}
-	if containsRunCall(commands.runCalls, "brew", []string{"trust", "--formula", "bat"}) {
+	if containsCommandCall(commands.succeedCalls, "brew", []string{"trust", "--formula", "bat"}) {
 		t.Fatal("did not expect brew trust for core formula bat")
 	}
 }
@@ -308,10 +310,10 @@ func TestInstallMacPackagesTrustsTapQualifiedCasks(t *testing.T) {
 		t.Fatalf("installMacPackages() returned error: %v", err)
 	}
 
-	if !containsRunCall(commands.runCalls, "brew", []string{"trust", "--cask", "someuser/some-tap/some-cask"}) {
+	if !containsCommandCall(commands.succeedCalls, "brew", []string{"trust", "--cask", "someuser/some-tap/some-cask"}) {
 		t.Fatal("expected brew trust --cask someuser/some-tap/some-cask")
 	}
-	if containsRunCall(commands.runCalls, "brew", []string{"trust", "--cask", "ghostty"}) {
+	if containsCommandCall(commands.succeedCalls, "brew", []string{"trust", "--cask", "ghostty"}) {
 		t.Fatal("did not expect brew trust for core cask ghostty")
 	}
 }
@@ -331,7 +333,7 @@ func TestTapQualifiedNamesRequiresOwnerTapNameShape(t *testing.T) {
 	}
 }
 
-func containsRunCall(calls []commandCall, command string, args []string) bool {
+func containsCommandCall(calls []commandCall, command string, args []string) bool {
 	for _, call := range calls {
 		if call.command != command {
 			continue


### PR DESCRIPTION
### Summary

macOS sync now runs `brew trust` for tap-qualified formulae and casks declared in the package catalog before Homebrew installs them.

## Why

Homebrew 6 requires explicit trust for packages from non-official taps. Without that step, sync can skip tap formulae such as `MisterTea/et/et` even when they are listed in `config/packages.toml`.

## Change

`installMacPackages` now calls `trustMacTapPackages` after `brew update` and before formula and cask installs. The step scans `common_packages`, `brew_specific`, and `brew_casks` for names with the `owner/tap/name` shape, then runs `brew trust --formula` or `brew trust --cask` for each match. Trust is best-effort and idempotent, so sync continues if trust already exists or if `brew trust` is unavailable. Only catalog-declared packages are trusted; taps installed manually but absent from the catalog are out of scope.

## Testing

`go test ./internal/sync/platform/macos/...` passed, including `TestInstallMacPackagesTrustsTapQualifiedFormulae`, which checks that tap-qualified entries are trusted and core formulae are not.