### PR TITLE
Fail loudly when corpus skill render hits corrupt marker-less SKILL.md

### DIFF
--- a/corpus/targets.toml
+++ b/corpus/targets.toml
@@ -13,7 +13,7 @@
 # ref_style values (skills only): mdc | md
 #
 # Codex, VSCode Copilot, Cursor, and Zed read shared skills from ~/.agents/skills.
-# Codex needs [features] skills = true in ~/.codex/config.toml.
+# Recent Codex builds enable skills by default; older builds needed [features] skills = true in ~/.codex/config.toml.
 # Claude Code and Claude Desktop read skills from ~/.claude/skills.
 # VSCode also reads ~/.copilot/instructions, ~/.claude/rules, and ~/.agents/skills.
 # Claude Desktop shares ~/.claude with Claude Code.

--- a/dots/internal/sync/compilation/compilation.go
+++ b/dots/internal/sync/compilation/compilation.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"text/template"
 
+	"gopkg.in/yaml.v3"
+
 	"goodkind.io/.dotfiles/internal/cmdexec"
 	"goodkind.io/.dotfiles/internal/prefercache"
 	"goodkind.io/.dotfiles/internal/runner"
@@ -483,28 +485,35 @@ func skillRenderConflict(target string) string {
 }
 
 func hasUsableSkillFrontmatter(content string) bool {
-	if !strings.HasPrefix(content, "---\n") {
+	frontmatter, err := parseSkillFrontmatter(content)
+	if err != nil {
 		return false
+	}
+	return strings.TrimSpace(frontmatter.Name) != "" &&
+		strings.TrimSpace(frontmatter.Description) != ""
+}
+
+type skillFrontmatterYAML struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+func parseSkillFrontmatter(content string) (skillFrontmatterYAML, error) {
+	var result skillFrontmatterYAML
+	if !strings.HasPrefix(content, "---\n") {
+		return result, fmt.Errorf("missing opening frontmatter delimiter")
 	}
 	endMarker := "\n---\n"
 	frontmatterEnd := strings.Index(content[4:], endMarker)
 	if frontmatterEnd == -1 {
-		return false
+		return result, fmt.Errorf("missing closing frontmatter delimiter")
 	}
-	frontmatter := content[4 : 4+frontmatterEnd]
-	return skillFrontmatterField(frontmatter, "name") != "" &&
-		skillFrontmatterField(frontmatter, "description") != ""
-}
-
-func skillFrontmatterField(frontmatter string, key string) string {
-	prefix := key + ":"
-	for line := range strings.SplitSeq(frontmatter, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, prefix) {
-			return strings.TrimSpace(trimmed[len(prefix):])
-		}
+	rawFrontmatter := content[4 : 4+frontmatterEnd]
+	if err := yaml.Unmarshal([]byte(rawFrontmatter), &result); err != nil {
+		slog.Warn("compilation: parseSkillFrontmatter yaml failed", "err", err)
+		return result, fmt.Errorf("parsing skill front matter: %w", err)
 	}
-	return ""
+	return result, nil
 }
 
 func skillRenderConflictsError(conflicts []string) error {

--- a/dots/internal/sync/compilation/compilation.go
+++ b/dots/internal/sync/compilation/compilation.go
@@ -391,6 +391,7 @@ func RenderSkillDirs(src string, dst string, refStyle SkillRefStyle) error {
 		return fmt.Errorf("read dir %s: %w", src, err)
 	}
 	activeSkills := make(map[string]struct{}, len(entries))
+	var conflicts []string
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -401,14 +402,17 @@ func RenderSkillDirs(src string, dst string, refStyle SkillRefStyle) error {
 		if isSymlink(target) {
 			_ = os.Remove(target)
 		}
-		if err := renderSkillDir(source, target, refStyle, ruleNames); err != nil {
+		if err := renderSkillDir(source, target, refStyle, ruleNames, &conflicts); err != nil {
 			return err
 		}
 	}
-	return removeMissingManagedSkillDirs(dst, activeSkills)
+	if err := removeMissingManagedSkillDirs(dst, activeSkills); err != nil {
+		return err
+	}
+	return skillRenderConflictsError(conflicts)
 }
 
-func renderSkillDir(src string, dst string, refStyle SkillRefStyle, ruleNames []string) error {
+func renderSkillDir(src string, dst string, refStyle SkillRefStyle, ruleNames []string, conflicts *[]string) error {
 	entries, err := os.ReadDir(src)
 	if err != nil {
 		slog.Warn("compilation: renderSkillDir ReadDir failed", "src", src, "err", err)
@@ -421,7 +425,7 @@ func renderSkillDir(src string, dst string, refStyle SkillRefStyle, ruleNames []
 		source := filepath.Join(src, entry.Name())
 		target := filepath.Join(dst, entry.Name())
 		if entry.IsDir() {
-			if err := renderSkillDir(source, target, refStyle, ruleNames); err != nil {
+			if err := renderSkillDir(source, target, refStyle, ruleNames, conflicts); err != nil {
 				return err
 			}
 			continue
@@ -433,8 +437,10 @@ func renderSkillDir(src string, dst string, refStyle SkillRefStyle, ruleNames []
 		}
 		outputName := entry.Name()
 		output := content
+		fromTemplate := false
 		if base, ok := strings.CutSuffix(entry.Name(), ".tmpl"); ok {
 			outputName = base
+			fromTemplate = true
 			rendered, tmplErr := renderSkillTemplate(string(content), refStyle, ruleNames, entry.Name())
 			if tmplErr != nil {
 				return tmplErr
@@ -445,11 +451,67 @@ func renderSkillDir(src string, dst string, refStyle SkillRefStyle, ruleNames []
 		if isSymlink(target) {
 			_ = os.Remove(target)
 		}
+		if fromTemplate && outputName == "SKILL.md" {
+			if conflict := skillRenderConflict(target); conflict != "" {
+				*conflicts = append(*conflicts, conflict)
+				continue
+			}
+		}
 		if err := writeFileIfChanged(target, output); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func skillRenderConflict(target string) string {
+	existing, err := os.ReadFile(filepath.Clean(target))
+	if err != nil {
+		return ""
+	}
+	existingContent := string(existing)
+	if strings.TrimSpace(existingContent) == "" {
+		return ""
+	}
+	if HasGeneratedMarker(existingContent) {
+		return ""
+	}
+	if hasUsableSkillFrontmatter(existingContent) {
+		return ""
+	}
+	return target + ": marker-less SKILL.md has unusable frontmatter; delete the file or restore the generated marker before syncing"
+}
+
+func hasUsableSkillFrontmatter(content string) bool {
+	if !strings.HasPrefix(content, "---\n") {
+		return false
+	}
+	endMarker := "\n---\n"
+	frontmatterEnd := strings.Index(content[4:], endMarker)
+	if frontmatterEnd == -1 {
+		return false
+	}
+	frontmatter := content[4 : 4+frontmatterEnd]
+	return skillFrontmatterField(frontmatter, "name") != "" &&
+		skillFrontmatterField(frontmatter, "description") != ""
+}
+
+func skillFrontmatterField(frontmatter string, key string) string {
+	prefix := key + ":"
+	for line := range strings.SplitSeq(frontmatter, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, prefix) {
+			return strings.TrimSpace(trimmed[len(prefix):])
+		}
+	}
+	return ""
+}
+
+func skillRenderConflictsError(conflicts []string) error {
+	if len(conflicts) == 0 {
+		return nil
+	}
+	return fmt.Errorf("skill render conflicts:\n- %s", strings.Join(conflicts, "\n- "))
 }
 
 // skillTemplateData exposes corpus reference helpers to a skill template as the

--- a/dots/internal/sync/compilation/skills_test.go
+++ b/dots/internal/sync/compilation/skills_test.go
@@ -116,7 +116,7 @@ func TestRenderSkillDirsPreservesHandEditedFiles(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "skills")
 
 	handEdited := filepath.Join(dst, "enforce-rules", "SKILL.md")
-	handEditedContent := "hand edited without marker\n"
+	handEditedContent := "---\nname: enforce-rules\ndescription: hand edited\n---\n\nhand edited without marker\n"
 	writeTestFile(t, handEdited, handEditedContent)
 
 	if err := RenderSkillDirs(src, dst, SkillRefMDC); err != nil {
@@ -128,7 +128,27 @@ func TestRenderSkillDirsPreservesHandEditedFiles(t *testing.T) {
 		t.Fatalf("reading skill: %v", err)
 	}
 	if string(got) != handEditedContent {
-		t.Errorf("expected hand-edited skill without marker to be preserved\nwant: %q\ngot: %q", handEditedContent, string(got))
+		t.Errorf("expected hand-edited skill with valid frontmatter to be preserved\nwant: %q\ngot: %q", handEditedContent, string(got))
+	}
+}
+
+func TestRenderSkillDirsFailsOnCorruptFrontmatter(t *testing.T) {
+	src := setupAgentSource(t)
+	dst := filepath.Join(t.TempDir(), "skills")
+
+	corrupt := filepath.Join(dst, "enforce-rules", "SKILL.md")
+	corruptContent := "---\n\n## name: enforce-rules\ndescription: broken\n"
+	writeTestFile(t, corrupt, corruptContent)
+
+	err := RenderSkillDirs(src, dst, SkillRefMDC)
+	if err == nil {
+		t.Fatal("expected RenderSkillDirs to fail on corrupt frontmatter, got nil")
+	}
+	if !strings.Contains(err.Error(), corrupt) {
+		t.Errorf("expected error to name corrupt skill path %q, got: %v", corrupt, err)
+	}
+	if !strings.Contains(err.Error(), "unusable frontmatter") {
+		t.Errorf("expected unusable frontmatter in error, got: %v", err)
 	}
 }
 

--- a/dots/internal/sync/compilation/skills_test.go
+++ b/dots/internal/sync/compilation/skills_test.go
@@ -152,6 +152,23 @@ func TestRenderSkillDirsFailsOnCorruptFrontmatter(t *testing.T) {
 	}
 }
 
+func TestRenderSkillDirsFailsOnInvalidYAMLFrontmatter(t *testing.T) {
+	src := setupAgentSource(t)
+	dst := filepath.Join(t.TempDir(), "skills")
+
+	corrupt := filepath.Join(dst, "enforce-rules", "SKILL.md")
+	corruptContent := "---\nname: enforce-rules\ndescription: \"broken\n---\n"
+	writeTestFile(t, corrupt, corruptContent)
+
+	err := RenderSkillDirs(src, dst, SkillRefMDC)
+	if err == nil {
+		t.Fatal("expected RenderSkillDirs to fail on invalid YAML frontmatter, got nil")
+	}
+	if !strings.Contains(err.Error(), corrupt) {
+		t.Errorf("expected error to name corrupt skill path %q, got: %v", corrupt, err)
+	}
+}
+
 func TestRenderSkillDirsReplacesSymlinkedSkillDir(t *testing.T) {
 	src := setupAgentSource(t)
 	dst := filepath.Join(t.TempDir(), "skills")


### PR DESCRIPTION
### Summary

Corpus sync now reports a conflict when a marker-less `SKILL.md` at a managed destination has unusable frontmatter, instead of silently preserving a broken file that Codex skips.

The `targets.toml` comment is updated to note that recent Codex builds enable skills by default.

## Why

A corrupted `graphite` skill in `~/.agents/skills/` had mangled YAML frontmatter and no generated marker. Sync treated it as hand-authored and never repaired it, so Codex silently dropped the skill.

## Change

`RenderSkillDirs` collects conflicts when an existing marker-less `SKILL.md` lacks parseable `name` and `description` frontmatter. Sync still renders healthy skills, then returns a combined error naming each bad path and the remedy.

Marker-less files with valid frontmatter continue to be preserved for genuine hand-authored skills.

## Testing

`go test ./...` in `dots/` passed after `make build`.