### PR TITLE
Fix nvim pager quit failure on git log after baleia ANSI processing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,4 +22,7 @@
     "editor.rulers": [
         90
     ],
+    "Lua.diagnostics.globals": [
+        "vim"
+    ],
 }

--- a/bin/nvim-pager
+++ b/bin/nvim-pager
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # nvim as a pager; ANSI rendering handled by the StdinReadPost autocmd in init.lua (baleia.nvim)
 
-exec nvim -R "$@"
+exec nvim -R --cmd 'let g:dotfiles_pager = 1' "$@"

--- a/home/.config/nvim/init.lua
+++ b/home/.config/nvim/init.lua
@@ -205,21 +205,27 @@ vim.api.nvim_create_autocmd('FileType', {
 vim.api.nvim_create_autocmd('StdinReadPost', {
     pattern = '*',
     callback = function(ev)
+        if not vim.g.dotfiles_pager then
+            return
+        end
         local buf = ev.buf
+
+        vim.bo[buf].buftype = 'nofile'
+        vim.bo[buf].swapfile = false
+        vim.bo[buf].bufhidden = 'wipe'
+        vim.keymap.set('n', 'q', '<cmd>quitall!<cr>', { buffer = buf, nowait = true })
+
         local first = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1] or ''
-        if not first:match('\27%[') then
-            return
+        if first:match('\27%[') and vim.g.baleia then
+            vim.bo[buf].readonly = false
+            vim.bo[buf].modifiable = true
+            vim.g.baleia.once(buf)
         end
-        if not vim.g.baleia then
-            return
-        end
-        local was_modifiable = vim.bo[buf].modifiable
-        vim.bo[buf].modifiable = true
-        vim.g.baleia.once(buf)
+
         vim.schedule(function()
             if vim.api.nvim_buf_is_valid(buf) then
                 vim.bo[buf].modified = false
-                vim.bo[buf].modifiable = was_modifiable
+                vim.bo[buf].modifiable = false
             end
         end)
     end,


### PR DESCRIPTION
### Summary

This change fixes the nvim pager so `git log` and other colorized pager output quit cleanly with `:q` or `q`.

## Why

The nvim pager reads colorized stdin through baleia, and that rewrite left the buffer marked modified while `nvim -R` kept it readonly. `:q` then failed with E37 and E162 instead of returning to the shell.

## Change

`bin/nvim-pager` now sets a `dotfiles_pager` sentinel when nvim starts as the pager. The `StdinReadPost` autocmd in `home/.config/nvim/init.lua` runs only when that sentinel is set. It turns the pager buffer into a throwaway scratch buffer, clears the modified flag after baleia runs, and maps buffer-local `q` to `quitall!`. Normal nvim editing is unchanged because the sentinel is not set outside the pager wrapper.

## Testing

Verified in a tmux interactive login shell with agent env vars stripped:

- `git log` then `:q` returns to the prompt with no E37, E162, or W10
- `git log` then `q` returns to the prompt with no errors
- `man ls` then `:q` still quits cleanly
- `nvim <file>`, edit, `:w`, `:q` still writes and quits normally