### PR TITLE
Require pr skill review per PR in graphite and split-to-prs

### DIFF
--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -123,7 +123,7 @@ args: ["submit", "--stack", "--dry-run", "--no-interactive"]
 args: ["submit", "--stack", "--no-interactive"]
 ```
 
-7. **Draft and review each PR.** For each PR in the stack, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body. The PR already exists from `gt submit`, so use the `pr` skill edit path (`gh pr edit`), not create.
+7. **Draft and review each PR.** Check out each branch bottom to top. The `pr` skill reads the current branch, so you must be on the PR's branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body. The PR already exists from `gt submit`, so use the `pr` skill edit path (`gh pr edit`), not create.
 
 8. **Mark PRs ready** when reviewers are required. Non-interactive submit often creates drafts and Copilot skips drafts:
 
@@ -178,7 +178,7 @@ Expect **Sync** or **New parent** actions. **Create** on an existing PR means th
 args: ["submit", "--stack", "--no-interactive"]
 ```
 
-7. **Draft and review each PR.** For each adopted PR, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`).
+7. **Draft and review each PR.** Check out each adopted branch bottom to top. The `pr` skill reads the current branch, so you must be on the PR's branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`).
 
 8. **Mark drafts ready** if reviewers are required.
 
@@ -200,7 +200,7 @@ When there is no existing branch chain:
 2. Preflight (above).
 3. For each PR bottom to top: write code, stage named paths, `["create", "--message", "..."]`.
 4. `["submit", "--stack", "--dry-run", "--no-interactive"]` then real submit.
-5. For each PR in the stack, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`).
+5. Check out each branch bottom to top. The `pr` skill reads the current branch, so you must be on the PR's branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`).
 6. Mark PRs ready. Share bottom PR URL.
 
 ---

--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -37,6 +37,8 @@ Shell `gt` is fallback only when MCP is missing or not loaded yet. Never fall ba
 
 Do **not** use `git commit`, `git push`, `git branch -D`, or manual rebases for work the user authorized through `gt`. If MCP is available, do not run ad hoc shell `gt` either.
 
+PR titles and bodies are owned by {{.Skill "pr"}}, not by `gt submit` defaults.
+
 ## Preflight (every task)
 
 Run through MCP before creating, adopting, or restacking:
@@ -121,15 +123,17 @@ args: ["submit", "--stack", "--dry-run", "--no-interactive"]
 args: ["submit", "--stack", "--no-interactive"]
 ```
 
-7. **Mark PRs ready** when reviewers are required. Non-interactive submit often creates drafts and Copilot skips drafts:
+7. **Draft and review each PR.** For each PR in the stack, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body. The PR already exists from `gt submit`, so use the `pr` skill edit path (`gh pr edit`), not create.
+
+8. **Mark PRs ready** when reviewers are required. Non-interactive submit often creates drafts and Copilot skips drafts:
 
 ```bash
 gh pr ready <number>   # for each PR in the stack
 ```
 
-8. **Report** bottom PR URL, full stack order, and anything left uncommitted on trunk.
+9. **Report** bottom PR URL, full stack order, and anything left uncommitted on trunk.
 
-One logical change per branch. The first commit message line becomes the PR title.
+One logical change per branch. The first commit message line becomes the initial PR title until the `pr` skill review updates it.
 
 ---
 
@@ -174,7 +178,9 @@ Expect **Sync** or **New parent** actions. **Create** on an existing PR means th
 args: ["submit", "--stack", "--no-interactive"]
 ```
 
-7. **Mark drafts ready** if reviewers are required.
+7. **Draft and review each PR.** For each adopted PR, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`).
+
+8. **Mark drafts ready** if reviewers are required.
 
 ### Worktree branches
 
@@ -194,7 +200,8 @@ When there is no existing branch chain:
 2. Preflight (above).
 3. For each PR bottom to top: write code, stage named paths, `["create", "--message", "..."]`.
 4. `["submit", "--stack", "--dry-run", "--no-interactive"]` then real submit.
-5. Mark PRs ready. Share bottom PR URL.
+5. For each PR in the stack, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`).
+6. Mark PRs ready. Share bottom PR URL.
 
 ---
 
@@ -377,6 +384,7 @@ Prefer `["continue"]` over `git rebase --continue`. Avoid `["abort"]` in agent s
 | babysit only the tip PR | miss blocked lower PRs | check whole stack each loop |
 | `gh pr merge` on a Graphite stack | skips Graphite merge orchestration; DIRTY upstack PRs | `gt merge` or Graphite UI after babysit |
 | merge before dry-run | wrong PRs may merge | `gt merge --dry-run` first |
+| auto-generated PR bodies from submit | reviewers get commit-message stubs | {{.Skill "pr"}} per PR before marking ready |
 
 ---
 

--- a/corpus/skills/split-to-prs/SKILL.md.tmpl
+++ b/corpus/skills/split-to-prs/SKILL.md.tmpl
@@ -73,7 +73,7 @@ fi
 For each approved slice:
 
 1. Create a branch from the right base, stage and commit only the planned files or hunks, then push.
-2. Invoke {{.Skill "pr"}} for that branch. Draft the title and body, review with the user, and open the PR through the canonical Step 1 through Step 8 flow.
+2. Stay on that branch (or check it out). The `pr` skill reads the current branch. Invoke {{.Skill "pr"}} to draft the title and body, review with the user, and open the PR through the canonical Step 1 through Step 8 flow.
 
 ## 4. Report back
 

--- a/corpus/skills/split-to-prs/SKILL.md.tmpl
+++ b/corpus/skills/split-to-prs/SKILL.md.tmpl
@@ -26,6 +26,7 @@ Use the plain git path in section 3 only when Graphite is unavailable and the us
 - Never discard user work. No destructive git commands (`reset --hard`, `clean -fdx`, branch deletion, force-push, history rewrite) without explicit approval.
 - Always save a recoverable snapshot before moving work around. This often starts from dirty work on `main`, so do not assume there is already a safe branch.
 - Stage only named files or hunks. No `git add .` or `git add -A`.
+- Every PR title and body comes from {{.Skill "pr"}}, reviewed with the user per PR. Do not use ad hoc text or default commit-message bodies.
 
 ## 1. Check the state
 
@@ -69,8 +70,11 @@ if [ -n "$SHA" ]; then
 fi
 ```
 
-For each approved slice, create a branch from the right base, stage and commit only the planned files or hunks, then push and open the PR.
+For each approved slice:
+
+1. Create a branch from the right base, stage and commit only the planned files or hunks, then push.
+2. Invoke {{.Skill "pr"}} for that branch. Draft the title and body, review with the user, and open the PR through the canonical Step 1 through Step 8 flow.
 
 ## 4. Report back
 
-Keep it short: PR titles and URLs, plus anything left on the starting branch or working tree. For Graphite splits, include the bottom PR URL and stack order. Do not delete the backup ref or original branch unless the user asks.
+Keep it short: PR titles and URLs, plus anything left on the starting branch or working tree. For Graphite splits, include the bottom PR URL and stack order. Per-PR final output (Slack one-liner and URL) comes from the `pr` skill Step 8. Do not delete the backup ref or original branch unless the user asks.


### PR DESCRIPTION
### Summary

This change makes the `graphite` and `split-to-prs` agent skills invoke the `pr` skill for every pull request they open or update.

Agents must draft and review each PR title and body with the user before marking PRs ready.

## Why

Split and Graphite workflows were opening PRs from commit messages or `gt submit` defaults without the canonical `/pr` review step.

Reviewers were getting stub descriptions that skipped user review and the structured PR prose the `pr` skill enforces.

## Change

The `split-to-prs` skill now requires `pr` in its hard rules, plain git execution path, and report section.

The `graphite` skill now requires `pr` after submit for split, adopt, and create-from-scratch tasks, states that PR descriptions are owned by `pr`, and adds a things-to-avoid row for auto-generated submit bodies.

For Graphite stacks, agents use the `pr` skill edit path (`gh pr edit`) because `gt submit` already created the PR.