### PR TITLE
Add reuse-before-recreate gate to split, graphite, and pr skills

### DIFF
--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -82,13 +82,32 @@ This is {{.Skill "split-to-prs"}} executed with Graphite instead of plain git br
 ### Planning rules (from split-to-prs)
 
 - Do not create branches, commit, submit, or open PRs until the user approves the split plan.
+- Reuse before recreate. If an open PR already covers the work being split, treat repurposing that PR as the base of the stack as the default. Never silently abandon an existing PR by opening new ones. Surface the choice and ask.
 - Never discard user work. No destructive git without explicit approval.
 - Save a recoverable snapshot before moving work around.
 - Stage only named files or hunks. No `git add .` or `git add -A`.
 - Default to independent PRs off trunk. Stack only when dependency is real.
 - Order foundations before consumers.
+- Do not check out trunk and `gt create` a fresh bottom slice when an open PR already covers the work. First decide whether that PR's branch becomes the stack base.
 
 Propose titles (and a Mermaid diagram when helpful). Ask for approval before executing.
+
+### When an open PR already exists
+
+Use this path when the approved plan repurposes an existing open PR as the stack base.
+
+1. Confirm the existing PR branch and number with `gh pr view`.
+2. Thin that branch to the bottom slice only (stage named files or hunks, then `["modify", "--all"]` or a new commit via `["modify", "--commit", "--message", "..."]`).
+3. If Graphite does not yet track the branch, adopt it before stacking:
+
+```text
+args: ["branch", "track", "<existing-branch>", "--parent", "main"]
+```
+
+4. Stack each remaining slice on top with `["create", "--message", "..."]` on the previous branch tip.
+5. Dry-run submit, submit, then draft and review each PR per the steps below.
+
+For full adopt steps when branches and PRs already exist but Graphite metadata is missing, see **Task: Adopt a non-Graphite stack** below.
 
 ### Execute with Graphite
 
@@ -372,6 +391,7 @@ Prefer `["continue"]` over `git rebase --continue`. Avoid `["abort"]` in agent s
 | shell `gt` when MCP is available | loses cross-turn context | `run_gt_cmd` |
 | branches created outside `gt` | invisible to `gt log` | `gt branch track` before submit |
 | submit without dry-run on existing PRs | duplicate PRs | dry-run first; expect Sync/New parent |
+| fresh stack from trunk when an open PR already covers the work | orphans the existing PR number and its review history | reuse the existing PR as the stack base, or ask |
 | ignore draft state after submit | Copilot and other bots skip drafts | `gh pr ready` on each PR |
 | stale trunk | submit and restack block | sync or fast-forward trunk first |
 | repo-wide `gt sync` with shared worktrees | restacks or deletes other agents' branches | scoped restack; check worktree list |

--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -97,7 +97,7 @@ Propose titles (and a Mermaid diagram when helpful). Ask for approval before exe
 Use this path when the approved plan repurposes an existing open PR as the stack base.
 
 1. Confirm the existing PR branch and number with `gh pr view`.
-2. Thin that branch to the bottom slice only. Stage named files or hunks. Amend or commit with `["modify", "--all"]` or `["modify", "--commit", "--message", "..."]`.
+2. Thin that branch to the bottom slice only. Stage named files or hunks. Amend with `["modify"]` or add a commit with `["modify", "--commit", "--message", "..."]`. Do not pass `--all`; only staged changes should enter the amend.
 3. If Graphite does not track the branch yet, adopt it before stacking:
 
 ```text

--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -82,13 +82,13 @@ This is {{.Skill "split-to-prs"}} executed with Graphite instead of plain git br
 ### Planning rules (from split-to-prs)
 
 - Do not create branches, commit, submit, or open PRs until the user approves the split plan.
-- Reuse before recreate. If an open PR already covers the work being split, treat repurposing that PR as the base of the stack as the default. Never silently abandon an existing PR by opening new ones. Surface the choice and ask.
+- When an open PR exists, follow **Reuse before recreate** in {{.Skill "split-to-prs"}}.
 - Never discard user work. No destructive git without explicit approval.
 - Save a recoverable snapshot before moving work around.
 - Stage only named files or hunks. No `git add .` or `git add -A`.
 - Default to independent PRs off trunk. Stack only when dependency is real.
 - Order foundations before consumers.
-- Do not check out trunk and `gt create` a fresh bottom slice when an open PR already covers the work. First decide whether that PR's branch becomes the stack base.
+- Do not check out trunk and `gt create` a fresh bottom slice until the approved plan names the stack base branch.
 
 Propose titles (and a Mermaid diagram when helpful). Ask for approval before executing.
 
@@ -97,8 +97,8 @@ Propose titles (and a Mermaid diagram when helpful). Ask for approval before exe
 Use this path when the approved plan repurposes an existing open PR as the stack base.
 
 1. Confirm the existing PR branch and number with `gh pr view`.
-2. Thin that branch to the bottom slice only (stage named files or hunks, then `["modify", "--all"]` or a new commit via `["modify", "--commit", "--message", "..."]`).
-3. If Graphite does not yet track the branch, adopt it before stacking:
+2. Thin that branch to the bottom slice only. Stage named files or hunks. Amend or commit with `["modify", "--all"]` or `["modify", "--commit", "--message", "..."]`.
+3. If Graphite does not track the branch yet, adopt it before stacking:
 
 ```text
 args: ["branch", "track", "<existing-branch>", "--parent", "main"]
@@ -107,9 +107,11 @@ args: ["branch", "track", "<existing-branch>", "--parent", "main"]
 4. Stack each remaining slice on top with `["create", "--message", "..."]` on the previous branch tip.
 5. Dry-run submit, submit, then draft and review each PR per the steps below.
 
-For full adopt steps when branches and PRs already exist but Graphite metadata is missing, see **Task: Adopt a non-Graphite stack** below.
+For adopt steps when Graphite metadata is missing, see **Task: Adopt a non-Graphite stack** below.
 
 ### Execute with Graphite
+
+Skip steps 3 and 4 below when the approved plan repurposes an existing open PR. Use **When an open PR already exists** instead.
 
 1. **Snapshot** uncommitted work:
 
@@ -142,7 +144,7 @@ args: ["submit", "--stack", "--dry-run", "--no-interactive"]
 args: ["submit", "--stack", "--no-interactive"]
 ```
 
-7. **Draft and review each PR.** Check out each branch bottom to top. The `pr` skill reads the current branch, so you must be on the PR's branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body. The PR already exists from `gt submit`, so use the `pr` skill edit path (`gh pr edit`), not create.
+7. **Draft and review each PR.** Check out each branch bottom to top. The `pr` skill reads the current branch, so check out the PR branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user. Apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`), not create. The PR already exists from `gt submit`.
 
 8. **Mark PRs ready** when reviewers are required. Non-interactive submit often creates drafts and Copilot skips drafts:
 
@@ -391,7 +393,7 @@ Prefer `["continue"]` over `git rebase --continue`. Avoid `["abort"]` in agent s
 | shell `gt` when MCP is available | loses cross-turn context | `run_gt_cmd` |
 | branches created outside `gt` | invisible to `gt log` | `gt branch track` before submit |
 | submit without dry-run on existing PRs | duplicate PRs | dry-run first; expect Sync/New parent |
-| fresh stack from trunk when an open PR already covers the work | orphans the existing PR number and its review history | reuse the existing PR as the stack base, or ask |
+| fresh stack from trunk when an open PR covers the work | orphans the PR number and review history | follow **Reuse before recreate** in {{.Skill "split-to-prs"}}, or ask |
 | ignore draft state after submit | Copilot and other bots skip drafts | `gh pr ready` on each PR |
 | stale trunk | submit and restack block | sync or fast-forward trunk first |
 | repo-wide `gt sync` with shared worktrees | restacks or deletes other agents' branches | scoped restack; check worktree list |

--- a/corpus/skills/pr/SKILL.md.tmpl
+++ b/corpus/skills/pr/SKILL.md.tmpl
@@ -24,6 +24,15 @@ You are working from the current branch. Choose exactly one path for that branch
 - Before modifying an open PR, read the full existing title and body and save them to a backup file in a temporary directory.
 - If the branch has an open PR and the user did not clearly ask to update it, ask whether they want to update the existing open PR or create a new PR for the current branch.
 
+### Split or stack context
+
+When the user asked to split work into multiple PRs or a stack, and an open PR already covers that work:
+
+- Reuse before recreate. If an open PR already covers the work being split, treat repurposing that PR as the base of the stack as the default. Never silently abandon an existing PR by opening new ones. Surface the choice and ask.
+- Do not open new PRs that abandon the existing one unless the user explicitly chose **Replace and close** or **Leave untouched** in the approved split plan from {{.Skill "split-to-prs"}}.
+- When repurposing is approved, update the existing PR's title and body to match the bottom slice only. Stack new PRs on top of that branch.
+- If the disposition is unclear, stop and ask before creating any PR.
+
 ## Step 2: Read The Branch
 
 Find the target branch from the workspace or repository context. Prefer the remote-tracking ref, such as `origin/main`.

--- a/corpus/skills/pr/SKILL.md.tmpl
+++ b/corpus/skills/pr/SKILL.md.tmpl
@@ -26,11 +26,10 @@ You are working from the current branch. Choose exactly one path for that branch
 
 ### Split or stack context
 
-When the user asked to split work into multiple PRs or a stack, and an open PR already covers that work:
+When the user asked to split work into multiple PRs or a stack, and an open PR already covers that work, follow **Reuse before recreate** in {{.Skill "split-to-prs"}}.
 
-- Reuse before recreate. If an open PR already covers the work being split, treat repurposing that PR as the base of the stack as the default. Never silently abandon an existing PR by opening new ones. Surface the choice and ask.
-- Do not open new PRs that abandon the existing one unless the user explicitly chose **Replace and close** or **Leave untouched** in the approved split plan from {{.Skill "split-to-prs"}}.
-- When repurposing is approved, update the existing PR's title and body to match the bottom slice only. Stack new PRs on top of that branch.
+- Do not open new PRs that abandon the existing one unless the user chose **Replace and close** or **Leave untouched** in the approved plan.
+- When repurposing is approved, update the existing PR title and body to match the bottom slice only. Stack new PRs on top of that branch.
 - If the disposition is unclear, stop and ask before creating any PR.
 
 ## Step 2: Read The Branch

--- a/corpus/skills/split-to-prs/SKILL.md.tmpl
+++ b/corpus/skills/split-to-prs/SKILL.md.tmpl
@@ -44,8 +44,9 @@ Check for existing open PRs that already cover this work:
 
 ```bash
 gh pr list --head "$(git branch --show-current)" --state open --json number,title,url,headRefName
-gh pr view --json body,title,url,state,number
 ```
+
+For each PR number returned, run `gh pr view <number> --json body,title,url,state,number`.
 
 Record every open PR number, branch, and URL. If the user mentioned a PR by number, confirm it with `gh pr view <number>`.
 
@@ -72,10 +73,10 @@ State which execution path you will use after approval:
 
 Ask for approval before starting. In Claude Code call `AskUserQuestion`. In Codex call `request_user_input`. In Cursor call `AskQuestion`. When none is available, present the plan in plain text and wait for approval.
 
-When an existing open PR was detected, the approval question must include these options in this order:
+When one or more existing open PRs were detected, the approval question must include these options in this order. Repeat the question for each open PR when more than one exists:
 
-1. Repurpose existing PR #N as the base of the stack (recommended)
-2. Create a new stack from trunk and leave #N alone
+1. Repurpose existing PR #<number> as the base of the stack (recommended)
+2. Create a new stack from trunk and leave #<number> alone
 3. Other
 
 ## 3. Execute the split

--- a/corpus/skills/split-to-prs/SKILL.md.tmpl
+++ b/corpus/skills/split-to-prs/SKILL.md.tmpl
@@ -23,7 +23,8 @@ Use the plain git path in section 3 only when Graphite is unavailable and the us
 ## Hard rules
 
 - Do not create branches, commit, push, or open PRs until the user approves the split plan.
-- Never discard user work. No destructive git commands (`reset --hard`, `clean -fdx`, branch deletion, force-push, history rewrite) without explicit approval.
+- Reuse before recreate. If an open PR already covers the work being split, treat repurposing that PR as the base of the stack as the default. Never silently abandon an existing PR by opening new ones. Surface the choice and ask.
+- Never discard user work. No destructive git commands (`reset --hard`, `clean -fdx`, branch deletion, force-push, history rewrite) without explicit approval. A recoverable snapshot does not mean leaving an existing open PR untouched when the user asked to split it.
 - Always save a recoverable snapshot before moving work around. This often starts from dirty work on `main`, so do not assume there is already a safe branch.
 - Stage only named files or hunks. No `git add .` or `git add -A`.
 - Every PR title and body comes from {{.Skill "pr"}}, reviewed with the user per PR. Do not use ad hoc text or default commit-message bodies.
@@ -33,6 +34,15 @@ Use the plain git path in section 3 only when Graphite is unavailable and the us
 Compare the current work to the repo's default branch, including committed and uncommitted changes. Summarize the real slices you see, and use the chat history to recover intent.
 
 Before proposing slices, find ownership signals for the touched paths (`CODEOWNERS`, nested ownership files, `tools/ownership/PRODUCTOWNERS`, or repo equivalents) and use them to identify natural reviewer boundaries.
+
+Check for existing open PRs that already cover this work:
+
+```bash
+gh pr list --head "$(git branch --show-current)" --state open --json number,title,url,headRefName
+gh pr view --json body,title,url,state,number
+```
+
+Record every open PR number, branch, and URL. If the user mentioned a PR by number, confirm it with `gh pr view <number>`.
 
 Note whether Graphite is available (see above).
 
@@ -44,12 +54,24 @@ Optimize for reviewer-aligned PRs with minimal unrelated diff: split independent
 
 Default to independent PRs off the default branch. Stack PRs only when the dependency is real.
 
+State the disposition of every existing open PR explicitly. Use one of these labels:
+
+- **Repurpose as stack base** (default when an open PR already covers the work)
+- **Replace and close** (open a new stack and close the old PR)
+- **Leave untouched** (only when the user explicitly wants the existing PR unchanged)
+
 State which execution path you will use after approval:
 
 - **Graphite** when Graphite is available (stacked branches when slices depend on each other, parallel `gt create` branches off trunk when slices are independent)
 - **Plain git branches** only when Graphite is unavailable or the user opts out
 
 Ask for approval before starting. In Claude Code call `AskUserQuestion`. In Codex call `request_user_input`. In Cursor call `AskQuestion`. When none is available, present the plan in plain text and wait for approval.
+
+When an existing open PR was detected, the approval question must include these options in this order:
+
+1. Repurpose existing PR #N as the base of the stack (recommended)
+2. Create a new stack from trunk and leave #N alone
+3. Other
 
 ## 3. Execute the split
 

--- a/corpus/skills/split-to-prs/SKILL.md.tmpl
+++ b/corpus/skills/split-to-prs/SKILL.md.tmpl
@@ -20,11 +20,16 @@ For planning, stay in this skill. For execution, follow {{.Skill "graphite"}} ta
 
 Use the plain git path in section 3 only when Graphite is unavailable and the user does not want to set it up.
 
+## Reuse before recreate
+
+When an open PR already covers the work being split, default to repurposing that PR as the stack base. Do not open new PRs that abandon the existing one unless the user explicitly chose otherwise in the approved plan. Surface the disposition and ask before you execute.
+
 ## Hard rules
 
 - Do not create branches, commit, push, or open PRs until the user approves the split plan.
-- Reuse before recreate. If an open PR already covers the work being split, treat repurposing that PR as the base of the stack as the default. Never silently abandon an existing PR by opening new ones. Surface the choice and ask.
-- Never discard user work. No destructive git commands (`reset --hard`, `clean -fdx`, branch deletion, force-push, history rewrite) without explicit approval. A recoverable snapshot does not mean leaving an existing open PR untouched when the user asked to split it.
+- When an open PR exists, follow **Reuse before recreate** above.
+- Never discard user work. No destructive git commands (`reset --hard`, `clean -fdx`, branch deletion, force-push, history rewrite) without explicit approval.
+- A recoverable snapshot preserves work. It does not require leaving an existing open PR untouched after a split request.
 - Always save a recoverable snapshot before moving work around. This often starts from dirty work on `main`, so do not assume there is already a safe branch.
 - Stage only named files or hunks. No `git add .` or `git add -A`.
 - Every PR title and body comes from {{.Skill "pr"}}, reviewed with the user per PR. Do not use ad hoc text or default commit-message bodies.
@@ -50,20 +55,20 @@ Note whether Graphite is available (see above).
 
 Use judgment on detail. Usually PR titles are enough. Add a one-line scope note only when a title is unclear. Show a Mermaid diagram when there are multiple slices.
 
-Optimize for reviewer-aligned PRs with minimal unrelated diff: split independent owners or concerns, keep tightly coupled changes together, and when stacking is necessary, order foundations before consumers.
+Optimize for reviewer-aligned PRs with minimal unrelated diff. Split independent owners or concerns. Keep tightly coupled changes together. When stacking is necessary, order foundations before consumers.
 
 Default to independent PRs off the default branch. Stack PRs only when the dependency is real.
 
 State the disposition of every existing open PR explicitly. Use one of these labels:
 
-- **Repurpose as stack base** (default when an open PR already covers the work)
-- **Replace and close** (open a new stack and close the old PR)
-- **Leave untouched** (only when the user explicitly wants the existing PR unchanged)
+- **Repurpose as stack base**: keep the open PR and thin it to the bottom slice (default)
+- **Replace and close**: open a new stack and close the old PR
+- **Leave untouched**: keep the existing PR unchanged (only when the user asks explicitly)
 
 State which execution path you will use after approval:
 
-- **Graphite** when Graphite is available (stacked branches when slices depend on each other, parallel `gt create` branches off trunk when slices are independent)
-- **Plain git branches** only when Graphite is unavailable or the user opts out
+- **Graphite** when Graphite is available. Use stacked branches when slices depend on each other. Use parallel `gt create` branches off trunk when slices are independent.
+- **Plain git branches** only when Graphite is unavailable or the user opts out.
 
 Ask for approval before starting. In Claude Code call `AskUserQuestion`. In Codex call `request_user_input`. In Cursor call `AskQuestion`. When none is available, present the plan in plain text and wait for approval.
 


### PR DESCRIPTION
### Summary

This change hardens the split-to-prs, graphite, and pr agent skills so an existing open PR is reused as the stack base by default instead of silently opening a new stack from trunk.

## Change

split-to-prs now defines a **Reuse before recreate** section, probes for open PRs before proposing slices, requires an explicit disposition per existing PR, and lists repurpose as the first approval option.

graphite links to that rule, adds a **When an open PR already exists** execution path, skips trunk `gt create` when repurposing is approved, and adds a Things to avoid row for orphaning an existing PR.

pr adds a **Split or stack context** branch under Step 1 that defers to split-to-prs and blocks abandoning an open PR without explicit approval.