### PR TITLE
Add stack position title marker to split-to-prs and graphite skills

### DIFF
--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -144,7 +144,7 @@ args: ["submit", "--stack", "--dry-run", "--no-interactive"]
 args: ["submit", "--stack", "--no-interactive"]
 ```
 
-7. **Draft and review each PR.** Check out each branch bottom to top. The `pr` skill reads the current branch, so check out the PR branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user. Apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`), not create. The PR already exists from `gt submit`.
+7. **Draft and review each PR.** Check out each branch bottom to top. The `pr` skill reads the current branch, so check out the PR branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user. Apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`), not create. The PR already exists from `gt submit`. After all stack PRs have numbers, read them bottom to top. When the numbers are non-sequential, append ` (PR x/N)` to each title through the `pr` skill edit path, per **Stack position in titles** in {{.Skill "split-to-prs"}}.
 
 8. **Mark PRs ready** when reviewers are required. Non-interactive submit often creates drafts and Copilot skips drafts:
 
@@ -199,7 +199,7 @@ Expect **Sync** or **New parent** actions. **Create** on an existing PR means th
 args: ["submit", "--stack", "--no-interactive"]
 ```
 
-7. **Draft and review each PR.** Check out each adopted branch bottom to top. The `pr` skill reads the current branch, so you must be on the PR's branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`).
+7. **Draft and review each PR.** Check out each adopted branch bottom to top. The `pr` skill reads the current branch, so you must be on the PR's branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`). After all stack PRs have numbers, read them bottom to top. When the numbers are non-sequential, append ` (PR x/N)` to each title through the `pr` skill edit path, per **Stack position in titles** in {{.Skill "split-to-prs"}}.
 
 8. **Mark drafts ready** if reviewers are required.
 
@@ -221,7 +221,7 @@ When there is no existing branch chain:
 2. Preflight (above).
 3. For each PR bottom to top: write code, stage named paths, `["create", "--message", "..."]`.
 4. `["submit", "--stack", "--dry-run", "--no-interactive"]` then real submit.
-5. Check out each branch bottom to top. The `pr` skill reads the current branch, so you must be on the PR's branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`).
+5. Check out each branch bottom to top. The `pr` skill reads the current branch, so you must be on the PR's branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user, then apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`). After all stack PRs have numbers, read them bottom to top. When the numbers are non-sequential, append ` (PR x/N)` to each title through the `pr` skill edit path, per **Stack position in titles** in {{.Skill "split-to-prs"}}.
 6. Mark PRs ready. Share bottom PR URL.
 
 ---

--- a/corpus/skills/split-to-prs/SKILL.md.tmpl
+++ b/corpus/skills/split-to-prs/SKILL.md.tmpl
@@ -24,6 +24,20 @@ Use the plain git path in section 3 only when Graphite is unavailable and the us
 
 When an open PR already covers the work being split, default to repurposing that PR as the stack base. Do not open new PRs that abandon the existing one unless the user explicitly chose otherwise in the approved plan. Surface the disposition and ask before you execute.
 
+## Stack position in titles
+
+After all PRs in the stack have GitHub numbers, read the numbers bottom to top.
+
+If the numbers are consecutive integers in stack order, leave titles unchanged.
+
+If the numbers are non-sequential, append ` (PR x/N)` to every title in the stack. Use `x` as the 1-based bottom-to-top position and `N` as the stack size. Apply the suffix through the `pr` skill edit path (`gh pr edit`).
+
+Put the suffix at the very end of the title, after the `[TICKET-12345] ...` text from the `pr` skill.
+
+Single-PR stacks (`N` is 1) never get the suffix.
+
+Example: `[AGENCY-11267] Add plaid relink URL (PR 2/3)`
+
 ## Hard rules
 
 - Do not create branches, commit, push, or open PRs until the user approves the split plan.
@@ -105,4 +119,4 @@ For each approved slice:
 
 ## 4. Report back
 
-Keep it short: PR titles and URLs, plus anything left on the starting branch or working tree. For Graphite splits, include the bottom PR URL and stack order. Per-PR final output (Slack one-liner and URL) comes from the `pr` skill Step 8. Do not delete the backup ref or original branch unless the user asks.
+Keep it short: PR titles and URLs, plus anything left on the starting branch or working tree. For Graphite splits, include the bottom PR URL and stack order. Before reporting, confirm stack PR numbers are sequential bottom to top. When they are not, apply **Stack position in titles** so each reported title includes ` (PR x/N)`. Per-PR final output (Slack one-liner and URL) comes from the `pr` skill Step 8. Do not delete the backup ref or original branch unless the user asks.


### PR DESCRIPTION
### Summary

This change adds guidance for appending ` (PR x/N)` to stack PR titles when GitHub assigns non-sequential PR numbers.

Reviewers can still infer stack order from consecutive numbers like `#101 #102 #103`. When unrelated PRs land in between and numbers skip, each title gets a position suffix so order stays visible.

## Change

The `split-to-prs` skill gains a **Stack position in titles** section. It defines when to leave titles alone, when to append ` (PR x/N)`, and where the suffix goes at the end of the title.

Section 4 now tells the agent to apply that rule before reporting stack results.

The `graphite` skill references the same rule in the three execute steps that draft and edit titles after submit.