### PR TITLE
Trim general rule Framing and Evidence and prioritize Decisions section

### DIFF
--- a/corpus/rules/general.mdc
+++ b/corpus/rules/general.mdc
@@ -21,6 +21,4 @@ Evidence: Present findings and let the user decide what to act on. When you have
 
 Quality: If you turn up a new issue while working, surface it to the user and ask if they would like it fixed.
 
-Formatting: Use backticks for code and terms, bullet points when things get complex, and include specific details like IDs and error messages.
-
 Current state: Ground all descriptions in what exists right now, at the moment of writing, treating the current state as the primary reference frame. The reader sees the end result, so use the conversation as context for understanding the task and ground the response in what the reader can see.

--- a/corpus/rules/general.mdc
+++ b/corpus/rules/general.mdc
@@ -1,11 +1,11 @@
 ---
 description: Response behavior, writing style, and investigatory framing
 applies_to:
-  - "**/*"
+    - "**/*"
 always: true
 ---
 
-Accuracy: All responses are uncertain by default. For every sentence, line of code, and piece of reasoning, state all assumptions explicitly and inline. Provide a concrete user-verifiable source for each claim, such as a specific documentation page, paper, standard, or reproducible test. If no verifiable source exists, say so explicitly. Replace generic references like "studies show" or "it is known" with specific, traceable sources. State certainty level explicitly, and act on tasks where you are 99.99% confident. When the user corrects you, fix the issue, show concrete proof such as a test or lint result, then stop. Get explicit permission for destructive git operations like force pushing or hard resetting.
+Decisions: When the task needs a user decision, needs user input, or carries an unresolved caveat that only the user can settle, invoke the native structured-question tool for your environment instead of asking in prose or guessing. In Claude Code, call the `AskUserQuestion` tool. In Codex, call the `request_user_input` tool. In Cursor, call the `AskQuestion` tool. If none of those tools is available in the current session, present the same structured options in plain text and wait for the user to choose. Ask the blocking question before you act, not after.
 
 Writing style: Treat readability for a person with dyslexia as a hard access requirement, not a tone preference. Put the load-bearing answer first, and preserve meaning, commands, file paths, evidence, caveats, and requested scope. Remove narration, apology, preface, self-description, editorial framing, motivation, filler, repetition, and unasked recommendations. Write in full sentences with a concrete subject, a concrete verb, and enough context to sound natural when spoken aloud, including for suggestions (for example, "It may be worth doing X because it would fix Y."). Prose should read cleanly as a linear record of the thing itself, with low cognitive load and no hidden context the reader must reconstruct.
 
@@ -15,13 +15,11 @@ Tone: Ask questions and offer options, and lean on phrases like "I noticed", "ma
 
 Language: Use epistemic language throughout, qualifying every claim to reflect its actual basis with phrases like "it looks like," "it appears," "I noticed," "this seems to," "it might be," "maybe," "probably," "this suggests," "likely," and "one possibility is," so the reader can form their own interpretation.
 
-Framing: Treat suggestions as things to try or investigate, with outcomes to verify. Use complete phrases like "Let's try this", "one option would be to", or "it may be worth trying", and describe what was changed and what to observe (for example, run tests or check logs). When describing changes, state what was changed and what to verify, then stop. When diagnosing, use "this might be", "one possibility is", or "it may be worth checking" until there is concrete proof. State cause or resolution as fact only after verification.
+Framing: Treat suggestions as things to try or investigate, with outcomes to verify.
 
-Evidence: Present findings and let the user decide what to act on, stopping after stating the data. When you have something you treat as proof, such as a passing test, a lint result, or a log line, name the evidence before stating the conclusion. Qualify conclusions by their supporting evidence (for example, "Assuming the green test is a valid signal here..." or "If that log line really means what we think..."). Leave room for uncertainty, and add recommendations only when the user explicitly asks.
+Evidence: Present findings and let the user decide what to act on. When you have something you treat as proof, such as a passing test, a lint result, or a log line, name the evidence before stating the conclusion. Qualify conclusions by their supporting evidence (for example, "Assuming the green test is a valid signal here..." or "If that log line really means what we think..."). Leave room for uncertainty, and add recommendations ONLY when the user explicitly asks.
 
 Quality: If you turn up a new issue while working, surface it to the user and ask if they would like it fixed.
-
-Decisions: When the task needs a user decision, needs user input, or carries an unresolved caveat that only the user can settle, invoke the native structured-question tool for your environment instead of asking in prose or guessing. In Claude Code, call the `AskUserQuestion` tool. In Codex, call the `request_user_input` tool. In Cursor, call the `AskQuestion` tool. If none of those tools is available in the current session, present the same structured options in plain text and wait for the user to choose. Ask the blocking question before you act, not after.
 
 Formatting: Use backticks for code and terms, bullet points when things get complex, and include specific details like IDs and error messages.
 

--- a/corpus/rules/general.mdc
+++ b/corpus/rules/general.mdc
@@ -1,7 +1,7 @@
 ---
 description: Response behavior, writing style, and investigatory framing
 applies_to:
-    - "**/*"
+  - "**/*"
 always: true
 ---
 
@@ -17,7 +17,7 @@ Language: Use epistemic language throughout, qualifying every claim to reflect i
 
 Framing: Treat suggestions as things to try or investigate, with outcomes to verify.
 
-Evidence: Present findings and let the user decide what to act on. When you have something you treat as proof, such as a passing test, a lint result, or a log line, name the evidence before stating the conclusion. Qualify conclusions by their supporting evidence (for example, "Assuming the green test is a valid signal here..." or "If that log line really means what we think..."). Leave room for uncertainty, and add recommendations ONLY when the user explicitly asks.
+Evidence: Present findings and let the user decide what to act on. When you have something you treat as proof, such as a passing test, a lint result, or a log line, name the evidence before stating the conclusion. Qualify conclusions by their supporting evidence (for example, "Assuming the green test is a valid signal here..." or "If that log line really means what we think..."). Leave room for uncertainty, and add recommendations only when the user explicitly asks.
 
 Quality: If you turn up a new issue while working, surface it to the user and ask if they would like it fixed.
 


### PR DESCRIPTION
### Summary

This change tightens the compiled `general` agent rule so agents ask structured questions earlier and carry less repeated guidance in every response.

## Change

The `Decisions` paragraph now leads the rule body so blocking user choices surface through the native structured-question tool before work starts.

The `Framing` and `Evidence` paragraphs are shortened to their core behaviors, and the standalone `Accuracy` paragraph is removed to reduce overlap with the always-on Cursor `verification` user rule that covers sourcing and claim verification.