### PR TITLE
Remove makefile dev-dir overrides and add architecture doc conventions

### DIFF
--- a/corpus/rules/general.mdc
+++ b/corpus/rules/general.mdc
@@ -1,9 +1,17 @@
 ---
 description: Response behavior, writing style, and investigatory framing
 applies_to:
-  - "**/*"
+    - "**/*"
 always: true
 ---
+
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+This is not negotiable. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
 
 Decisions: When the task needs a user decision, needs user input, or carries an unresolved caveat that only the user can settle, invoke the native structured-question tool for your environment instead of asking in prose or guessing. In Claude Code, call the `AskUserQuestion` tool. In Codex, call the `request_user_input` tool. In Cursor, call the `AskQuestion` tool. If none of those tools is available in the current session, present the same structured options in plain text and wait for the user to choose. Ask the blocking question before you act, not after.
 

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -153,7 +153,7 @@ Architecture docs describe the system as it is now, and link to the code or test
 
 - One `overview.md` per area lives at `docs/<area>/overview.md`.
 - A short entry pointer in `README.md` or `AGENTS.md` links to each area overview.
-- Doc path segments are single words, so `docs/deadcode/overview.md`, never `docs/dead-code/`.
+- Doc path segments are single words. Use paths like `docs/deadcode/overview.md`, and never use paths like `docs/dead-code/overview.md`.
 - The overview states what the area does today, in present tense.
 - Each statement links to the source file, test, or doc that holds the truth.
 - The enforcing test or rule is the source of truth, and the doc never copies the invariant it enforces.

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -146,3 +146,17 @@ Links work best when another local source is the stable home for the detail.
 - Repeated detail creates drift.
 - Current behavior matters more than history.
 - Historical notes appear only when current work requires them.
+
+## Document architecture as current state
+
+Architecture docs describe the system as it is now, and link to the code or test that holds each detail, so the doc cannot drift from the code.
+
+- One `overview.md` per area lives at `docs/<area>/overview.md`.
+- A short entry pointer in `README.md` or `AGENTS.md` links to each area overview.
+- Doc path segments are single words, so `docs/deadcode/overview.md`, never `docs/dead-code/`.
+- The overview states what the area does today, in present tense.
+- Each statement links to the source file, test, or doc that holds the truth.
+- The enforcing test or rule is the source of truth, and the doc never copies the invariant it enforces.
+- A copied detail drifts, so link to it instead of restating it.
+- The doc describes what is, not how the decision was reached.
+- Decision history stays out unless current work needs it.

--- a/zshrc/incl.zsh
+++ b/zshrc/incl.zsh
@@ -2,17 +2,6 @@ export PATH="$PATH:$HOME/.cargo/bin"
 export PATH="$PATH:$HOME/go/bin"
 export NVM_LAZY_LOAD=true
 
-# Use local shared makefile checkouts so consumer repos pick up unpushed
-# pipeline changes immediately. Conditional so machines without a checkout
-# fall back to the network fetch path. Run `make smoke-fetch` in any
-# consumer repo to exercise the remote curl chain explicitly.
-if [[ -d "$HOME/Sites/go-makefile" ]]; then
-    export GO_MK_DEV_DIR="$HOME/Sites/go-makefile"
-fi
-if [[ -d "$HOME/Sites/swift-makefile" ]]; then
-    export SWIFT_MK_DEV_DIR="$HOME/Sites/swift-makefile"
-fi
-
 # shellcheck shell=bash
 source "$DOTDOTFILES/zshrc/core/perf.zsh"
 


### PR DESCRIPTION
### Summary

This change removes conditional local makefile dev-dir exports from zsh startup and adds architecture documentation conventions to the writing rules corpus.

## Change

`incl.zsh` no longer checks for `~/Sites/go-makefile` or `~/Sites/swift-makefile` during shell startup. Every machine now uses the network fetch path for shared makefiles.

The writing rules corpus now documents how architecture overviews should live under `docs/<area>/overview.md`, link to source instead of copying invariants, and describe current behavior in present tense.

Made with [Cursor](https://cursor.com)