### PR TITLE
Allow AI agent authors in global pre-push hook

### DIFF
--- a/git-global-hooks/email-guard.sh
+++ b/git-global-hooks/email-guard.sh
@@ -2,6 +2,15 @@
 # Resolve allowed email and name for repo at $PWD
 
 resolve_allowed_identity() {
+    local configured_email configured_name
+    configured_email="$(git config --get goodkind.allowedEmail 2>/dev/null || true)"
+    configured_name="$(git config --get goodkind.allowedName 2>/dev/null || true)"
+    if [[ -n "$configured_email" && -n "$configured_name" ]]; then
+        echo "$configured_email"
+        echo "$configured_name"
+        return
+    fi
+
     local rules_file="${GIT_EMAIL_RULES:-}"
     local repo_path
     repo_path="$(git rev-parse --show-toplevel \
@@ -49,4 +58,57 @@ resolve_allowed_identity() {
 
     echo "$match_email"
     echo "$match_name"
+}
+
+resolve_allowed_identity_fields() {
+    local identity
+    identity="$(resolve_allowed_identity)"
+    if [[ -z "$identity" ]]; then
+        return 1
+    fi
+
+    RESOLVED_ALLOWED_EMAIL="${identity%%$'\n'*}"
+    if [[ "$identity" == *$'\n'* ]]; then
+        RESOLVED_ALLOWED_NAME="${identity#*$'\n'}"
+    else
+        RESOLVED_ALLOWED_NAME=""
+    fi
+
+    return 0
+}
+
+default_allowed_authors() {
+    printf '%s\n' \
+        'Codex <codex@openai.com>' \
+        'Claude <noreply@anthropic.com>' \
+        'Cursor <cursoragent@cursor.com>' \
+        'Cursor Agent <cursoragent@cursor.com>'
+}
+
+resolve_allowed_authors() {
+    if resolve_allowed_identity_fields; then
+        printf '%s <%s>\n' "$RESOLVED_ALLOWED_NAME" "$RESOLVED_ALLOWED_EMAIL"
+    fi
+
+    # Keep the committer human-scoped, but allow well-known AI authors on
+    # pushed commits so signed human commits can carry explicit agent authorship.
+    default_allowed_authors
+    git config --get-all goodkind.allowedAuthor 2>/dev/null || true
+}
+
+author_is_allowed() {
+    local current_author="$1"
+    local allowed_authors="$2"
+    local allowed_author
+
+    while IFS= read -r allowed_author; do
+        if [[ -z "$allowed_author" ]]; then
+            continue
+        fi
+        if [[ "$current_author" == "$allowed_author" ]]; then
+            return 0
+        fi
+    done <<<"$allowed_authors"
+
+    return 1
 }

--- a/git-global-hooks/pre-commit
+++ b/git-global-hooks/pre-commit
@@ -2,10 +2,9 @@
 source "$(dirname "$0")/email-guard.sh"
 source "$(dirname "$0")/chain-hook.sh"
 
-identity=$(resolve_allowed_identity)
-if [[ -n "$identity" ]]; then
-    allowed_email=$(echo "$identity" | head -1)
-    allowed_name=$(echo "$identity" | tail -1)
+if resolve_allowed_identity_fields; then
+    allowed_email="$RESOLVED_ALLOWED_EMAIL"
+    allowed_name="$RESOLVED_ALLOWED_NAME"
     current_email=$(git config user.email)
     current_name=$(git config user.name)
 
@@ -20,7 +19,7 @@ if [[ -n "$identity" ]]; then
             echo "  git config user.email $allowed_email"
         fi
         if [[ "$current_name" != "$allowed_name" ]]; then
-            echo "  git config user.name \"$allowed_name\""
+            printf '  git config user.name %q\n' "$allowed_name"
         fi
         exit 1
     fi

--- a/git-global-hooks/pre-push
+++ b/git-global-hooks/pre-push
@@ -12,10 +12,10 @@ trap cleanup EXIT
 cat >"$stdin_file"
 export CHAIN_HOOK_STDIN_FILE="$stdin_file"
 
-identity=$(resolve_allowed_identity)
-if [[ -n "$identity" ]]; then
-    allowed_email=$(echo "$identity" | head -1)
-    allowed_name=$(echo "$identity" | tail -1)
+if resolve_allowed_identity_fields; then
+    allowed_email="$RESOLVED_ALLOWED_EMAIL"
+    allowed_name="$RESOLVED_ALLOWED_NAME"
+    allowed_authors="$(resolve_allowed_authors)"
 
     # Exclude default branches (push remote and upstream) from author check.
     # When pushing a branch based on upstream/master to a fork, only commits
@@ -41,14 +41,26 @@ if [[ -n "$identity" ]]; then
             range="$remote_oid..$local_oid$exclude_not"
         fi
 
-        bad=$(git log "$range" \
-            --format="%H %an <%ae>" 2>/dev/null |
-            grep -v "$allowed_name <$allowed_email>" ||
-            true)
+        bad=""
+        while IFS= read -r author_line; do
+            if [[ -z "$author_line" ]]; then
+                continue
+            fi
+            if ! author_is_allowed "$author_line" "$allowed_authors"; then
+                bad+="$author_line"$'\n'
+            fi
+        done < <(git log "$range" --format="%H %an <%ae>" 2>/dev/null)
 
         if [[ -n "$bad" ]]; then
             echo "error: push blocked, bad author"
-            echo "  allowed: $allowed_name <$allowed_email>"
+            echo "  allowed committer: $allowed_name <$allowed_email>"
+            echo "  allowed authors:"
+            while IFS= read -r allowed_author; do
+                if [[ -z "$allowed_author" ]]; then
+                    continue
+                fi
+                echo "    $allowed_author"
+            done <<<"$allowed_authors"
             echo "$bad" | while read -r line; do
                 echo "  $line"
             done

--- a/git-global-hooks/pre-push
+++ b/git-global-hooks/pre-push
@@ -42,12 +42,12 @@ if resolve_allowed_identity_fields; then
         fi
 
         bad=""
-        while IFS= read -r author_line; do
-            if [[ -z "$author_line" ]]; then
+        while IFS= read -r commit_hash author_pair; do
+            if [[ -z "$author_pair" ]]; then
                 continue
             fi
-            if ! author_is_allowed "$author_line" "$allowed_authors"; then
-                bad+="$author_line"$'\n'
+            if ! author_is_allowed "$author_pair" "$allowed_authors"; then
+                bad+="$commit_hash $author_pair"$'\n'
             fi
         done < <(git log "$range" --format="%H %an <%ae>" 2>/dev/null)
 


### PR DESCRIPTION
### Summary

This change updates the global git hooks so pushes can include commits authored by well-known AI agents while the committer identity stays human-scoped.

## Change

The pre-push hook now checks each commit author against an allowlist instead of requiring every author to match the human committer identity. The allowlist includes Codex, Claude, and Cursor, plus any entries in `goodkind.allowedAuthor`.

The email guard also reads `goodkind.allowedEmail` and `goodkind.allowedName` from git config when set, and the pre-commit hook now prints the suggested name fix with proper shell quoting.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identity validation for commit hooks by honoring optional `goodkind.allowedEmail` and `goodkind.allowedName` git config values when present.
  * Validation guidance is now more precise, including correctly escaped suggested `git config user.name` updates.
  * Pre-push checks now more consistently evaluate commit authors, and report a clearer allowlist alongside any blocked, disallowed author entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->