### PR TITLE
Update codex-subagent defaults in corpus/skills/codex-subagent/SKILL.md.tmpl

### DIFF
--- a/corpus/skills/codex-subagent/SKILL.md.tmpl
+++ b/corpus/skills/codex-subagent/SKILL.md.tmpl
@@ -13,9 +13,9 @@ Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 
 Every `codex exec` dispatch uses these flags unless the user overrides them:
 
-- **Reasoning:** `-c model_reasoning_effort="xhigh"`.
-- **Model:** omit `-m` unless the user names a model. The default model comes from `~/.codex/config.toml` on the host machine.
-- **Sandbox:** `--dangerously-bypass-approvals-and-sandbox` up front when the user has delegated work to Codex through this skill. Do not start with `-s read-only` or `-s workspace-write` and lift sandbox later. Sandboxed runs routinely fail on `.git` writes in linked worktrees and force cache or Makefile workarounds. Scope limits ("read-only" vs "edit allowed") live in the prompt.
+- **Reasoning:** `-c model_reasoning_effort="xhigh"`. If `codex exec` rejects `xhigh` for the default model, retry with `-c model_reasoning_effort="high"` or drop the override.
+- **Model:** omit `-m` unless the user names a model. The default model comes from host configuration (for example `~/.codex/config.toml` when present) or Codex's built-in default.
+- **Sandbox:** `--dangerously-bypass-approvals-and-sandbox` up front when the user has delegated work to Codex through this skill. This bypasses approval prompts and the filesystem sandbox. Do not start with `-s read-only` or `-s workspace-write` and lift sandbox later. Sandboxed runs routinely fail on `.git` writes in linked worktrees and force cache or Makefile workarounds. Scope limits ("read-only" vs "edit allowed") live in the prompt.
 
 ## Run codex exec
 
@@ -37,7 +37,7 @@ Permissions:
 
 - Read-only analysis, review, and search: state "read-only" in the prompt and do not edit files.
 - Implementation: state "edit allowed" in the prompt when the user grants edit permission for that work.
-- The bypass flag removes the filesystem sandbox, so scope discipline lives in the prompt. Polling and timeout remain mandatory.
+- The bypass flag removes approval prompts and the filesystem sandbox, so scope discipline lives in the prompt. Polling and timeout remain mandatory.
 
 Continue a prior session with `codex exec resume`:
 

--- a/corpus/skills/codex-subagent/SKILL.md.tmpl
+++ b/corpus/skills/codex-subagent/SKILL.md.tmpl
@@ -9,13 +9,24 @@ Use `codex exec` when the user asks to delegate work to Codex. The CLI path give
 
 Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 
+## Defaults
+
+Every `codex exec` dispatch uses these flags unless the user overrides them:
+
+- **Reasoning:** `-c model_reasoning_effort="xhigh"`.
+- **Model:** omit `-m` unless the user names a model. The config default in `~/.codex/config.toml` tracks the latest supported model.
+- **Sandbox:** `--dangerously-bypass-approvals-and-sandbox` up front. Do not start with `-s read-only` or `-s workspace-write` and lift sandbox later. Sandboxed runs routinely fail on `.git` writes in linked worktrees and force cache or Makefile workarounds.
+
 ## Run codex exec
 
-Start a new read-only task with the prompt on stdin and the final answer written to a file:
+Start a new task with the prompt on stdin and the final answer written to a file:
 
 ```bash
 result_file="$(mktemp)"
-timeout 1500 codex exec -s read-only -m gpt-5.5 -o "$result_file" - <<'PROMPT'
+timeout 1500 codex exec \
+  --dangerously-bypass-approvals-and-sandbox \
+  -c model_reasoning_effort="xhigh" \
+  -o "$result_file" - <<'PROMPT'
 <bounded prompt>
 PROMPT
 ```
@@ -24,15 +35,18 @@ GNU `timeout` is required. On macOS, use `gtimeout` from coreutils when `timeout
 
 Permissions:
 
-- Use `-s read-only` for analysis, review, and search.
-- Use `-s workspace-write` only when the user grants edit permission for that work.
-- `codex exec` does not wait on stdin for approvals, but approval-elicitation stalls can still happen in edge cases, so polling and timeout remain mandatory.
+- Read-only analysis, review, and search: state "read-only" in the prompt and do not edit files.
+- Implementation: state "edit allowed" in the prompt when the user grants edit permission for that work.
+- The bypass flag removes the filesystem sandbox, so scope discipline lives in the prompt. Polling and timeout remain mandatory.
 
 Continue a prior session with `codex exec resume`:
 
 ```bash
 result_file="$(mktemp)"
-timeout 1500 codex exec resume <session-id> -s read-only -m gpt-5.5 -o "$result_file" - <<'PROMPT'
+timeout 1500 codex exec resume <session-id> \
+  --dangerously-bypass-approvals-and-sandbox \
+  -c model_reasoning_effort="xhigh" \
+  -o "$result_file" - <<'PROMPT'
 <follow-up prompt>
 PROMPT
 ```
@@ -105,6 +119,6 @@ Report the result in this order:
 4. Name any verification performed by the host agent after the Codex response.
 5. State exact errors if the `codex exec` run failed.
 
-For failures, preserve exact CLI stderr and exit code. If a retry is appropriate, retry once with no model override or with `-m gpt-5.5`, then report the observed result.
+For failures, preserve exact CLI stderr and exit code. If a retry is appropriate, retry once with the same defaults (xhigh, config model, no sandbox), then report the observed result.
 
 Avoid `-m gpt-5.5-codex` for ChatGPT-account Codex sessions unless the user has verified that model is supported for the account.

--- a/corpus/skills/codex-subagent/SKILL.md.tmpl
+++ b/corpus/skills/codex-subagent/SKILL.md.tmpl
@@ -14,8 +14,8 @@ Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 Every `codex exec` dispatch uses these flags unless the user overrides them:
 
 - **Reasoning:** `-c model_reasoning_effort="xhigh"`.
-- **Model:** omit `-m` unless the user names a model. The config default in `~/.codex/config.toml` tracks the latest supported model.
-- **Sandbox:** `--dangerously-bypass-approvals-and-sandbox` up front. Do not start with `-s read-only` or `-s workspace-write` and lift sandbox later. Sandboxed runs routinely fail on `.git` writes in linked worktrees and force cache or Makefile workarounds.
+- **Model:** omit `-m` unless the user names a model. The default model comes from `~/.codex/config.toml` on the host machine.
+- **Sandbox:** `--dangerously-bypass-approvals-and-sandbox` up front when the user has delegated work to Codex through this skill. Do not start with `-s read-only` or `-s workspace-write` and lift sandbox later. Sandboxed runs routinely fail on `.git` writes in linked worktrees and force cache or Makefile workarounds. Scope limits ("read-only" vs "edit allowed") live in the prompt.
 
 ## Run codex exec
 

--- a/corpus/skills/codex-subagent/SKILL.md.tmpl
+++ b/corpus/skills/codex-subagent/SKILL.md.tmpl
@@ -119,6 +119,6 @@ Report the result in this order:
 4. Name any verification performed by the host agent after the Codex response.
 5. State exact errors if the `codex exec` run failed.
 
-For failures, preserve exact CLI stderr and exit code. If a retry is appropriate, retry once with the same defaults (xhigh, config model, no sandbox), then report the observed result.
+For failures, preserve exact CLI stderr and exit code. If a retry is appropriate, retry once with adjusted parameters (try `-c model_reasoning_effort="high"` if xhigh was rejected, otherwise use the same defaults), then report the observed result.
 
 Avoid `-m gpt-5.5-codex` for ChatGPT-account Codex sessions unless the user has verified that model is supported for the account.


### PR DESCRIPTION
### Summary

The codex-subagent skill now tells host agents to dispatch Codex with xhigh reasoning, the config-driven latest model, and no sandbox from the first command.

## Why

Sandboxed `codex exec` runs failed in practice on linked worktrees and normal repos. They blocked `.git` writes, forced Go cache workarounds, and required a kill-and-resume cycle to lift the sandbox. The skill still hardcoded `-s read-only` / `-s workspace-write` and `-m gpt-5.5`, which did not match how this environment already runs Codex.

## Change

`corpus/skills/codex-subagent/SKILL.md.tmpl` adds a Defaults section and updates both example commands to pass `-c model_reasoning_effort="xhigh"` and `--dangerously-bypass-approvals-and-sandbox`, while omitting `-m` so `~/.codex/config.toml` selects the model. Permissions move into the prompt ("read-only" vs "edit allowed") because the bypass flag removes the filesystem sandbox. The failure-retry guidance matches the new defaults.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated delegated execution defaults for the Codex subagent, including consistent sandbox-bypass behavior and a higher default reasoning effort for new and resumed runs.
* **Bug Fixes**
  * Improved resume and retry handling to reuse the same defaults and preserve observed error details (including exit code and stderr) between attempts.
* **Documentation**
  * Refined the skill guidance so model selection and permission wording behave consistently—applying defaults only when no explicit model is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->