### PR TITLE
Add worktree trunk ref guards to graphite split-to-prs and babysit skills

### DIFF
--- a/corpus/rules/code.mdc
+++ b/corpus/rules/code.mdc
@@ -31,7 +31,7 @@ Use the remote-tracking ref (for example `origin/main`, or `upstream/master` whe
 
 Never move `refs/heads/<branch>` while that branch is checked out in another worktree. Use `origin/<branch>` for comparisons and `gt restack` for stack updates instead.
 
-Local refs can go stale when they are checked out elsewhere in worktrees.
+When a branch ref moves out from under another checkout, that checkout's index and working tree can stay at the old commit even though HEAD follows the new ref.
 
 ## Subagents
 

--- a/corpus/rules/code.mdc
+++ b/corpus/rules/code.mdc
@@ -29,6 +29,8 @@ Fetch before any diff, merge-base, log range, or branch comparison.
 
 Use the remote-tracking ref (for example `origin/main`, or `upstream/master` when that is the upstream) rather than the local branch name.
 
+Never move `refs/heads/<branch>` while that branch is checked out in another worktree. Use `origin/<branch>` for comparisons and `gt restack` for stack updates instead.
+
 Local refs can go stale when they are checked out elsewhere in worktrees.
 
 ## Subagents

--- a/corpus/skills/babysit/SKILL.md.tmpl
+++ b/corpus/skills/babysit/SKILL.md.tmpl
@@ -48,7 +48,7 @@ Only `active` rules are returned. Rules in `evaluate` or `disabled` enforcement 
 
 Resolve merge conflicts while preserving intent on both the PR branch and the base branch. If intents truly conflict, abort the merge and ask the user for clarification before continuing.
 
-If `mergeStateStatus` is `BEHIND`, update the branch from base before re-checking CI, since another PR may have already fixed a failing check.
+If `mergeStateStatus` is `BEHIND`, update the branch from base before re-checking CI, since another PR may have already fixed a failing check. When babysitting a Graphite stack in a feature worktree, restack via {{.Skill "graphite"}} (`gt restack` / `gt submit`). Never fast-forward or `update-ref` local `refs/heads/<trunk>` if trunk is checked out in another worktree.
 
 ## 4. Triage inline review comments
 

--- a/corpus/skills/babysit/SKILL.md.tmpl
+++ b/corpus/skills/babysit/SKILL.md.tmpl
@@ -48,7 +48,7 @@ Only `active` rules are returned. Rules in `evaluate` or `disabled` enforcement 
 
 Resolve merge conflicts while preserving intent on both the PR branch and the base branch. If intents truly conflict, abort the merge and ask the user for clarification before continuing.
 
-If `mergeStateStatus` is `BEHIND`, update the branch from base before re-checking CI, since another PR may have already fixed a failing check. When babysitting a Graphite stack in a feature worktree, restack via {{.Skill "graphite"}} (`gt restack` / `gt submit`). Never fast-forward or `update-ref` local `refs/heads/<trunk>` if trunk is checked out in another worktree.
+If `mergeStateStatus` is `BEHIND`, update the branch from base before re-checking CI, since another PR may have already fixed a failing check. When babysitting a Graphite stack in a feature worktree, restack via {{.Skill "graphite"}} (`gt restack` / `gt submit`). Never fast-forward or `git update-ref` local `refs/heads/<trunk>` if trunk is checked out in another worktree.
 
 ## 4. Triage inline review comments
 

--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -52,17 +52,17 @@ Run through MCP before creating, adopting, or restacking:
 
 ## Worktrees and trunk refs
 
-Use this section whenever stack work runs in a feature worktree while trunk stays checked out elsewhere (for example a banned primary checkout).
+Use this section whenever stack work runs in a feature worktree while trunk stays checked out elsewhere (for example the primary checkout, which is off limits as a work surface).
 
 ### Hard rules
 
 1. **Never move a branch ref that is checked out in another worktree.** Banned when trunk is checked out elsewhere:
    - `git update-ref refs/heads/<trunk> ...`
    - `git branch -f <trunk> ...`
-   - `git reset --hard <trunk>` or any command that moves `refs/heads/<trunk>`
+   - `git reset --hard <other-ref>` while checked out on `<trunk>`, or any command that moves `refs/heads/<trunk>`
 2. **Snapshots use `refs/backup/*` only**, never `refs/heads/*`.
 3. **Compare and rebase against `origin/<trunk>`**, not local `<trunk>`, when the feature worktree is active and trunk lives in a different checkout.
-4. **All stack git/gt/gh/make writes** use an explicit worktree path (`run_gt_cmd` `cwd`, or `git -C <worktree>`). Shell cwd resets to the primary checkout between tool calls.
+4. **All stack git/gt/make writes** use an explicit worktree path (`run_gt_cmd` `cwd`, or `git -C <worktree>`). **`gh` writes** must run with the shell cwd in the target worktree (or after `cd <worktree>`), since `gh` has no path flag. Shell cwd resets to the primary checkout between tool calls.
 
 Moving `refs/heads/<trunk>` out from under another checkout leaves that checkout's HEAD at the new commit while its index and working tree stay at the old one. `git status` there then reports the entire trunk diff as staged changes even though no file contents were edited.
 

--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -46,7 +46,7 @@ Run through MCP before creating, adopting, or restacking:
 1. `["log", "short"]` for tracked branches and parent chain
 2. `["init"]` and `["auth"]` if the repo is new to Graphite
 3. `git -C <worktree> fetch origin` and compare the stack base to `origin/<trunk>`. Stale remote trunk blocks submit and restack. Do not move `refs/heads/<trunk>` when trunk is checked out in another worktree (see **Worktrees and trunk refs**).
-4. `git -C <worktree> worktree list` and record which checkout owns trunk. When multiple agents may share the repo, also run `git -C <worktree> symbolic-ref refs/remotes/origin/HEAD` to discover the default branch name.
+4. `git -C <worktree> worktree list` and record which checkout owns trunk. When multiple agents may share the repo, discover the default branch with `git -C <worktree> symbolic-ref --quiet refs/remotes/origin/HEAD` when it exists, or `git -C <worktree> remote show origin` as a fallback.
 
 **Untracked branches:** if git shows branches that `gt log` omits, they were created outside Graphite. Adopt before submit (see adopt workflow below).
 
@@ -149,7 +149,7 @@ if [ -n "$SHA" ]; then
 fi
 ```
 
-2. **Refresh remote trunk** with `git -C <worktree> fetch origin`. Use `["sync", "--no-interactive"]` only when trunk is checked out in `<worktree>`. Never `update-ref refs/heads/<trunk>` when trunk is checked out elsewhere.
+2. **Refresh remote trunk** with `git -C <worktree> fetch origin`. Use `["sync", "--no-interactive"]` only when trunk is checked out in `<worktree>`. Never `git update-ref refs/heads/<trunk>` when trunk is checked out elsewhere.
 
 3. **Bottom slice first.** Check out trunk, apply only that slice's files/hunks, stage, then:
 
@@ -275,7 +275,7 @@ Graphite adds stack-specific state that plain PR babysitting misses.
 
 When `mergeStateStatus` is `BEHIND` or trunk advanced while your stack is open:
 
-1. Prefer a **scoped restack** of your stack, not a repo-wide sync, when other worktrees are active. Never `update-ref refs/heads/<trunk>` or otherwise move the local trunk ref when trunk is checked out in another worktree.
+1. Prefer a **scoped restack** of your stack, not a repo-wide sync, when other worktrees are active. Never `git update-ref refs/heads/<trunk>` or otherwise move the local trunk ref when trunk is checked out in another worktree.
 2. Run `git -C <worktree> fetch origin`, then MCP: `["sync", "--no-interactive"]` only after confirming `git worktree list` shows no unrelated mid-flight work and trunk is checked out in `<worktree>`. Otherwise restack just your stack:
 
 ```text
@@ -447,8 +447,8 @@ Prefer `["continue"]` over `git rebase --continue`. Avoid `["abort"]` in agent s
 | submit without dry-run on existing PRs | duplicate PRs | dry-run first; expect Sync/New parent |
 | fresh stack from trunk when an open PR covers the work | orphans the PR number and review history | follow **Reuse before recreate** in {{.Skill "split-to-prs"}}, or ask |
 | ignore draft state after submit | Copilot and other bots skip drafts | `gh pr ready` on each PR |
-| stale trunk | submit and restack block | `git fetch origin` plus scoped `gt restack`; never `update-ref refs/heads/<trunk>` when trunk is checked out elsewhere |
-| `update-ref refs/heads/<trunk>` while trunk checked out elsewhere | skews that checkout; entire trunk looks staged/dirty | `git fetch origin` plus `gt restack` onto `origin/<trunk>` |
+| stale trunk | submit and restack block | `git fetch origin` plus scoped `gt restack`; never `git update-ref refs/heads/<trunk>` when trunk is checked out elsewhere |
+| `git update-ref refs/heads/<trunk>` while trunk checked out elsewhere | skews that checkout; entire trunk looks staged/dirty | `git fetch origin` plus `gt restack` onto `origin/<trunk>` |
 | repo-wide `gt sync` with shared worktrees | restacks or deletes other agents' branches | scoped restack; check worktree list |
 | `git branch -D` when user authorized `gt delete` | ghost Graphite metadata | `gt delete` or `gt sync` when safe |
 | manual rebase of one stack branch | desyncs upstack parents | `gt modify` or `gt restack` |

--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -45,10 +45,37 @@ Run through MCP before creating, adopting, or restacking:
 
 1. `["log", "short"]` for tracked branches and parent chain
 2. `["init"]` and `["auth"]` if the repo is new to Graphite
-3. Fetch trunk and confirm it is current. Stale local trunk blocks submit and restack
-4. `git worktree list` when multiple agents may share the repo
+3. `git -C <worktree> fetch origin` and compare the stack base to `origin/<trunk>`. Stale remote trunk blocks submit and restack. Do not move `refs/heads/<trunk>` when trunk is checked out in another worktree (see **Worktrees and trunk refs**).
+4. `git -C <worktree> worktree list` and record which checkout owns trunk. When multiple agents may share the repo, also run `git -C <worktree> symbolic-ref refs/remotes/origin/HEAD` to discover the default branch name.
 
 **Untracked branches:** if git shows branches that `gt log` omits, they were created outside Graphite. Adopt before submit (see adopt workflow below).
+
+## Worktrees and trunk refs
+
+Use this section whenever stack work runs in a feature worktree while trunk stays checked out elsewhere (for example a banned primary checkout).
+
+### Hard rules
+
+1. **Never move a branch ref that is checked out in another worktree.** Banned when trunk is checked out elsewhere:
+   - `git update-ref refs/heads/<trunk> ...`
+   - `git branch -f <trunk> ...`
+   - `git reset --hard <trunk>` or any command that moves `refs/heads/<trunk>`
+2. **Snapshots use `refs/backup/*` only**, never `refs/heads/*`.
+3. **Compare and rebase against `origin/<trunk>`**, not local `<trunk>`, when the feature worktree is active and trunk lives in a different checkout.
+4. **All stack git/gt/gh/make writes** use an explicit worktree path (`run_gt_cmd` `cwd`, or `git -C <worktree>`). Shell cwd resets to the primary checkout between tool calls.
+
+Moving `refs/heads/<trunk>` out from under another checkout leaves that checkout's HEAD at the new commit while its index and working tree stay at the old one. `git status` there then reports the entire trunk diff as staged changes even though no file contents were edited.
+
+### Safe restack when trunk advanced
+
+```bash
+git -C <worktree> fetch origin
+# MCP from <worktree> cwd:
+# args: ["restack", "--branch", "<bottom-branch>", "--upstack", "--no-interactive"]
+# then: ["submit", "--stack", "--no-interactive"]
+```
+
+Use `["sync", "--no-interactive"]` only when trunk is checked out in the same worktree you are driving. Otherwise rely on `git fetch origin` plus scoped `gt restack`.
 
 ## Command Map
 
@@ -122,7 +149,7 @@ if [ -n "$SHA" ]; then
 fi
 ```
 
-2. **Sync trunk** via MCP: `["sync", "--no-interactive"]` or fast-forward trunk first.
+2. **Refresh remote trunk** with `git -C <worktree> fetch origin`. Use `["sync", "--no-interactive"]` only when trunk is checked out in `<worktree>`. Never `update-ref refs/heads/<trunk>` when trunk is checked out elsewhere.
 
 3. **Bottom slice first.** Check out trunk, apply only that slice's files/hunks, stage, then:
 
@@ -248,8 +275,8 @@ Graphite adds stack-specific state that plain PR babysitting misses.
 
 When `mergeStateStatus` is `BEHIND` or trunk advanced while your stack is open:
 
-1. Prefer a **scoped restack** of your stack, not a repo-wide sync, when other worktrees are active.
-2. MCP: `["sync", "--no-interactive"]` only after confirming `git worktree list` shows no unrelated mid-flight work, or restack just your stack:
+1. Prefer a **scoped restack** of your stack, not a repo-wide sync, when other worktrees are active. Never `update-ref refs/heads/<trunk>` or otherwise move the local trunk ref when trunk is checked out in another worktree.
+2. Run `git -C <worktree> fetch origin`, then MCP: `["sync", "--no-interactive"]` only after confirming `git worktree list` shows no unrelated mid-flight work and trunk is checked out in `<worktree>`. Otherwise restack just your stack:
 
 ```text
 args: ["restack", "--branch", "<bottom-branch>", "--upstack", "--no-interactive"]
@@ -420,7 +447,8 @@ Prefer `["continue"]` over `git rebase --continue`. Avoid `["abort"]` in agent s
 | submit without dry-run on existing PRs | duplicate PRs | dry-run first; expect Sync/New parent |
 | fresh stack from trunk when an open PR covers the work | orphans the PR number and review history | follow **Reuse before recreate** in {{.Skill "split-to-prs"}}, or ask |
 | ignore draft state after submit | Copilot and other bots skip drafts | `gh pr ready` on each PR |
-| stale trunk | submit and restack block | sync or fast-forward trunk first |
+| stale trunk | submit and restack block | `git fetch origin` plus scoped `gt restack`; never `update-ref refs/heads/<trunk>` when trunk is checked out elsewhere |
+| `update-ref refs/heads/<trunk>` while trunk checked out elsewhere | skews that checkout; entire trunk looks staged/dirty | `git fetch origin` plus `gt restack` onto `origin/<trunk>` |
 | repo-wide `gt sync` with shared worktrees | restacks or deletes other agents' branches | scoped restack; check worktree list |
 | `git branch -D` when user authorized `gt delete` | ghost Graphite metadata | `gt delete` or `gt sync` when safe |
 | manual rebase of one stack branch | desyncs upstack parents | `gt modify` or `gt restack` |

--- a/corpus/skills/split-to-prs/SKILL.md.tmpl
+++ b/corpus/skills/split-to-prs/SKILL.md.tmpl
@@ -71,7 +71,7 @@ Note whether Graphite is available (see above).
 When `git worktree list` shows more than one checkout, record which path owns trunk before proposing slices:
 
 ```bash
-git -C <worktree> worktree list
+git worktree list
 ```
 
 For trunk and ref safety during Graphite execution, follow **Worktrees and trunk refs** in {{.Skill "graphite"}}.

--- a/corpus/skills/split-to-prs/SKILL.md.tmpl
+++ b/corpus/skills/split-to-prs/SKILL.md.tmpl
@@ -45,6 +45,8 @@ Example: `[AGENCY-11267] Add plaid relink URL (PR 2/3)`
 - Never discard user work. No destructive git commands (`reset --hard`, `clean -fdx`, branch deletion, force-push, history rewrite) without explicit approval.
 - A recoverable snapshot preserves work. It does not require leaving an existing open PR untouched after a split request.
 - Always save a recoverable snapshot before moving work around. This often starts from dirty work on `main`, so do not assume there is already a safe branch.
+- When work happens in a feature worktree, record the primary checkout path and treat local `refs/heads/<trunk>` as read-only. Never move trunk refs from the feature worktree when trunk is checked out elsewhere.
+- Snapshot refs must stay under `refs/backup/`, never `refs/heads/`.
 - Stage only named files or hunks. No `git add .` or `git add -A`.
 - Every PR title and body comes from {{.Skill "pr"}}, reviewed with the user per PR. Do not use ad hoc text or default commit-message bodies.
 
@@ -65,6 +67,14 @@ For each PR number returned, run `gh pr view <number> --json body,title,url,stat
 Record every open PR number, branch, and URL. If the user mentioned a PR by number, confirm it with `gh pr view <number>`.
 
 Note whether Graphite is available (see above).
+
+When `git worktree list` shows more than one checkout, record which path owns trunk before proposing slices:
+
+```bash
+git -C <worktree> worktree list
+```
+
+For trunk and ref safety during Graphite execution, follow **Worktrees and trunk refs** in {{.Skill "graphite"}}.
 
 ## 2. Propose the split
 


### PR DESCRIPTION
### Summary

This change adds worktree-safe trunk guidance to the graphite, split-to-prs, and babysit corpus skills, and expands the git section in `code.mdc`.

Agents were moving `refs/heads/main` from a feature worktree while `main` stayed checked out in the primary checkout. That ref move skewed the primary checkout and made the entire trunk diff look staged even though no files were edited.

## Why

Graphite stack workflows told agents to "fast-forward trunk first" without a worktree guard. That wording led to `git update-ref refs/heads/main origin/main` from a feature worktree during restack prep.

## Change

The graphite skill now documents **Worktrees and trunk refs** with hard rules, a safe restack recipe, and updated preflight and babysit steps. Split-to-prs and babysit cross-link that guidance. `code.mdc` states the same rule at the git layer.

Snapshot refs stay under `refs/backup/`. Agents compare against `origin/<trunk>` and use scoped `gt restack` instead of moving local trunk refs when trunk is checked out elsewhere.

A matching `never-move-checked-out-branch-ref` agent-gate rule and validator were added locally in `~/.config/agent-gate/` (outside this repo).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded stacked PR workflow guidance with stricter rules for multi-worktree environments, including when trunk refs must be treated as read-only.
  * Added clearer preflight and refresh steps for pulling the latest remote trunk and comparing against the correct upstream reference.
  * Improved “behind” merge-conflict recovery instructions with explicit restack actions for the stack and safer handling to prevent updating the wrong local trunk ref.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->