### PR TITLE
Make code, python, and writing corpus rules always-on and remove the claude instruction-doc output

### DIFF
--- a/corpus/rules/code.mdc
+++ b/corpus/rules/code.mdc
@@ -10,7 +10,7 @@ applies_to:
   - "*.zsh"
   - "*.bash"
   - "*.go"
-always: false
+always: true
 ---
 
 # Code style

--- a/corpus/rules/python.mdc
+++ b/corpus/rules/python.mdc
@@ -2,7 +2,7 @@
 description: Python code style, typing, toolchain, and project conventions
 applies_to:
   - "*.py"
-always: false
+always: true
 ---
 
 Python version: Use the latest stable Python release for all repos. Set `requires-python`, `mypy python_version`, `basedpyright pythonVersion`, and `ruff target-version` to match in `pyproject.toml`.

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -4,7 +4,7 @@ applies_to:
   - "*.md"
   - "*.mdc"
   - "*.txt"
-always: false
+always: true
 ---
 
 # Technical documentation writing

--- a/corpus/targets.toml
+++ b/corpus/targets.toml
@@ -33,13 +33,6 @@ dest       = ".claude/rules"
 rule_ext   = ".md"
 skill_dest = ".claude/skills"
 
-[[output]]
-provider   = "claude"
-kind       = "instruction-doc"
-dest       = ".claude/CLAUDE.md"
-title      = "Claude Memory"
-skill_dest = ".claude/skills"
-
 # Shared cross-agent directory (read by Zed, VSCode, and Codex)
 [[output]]
 provider  = "agents"


### PR DESCRIPTION
### Summary

Claude Code now loads every user rule at session start, and `~/.claude/CLAUDE.md` is no longer generated. The dotfiles sync engine previously wrote each corpus rule to two Claude targets at once: a per-file `~/.claude/rules/*.md` and a concatenated `~/.claude/CLAUDE.md`. That duplicated all 8 rules, and the concatenation path stripped frontmatter, so the path-scoped rules (`code`, `python`, `writing`) were re-emitted into CLAUDE.md with no `paths:` and loaded unconditionally anyway.

## Why

Claude's harness does not reliably load path-scoped rules at the moment they are needed, so scoping them by file glob left the rules silent when they should apply. An unscoped rule file loads at launch with the same priority as CLAUDE.md, so making every rule always-on is both simpler and more reliable for this use.

## Change

`corpus/rules/code.mdc`, `python.mdc`, and `writing.mdc` now set `always: true` instead of `always: false`. Their `applies_to` globs stay in place for the cursor and copilot targets, where `always: true` renders as `alwaysApply: true` / `applyTo: **/*`.

`corpus/targets.toml` drops the `claude` `instruction-doc` output row, so the sync engine stops generating `~/.claude/CLAUDE.md`. The other providers (agents, codex, gemini, copilot, zed) keep their instruction-doc outputs, since they have no same-priority rules directory. The `instruction-doc` kind itself is unchanged in the engine.
