### PR TITLE
Add lowercase uuid command via prefer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
   go:
     uses: agoodkind/go-makefile/.github/workflows/_ci.yml@main
     permissions:
-      attestations: write
       contents: read
       id-token: write
       attestations: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   go:
-    uses: agoodkind/go-makefile/.github/workflows/_ci.yml@main
+    uses: agoodkind/go-makefile/.github/workflows/_ci.yml@033f704db6d21ff71b25cd2299a457f4db78b5a2
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      attestations: write
+    secrets: inherit
     with:
       apt_packages: zsh
       go_version_file: dots/go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   go:
-    uses: agoodkind/go-makefile/.github/workflows/_ci.yml@033f704db6d21ff71b25cd2299a457f4db78b5a2
+    uses: agoodkind/go-makefile/.github/workflows/_ci.yml@main
     permissions:
       contents: read
       id-token: write

--- a/config/dispatch.toml
+++ b/config/dispatch.toml
@@ -20,5 +20,6 @@ source_files = [
     "$DOTDOTFILES/zshrc/core/prefer.zsh",
     "$DOTDOTFILES/zshrc/commands/prefer-decls.zsh",
     "$DOTDOTFILES/zshrc/commands/editors.zsh",
+    "$DOTDOTFILES/zshrc/commands/aliases.zsh",
     "$DOTDOTFILES/zshrc/integrations/zoxide.zsh",
 ]

--- a/dots/config/prefercache-bootstrap.zsh.tmpl
+++ b/dots/config/prefercache-bootstrap.zsh.tmpl
@@ -8,6 +8,7 @@ function isinstalled() {
 
 source "$DOTDOTFILES/zshrc/core/prefer.zsh"
 source "$DOTDOTFILES/zshrc/commands/editors.zsh"
+source "$DOTDOTFILES/zshrc/commands/aliases.zsh"
 source "$DOTDOTFILES/zshrc/integrations/zoxide.zsh"
 source "$DOTDOTFILES/zshrc/commands/prefer-decls.zsh"
 true

--- a/zshrc/commands/aliases.zsh
+++ b/zshrc/commands/aliases.zsh
@@ -21,6 +21,10 @@ function pbcopy() {
     fi
 }
 
+function _uuid() {
+    print -r -- ${(L)$(uuidgen)}
+}
+
 # thefuck wrapper: lazy load on first use
 function fuck() {
     unfunction fuck

--- a/zshrc/commands/aliases.zsh
+++ b/zshrc/commands/aliases.zsh
@@ -27,7 +27,7 @@ function _uuid() {
         return 0
     fi
     if [[ -r /proc/sys/kernel/random/uuid ]]; then
-        tr -d '\n' </proc/sys/kernel/random/uuid
+        cat /proc/sys/kernel/random/uuid
         return 0
     fi
     echo "_uuid: uuidgen not found; install uuid-runtime (Debian/Ubuntu) or util-linux" >&2

--- a/zshrc/commands/aliases.zsh
+++ b/zshrc/commands/aliases.zsh
@@ -25,15 +25,13 @@ function _uuid() {
     local uuid
     if command -v uuidgen >/dev/null 2>&1; then
         uuid=$(command uuidgen) || return $?
-        print -r -- ${(L)uuid}
-        return 0
+    elif [[ -r /proc/sys/kernel/random/uuid ]]; then
+        uuid=$(</proc/sys/kernel/random/uuid) || return $?
+    else
+        echo "_uuid: uuidgen not found; install uuid-runtime (Debian/Ubuntu) or util-linux" >&2
+        return 127
     fi
-    if [[ -r /proc/sys/kernel/random/uuid ]]; then
-        cat /proc/sys/kernel/random/uuid
-        return 0
-    fi
-    echo "_uuid: uuidgen not found; install uuid-runtime (Debian/Ubuntu) or util-linux" >&2
-    return 127
+    print -r -- ${uuid:l}
 }
 
 # thefuck wrapper: lazy load on first use

--- a/zshrc/commands/aliases.zsh
+++ b/zshrc/commands/aliases.zsh
@@ -22,7 +22,16 @@ function pbcopy() {
 }
 
 function _uuid() {
-    print -r -- ${(L)$(uuidgen)}
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr '[:upper:]' '[:lower:]'
+        return 0
+    fi
+    if [[ -r /proc/sys/kernel/random/uuid ]]; then
+        tr -d '\n' </proc/sys/kernel/random/uuid
+        return 0
+    fi
+    echo "_uuid: uuidgen not found; install uuid-runtime (Debian/Ubuntu) or util-linux" >&2
+    return 127
 }
 
 # thefuck wrapper: lazy load on first use

--- a/zshrc/commands/aliases.zsh
+++ b/zshrc/commands/aliases.zsh
@@ -22,8 +22,10 @@ function pbcopy() {
 }
 
 function _uuid() {
+    local uuid
     if command -v uuidgen >/dev/null 2>&1; then
-        uuidgen | tr '[:upper:]' '[:lower:]'
+        uuid=$(command uuidgen) || return $?
+        print -r -- ${(L)uuid}
         return 0
     fi
     if [[ -r /proc/sys/kernel/random/uuid ]]; then

--- a/zshrc/commands/aliases.zsh
+++ b/zshrc/commands/aliases.zsh
@@ -23,7 +23,7 @@ function pbcopy() {
 
 function _uuid() {
     local uuid
-    if command -v uuidgen >/dev/null 2>&1; then
+    if (($+commands[uuidgen])); then
         uuid=$(command uuidgen) || return $?
     elif [[ -r /proc/sys/kernel/random/uuid ]]; then
         uuid=$(</proc/sys/kernel/random/uuid) || return $?

--- a/zshrc/commands/aliases.zsh
+++ b/zshrc/commands/aliases.zsh
@@ -31,7 +31,7 @@ function _uuid() {
         echo "_uuid: uuidgen not found; install uuid-runtime (Debian/Ubuntu) or util-linux" >&2
         return 127
     fi
-    print -r -- ${uuid:l}
+    print -r -- "${uuid:l}"
 }
 
 # thefuck wrapper: lazy load on first use

--- a/zshrc/commands/prefer-decls.zsh
+++ b/zshrc/commands/prefer-decls.zsh
@@ -31,6 +31,7 @@ prefer npm pnpm
 
 # ssh helper
 prefer sshrm ssh-keygen -R
+prefer uuid _uuid
 
 # Editor: nvim > vim > vi (with sudoedit wrappers)
 if isinstalled nvim; then

--- a/zshrc/core/utils.zsh
+++ b/zshrc/core/utils.zsh
@@ -151,6 +151,7 @@ function dotfiles_changed_hash() {
         "$DOTDOTFILES/zshrc/core/prefer.zsh" \
         "$DOTDOTFILES/zshrc/commands/prefer-decls.zsh" \
         "$DOTDOTFILES/zshrc/commands/editors.zsh" \
+        "$DOTDOTFILES/zshrc/commands/aliases.zsh" \
         "$DOTDOTFILES/zshrc/integrations/zoxide.zsh"; do
         if zstat -A file_stat +mtime "$f" 2>/dev/null; then
             if ((file_stat[1] > max_mtime)); then


### PR DESCRIPTION
### Summary

This change adds a `uuid` shell command that prints a lowercase UUID.

## Change

A new `_uuid` helper in `aliases.zsh` reads a UUID from `uuidgen` or `/proc/sys/kernel/random/uuid` and lowercases it with zsh `${uuid:l}`. `prefer-decls.zsh` registers it as `prefer uuid _uuid`, so it follows the same prefer-alias pattern as other helper commands.

`aliases.zsh` is also wired into the prefer-cache bootstrap, `dispatch.toml` source files, and `dotfiles_changed_hash`, so background cache rebuilds resolve `_uuid` the same way as other prefer helpers defined outside `prefer-decls.zsh`.

## Testing

In zsh with the prefer chain sourced, `_uuid` prints a lowercase RFC-style UUID, `type uuid` shows `uuid is an alias for _uuid`, and the prefer cache contains `alias uuid=_uuid`.

Made with [Cursor](https://cursor.com)