### PR TITLE
Add RuleBody transclusion helper for corpus skill templates (PR 1/4)

### DIFF
--- a/dots/internal/sync/compilation/compilation.go
+++ b/dots/internal/sync/compilation/compilation.go
@@ -383,7 +383,8 @@ func RenderSkillDirs(src string, dst string, refStyle SkillRefStyle) error {
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		return fmt.Errorf("creating directory %s: %w", dst, err)
 	}
-	ruleNames, err := ruleBaseNames(filepath.Join(filepath.Dir(src), "rules"))
+	rulesDir := filepath.Join(filepath.Dir(src), "rules")
+	ruleNames, err := ruleBaseNames(rulesDir)
 	if err != nil {
 		return err
 	}
@@ -404,7 +405,7 @@ func RenderSkillDirs(src string, dst string, refStyle SkillRefStyle) error {
 		if isSymlink(target) {
 			_ = os.Remove(target)
 		}
-		if err := renderSkillDir(source, target, refStyle, ruleNames, &conflicts); err != nil {
+		if err := renderSkillDir(source, target, refStyle, rulesDir, ruleNames, &conflicts); err != nil {
 			return err
 		}
 	}
@@ -414,7 +415,7 @@ func RenderSkillDirs(src string, dst string, refStyle SkillRefStyle) error {
 	return skillRenderConflictsError(conflicts)
 }
 
-func renderSkillDir(src string, dst string, refStyle SkillRefStyle, ruleNames []string, conflicts *[]string) error {
+func renderSkillDir(src string, dst string, refStyle SkillRefStyle, rulesDir string, ruleNames []string, conflicts *[]string) error {
 	entries, err := os.ReadDir(src)
 	if err != nil {
 		slog.Warn("compilation: renderSkillDir ReadDir failed", "src", src, "err", err)
@@ -427,7 +428,7 @@ func renderSkillDir(src string, dst string, refStyle SkillRefStyle, ruleNames []
 		source := filepath.Join(src, entry.Name())
 		target := filepath.Join(dst, entry.Name())
 		if entry.IsDir() {
-			if err := renderSkillDir(source, target, refStyle, ruleNames, conflicts); err != nil {
+			if err := renderSkillDir(source, target, refStyle, rulesDir, ruleNames, conflicts); err != nil {
 				return err
 			}
 			continue
@@ -443,7 +444,7 @@ func renderSkillDir(src string, dst string, refStyle SkillRefStyle, ruleNames []
 		if base, ok := strings.CutSuffix(entry.Name(), ".tmpl"); ok {
 			outputName = base
 			fromTemplate = true
-			rendered, tmplErr := renderSkillTemplate(string(content), refStyle, ruleNames, entry.Name())
+			rendered, tmplErr := renderSkillTemplate(string(content), refStyle, rulesDir, ruleNames, entry.Name())
 			if tmplErr != nil {
 				return tmplErr
 			}
@@ -524,10 +525,12 @@ func skillRenderConflictsError(conflicts []string) error {
 }
 
 // skillTemplateData exposes corpus reference helpers to a skill template as the
-// "{{.Rules}}", "{{.Rule \"name\"}}", and "{{.Skill \"name\"}}" methods.
+// "{{.Rules}}", "{{.Rule \"name\"}}", "{{.RuleBody \"name\"}}", and "{{.Skill \"name\"}}" methods.
 type skillTemplateData struct {
 	style     SkillRefStyle
+	rulesDir  string
 	ruleNames []string
+	execErr   *error
 }
 
 // Rules renders the full rule list for the active style.
@@ -539,22 +542,70 @@ func (d skillTemplateData) Rule(name string) string { return renderRuleLink(d.st
 // Skill renders a sibling skill link for the active style.
 func (d skillTemplateData) Skill(name string) string { return renderSkillSiblingLink(name) }
 
+// RuleBody inlines a corpus rule body, expanding any skill references inside it.
+func (d skillTemplateData) RuleBody(name string) string {
+	path := filepath.Join(d.rulesDir, name+".mdc")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if d.execErr != nil {
+			*d.execErr = fmt.Errorf("reading rule body %q: %w", name, err)
+		}
+		return ""
+	}
+	rule, parseErr := ParseRuleSource(string(content))
+	if parseErr != nil {
+		if d.execErr != nil {
+			*d.execErr = fmt.Errorf("parsing rule body %q: %w", name, parseErr)
+		}
+		return ""
+	}
+	body := strings.TrimSpace(rule.Body)
+	if !strings.Contains(body, "{{") {
+		return body
+	}
+	parsed, parseErr := template.New(name + ".mdc").Parse(body)
+	if parseErr != nil {
+		if d.execErr != nil {
+			*d.execErr = fmt.Errorf("parsing rule body template %q: %w", name, parseErr)
+		}
+		return ""
+	}
+	buf := bytes.NewBuffer(nil)
+	if execErr := parsed.Execute(buf, d); execErr != nil {
+		if d.execErr != nil {
+			*d.execErr = fmt.Errorf("executing rule body template %q: %w", name, execErr)
+		}
+		return ""
+	}
+	return strings.TrimSpace(buf.String())
+}
+
 func renderSkillSiblingLink(name string) string {
 	skillPath := filepath.ToSlash(filepath.Join("..", name, "SKILL.md"))
 	return fmt.Sprintf("[%s](%s)", name, skillPath)
 }
 
 // renderSkillTemplate renders one skill template through text/template.
-func renderSkillTemplate(content string, refStyle SkillRefStyle, ruleNames []string, name string) (string, error) {
+func renderSkillTemplate(content string, refStyle SkillRefStyle, rulesDir string, ruleNames []string, name string) (string, error) {
 	parsed, err := template.New(name).Parse(content)
 	if err != nil {
 		slog.Warn("compilation: renderSkillTemplate parse failed", "name", name, "err", err)
 		return "", fmt.Errorf("parsing skill template %s: %w", name, err)
 	}
+	var execErr error
 	buf := bytes.NewBuffer(nil)
-	if err := parsed.Execute(buf, skillTemplateData{style: refStyle, ruleNames: ruleNames}); err != nil {
+	data := skillTemplateData{
+		style:     refStyle,
+		rulesDir:  rulesDir,
+		ruleNames: ruleNames,
+		execErr:   &execErr,
+	}
+	if err := parsed.Execute(buf, data); err != nil {
 		slog.Warn("compilation: renderSkillTemplate execute failed", "name", name, "err", err)
 		return "", fmt.Errorf("executing skill template %s: %w", name, err)
+	}
+	if execErr != nil {
+		return "", execErr
 	}
 	return injectSkillMarker(buf.String()), nil
 }

--- a/dots/internal/sync/compilation/compilation.go
+++ b/dots/internal/sync/compilation/compilation.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"text/template"
@@ -531,6 +532,26 @@ type skillTemplateData struct {
 	rulesDir  string
 	ruleNames []string
 	execErr   *error
+	expanding *map[string]struct{}
+}
+
+func (d skillTemplateData) setExecErr(err error) {
+	if d.execErr != nil && *d.execErr == nil {
+		*d.execErr = err
+	}
+}
+
+func (d skillTemplateData) validRuleBodyName(name string) error {
+	if name == "" || name == "." || name == ".." {
+		return fmt.Errorf("invalid rule body name %q", name)
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, string(filepath.Separator)) {
+		return fmt.Errorf("invalid rule body name %q", name)
+	}
+	if !slices.Contains(d.ruleNames, name) {
+		return fmt.Errorf("unknown rule body %q", name)
+	}
+	return nil
 }
 
 // Rules renders the full rule list for the active style.
@@ -544,19 +565,27 @@ func (d skillTemplateData) Skill(name string) string { return renderSkillSibling
 
 // RuleBody inlines a corpus rule body, expanding any skill references inside it.
 func (d skillTemplateData) RuleBody(name string) string {
+	if err := d.validRuleBodyName(name); err != nil {
+		d.setExecErr(err)
+		return ""
+	}
+	if d.expanding != nil {
+		if _, ok := (*d.expanding)[name]; ok {
+			d.setExecErr(fmt.Errorf("cyclic rule body transclusion for %q", name))
+			return ""
+		}
+		(*d.expanding)[name] = struct{}{}
+		defer delete(*d.expanding, name)
+	}
 	path := filepath.Join(d.rulesDir, name+".mdc")
 	content, err := os.ReadFile(path)
 	if err != nil {
-		if d.execErr != nil {
-			*d.execErr = fmt.Errorf("reading rule body %q: %w", name, err)
-		}
+		d.setExecErr(fmt.Errorf("reading rule body %q: %w", name, err))
 		return ""
 	}
 	rule, parseErr := ParseRuleSource(string(content))
 	if parseErr != nil {
-		if d.execErr != nil {
-			*d.execErr = fmt.Errorf("parsing rule body %q: %w", name, parseErr)
-		}
+		d.setExecErr(fmt.Errorf("parsing rule body %q: %w", name, parseErr))
 		return ""
 	}
 	body := strings.TrimSpace(rule.Body)
@@ -565,16 +594,12 @@ func (d skillTemplateData) RuleBody(name string) string {
 	}
 	parsed, parseErr := template.New(name + ".mdc").Parse(body)
 	if parseErr != nil {
-		if d.execErr != nil {
-			*d.execErr = fmt.Errorf("parsing rule body template %q: %w", name, parseErr)
-		}
+		d.setExecErr(fmt.Errorf("parsing rule body template %q: %w", name, parseErr))
 		return ""
 	}
 	buf := bytes.NewBuffer(nil)
 	if execErr := parsed.Execute(buf, d); execErr != nil {
-		if d.execErr != nil {
-			*d.execErr = fmt.Errorf("executing rule body template %q: %w", name, execErr)
-		}
+		d.setExecErr(fmt.Errorf("executing rule body template %q: %w", name, execErr))
 		return ""
 	}
 	return strings.TrimSpace(buf.String())
@@ -593,19 +618,21 @@ func renderSkillTemplate(content string, refStyle SkillRefStyle, rulesDir string
 		return "", fmt.Errorf("parsing skill template %s: %w", name, err)
 	}
 	var execErr error
+	expanding := make(map[string]struct{})
 	buf := bytes.NewBuffer(nil)
 	data := skillTemplateData{
 		style:     refStyle,
 		rulesDir:  rulesDir,
 		ruleNames: ruleNames,
 		execErr:   &execErr,
+		expanding: &expanding,
 	}
 	if err := parsed.Execute(buf, data); err != nil {
 		slog.Warn("compilation: renderSkillTemplate execute failed", "name", name, "err", err)
 		return "", fmt.Errorf("executing skill template %s: %w", name, err)
 	}
 	if execErr != nil {
-		return "", execErr
+		return "", fmt.Errorf("executing skill template %s: %w", name, execErr)
 	}
 	return injectSkillMarker(buf.String()), nil
 }

--- a/dots/internal/sync/compilation/skills_test.go
+++ b/dots/internal/sync/compilation/skills_test.go
@@ -334,6 +334,72 @@ func TestRenderRuleFiles(t *testing.T) {
 	}
 }
 
+func TestRenderSkillDirsRuleBodyTransclusion(t *testing.T) {
+	root := t.TempDir()
+	rulesDir := filepath.Join(root, "rules")
+	writeTestFile(t, filepath.Join(rulesDir, "writing.mdc"), strings.Join([]string{
+		"---",
+		"description: Writing rules",
+		"---",
+		"",
+		"# Writing rule",
+		"",
+		"See {{.Skill \"make-readable\"}} for help.",
+		"",
+		"Anti-hardcode guidance lives here.",
+	}, "\n"))
+	skillsDir := filepath.Join(root, "skills")
+	writeTestFile(
+		t,
+		filepath.Join(skillsDir, "enforce-rules", "SKILL.md.tmpl"),
+		"---\nname: enforce-rules\ndescription: d\n---\n\n## Writing\n\n{{.RuleBody \"writing\"}}\n",
+	)
+	dst := filepath.Join(t.TempDir(), "skills")
+	if err := RenderSkillDirs(skillsDir, dst, SkillRefMDC); err != nil {
+		t.Fatalf("RenderSkillDirs: %v", err)
+	}
+	rendered, err := os.ReadFile(filepath.Join(dst, "enforce-rules", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading rendered skill: %v", err)
+	}
+	got := string(rendered)
+	if !strings.Contains(got, "# Writing rule") {
+		t.Errorf("rendered skill missing inlined rule heading:\n%s", got)
+	}
+	if !strings.Contains(got, "Anti-hardcode guidance lives here.") {
+		t.Errorf("rendered skill missing inlined rule body:\n%s", got)
+	}
+	wantSkillLink := "See [make-readable](../make-readable/SKILL.md) for help."
+	if !strings.Contains(got, wantSkillLink) {
+		t.Errorf("rendered skill missing rewritten skill link\nwant substring:\n%s\ngot:\n%s", wantSkillLink, got)
+	}
+	if strings.Count(got, GeneratedAgentHTMLMarker) != 1 {
+		t.Errorf("expected exactly one generated marker, got %d in:\n%s", strings.Count(got, GeneratedAgentHTMLMarker), got)
+	}
+	if strings.Contains(got, "{{") {
+		t.Errorf("rendered skill still contains unexpanded token:\n%s", got)
+	}
+}
+
+func TestRenderSkillDirsRuleBodyMissing(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "rules", "code.mdc"), "---\ndescription: c\n---\ncode body\n")
+	skillsDir := filepath.Join(root, "skills")
+	writeTestFile(
+		t,
+		filepath.Join(skillsDir, "broken", "SKILL.md.tmpl"),
+		"---\nname: broken\ndescription: d\n---\n\n{{.RuleBody \"missing\"}}\n",
+	)
+	dst := filepath.Join(t.TempDir(), "skills")
+	err := RenderSkillDirs(skillsDir, dst, SkillRefMDC)
+	if err == nil {
+		t.Fatal("expected RenderSkillDirs to fail on missing rule body, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Errorf("expected missing rule name in error, got: %v", err)
+	}
+}
+
 func TestRenderRulesForUpload(t *testing.T) {
 	srcRoot := t.TempDir()
 	writeTestFile(t, filepath.Join(srcRoot, "writing.mdc"),

--- a/dots/internal/sync/compilation/skills_test.go
+++ b/dots/internal/sync/compilation/skills_test.go
@@ -400,6 +400,46 @@ func TestRenderSkillDirsRuleBodyMissing(t *testing.T) {
 	}
 }
 
+func TestRenderSkillDirsRuleBodyRejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "rules", "code.mdc"), "---\ndescription: c\n---\ncode body\n")
+	skillsDir := filepath.Join(root, "skills")
+	writeTestFile(
+		t,
+		filepath.Join(skillsDir, "broken", "SKILL.md.tmpl"),
+		"---\nname: broken\ndescription: d\n---\n\n{{.RuleBody \"../secrets\"}}\n",
+	)
+	dst := filepath.Join(t.TempDir(), "skills")
+	err := RenderSkillDirs(skillsDir, dst, SkillRefMDC)
+	if err == nil {
+		t.Fatal("expected RenderSkillDirs to fail on traversal rule name, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid rule body name") {
+		t.Errorf("expected invalid rule body name in error, got: %v", err)
+	}
+}
+
+func TestRenderSkillDirsRuleBodyRejectsCycles(t *testing.T) {
+	root := t.TempDir()
+	rulesDir := filepath.Join(root, "rules")
+	writeTestFile(t, filepath.Join(rulesDir, "loop-a.mdc"), "---\ndescription: a\n---\n{{.RuleBody \"loop-b\"}}\n")
+	writeTestFile(t, filepath.Join(rulesDir, "loop-b.mdc"), "---\ndescription: b\n---\n{{.RuleBody \"loop-a\"}}\n")
+	skillsDir := filepath.Join(root, "skills")
+	writeTestFile(
+		t,
+		filepath.Join(skillsDir, "broken", "SKILL.md.tmpl"),
+		"---\nname: broken\ndescription: d\n---\n\n{{.RuleBody \"loop-a\"}}\n",
+	)
+	dst := filepath.Join(t.TempDir(), "skills")
+	err := RenderSkillDirs(skillsDir, dst, SkillRefMDC)
+	if err == nil {
+		t.Fatal("expected RenderSkillDirs to fail on cyclic rule body transclusion, got nil")
+	}
+	if !strings.Contains(err.Error(), "cyclic rule body transclusion") {
+		t.Errorf("expected cyclic transclusion in error, got: %v", err)
+	}
+}
+
 func TestRenderRulesForUpload(t *testing.T) {
 	srcRoot := t.TempDir()
 	writeTestFile(t, filepath.Join(srcRoot, "writing.mdc"),


### PR DESCRIPTION
## Summary

Adds `{{.RuleBody "name"}}` to the corpus skill template compiler so skills can inline a full rule body at sync time instead of duplicating prose.

## Changes

- Extend `skillTemplateData` with `rulesDir` and `execErr` for loud sync failures on missing rules.
- Thread the rules directory through `RenderSkillDirs` and `renderSkillTemplate`.
- Implement `RuleBody` to parse `.mdc` sources, expand nested `{{.Skill}}` references, and return trimmed body text.
- Add tests for successful transclusion, single generated marker, and missing-rule errors.

## Test plan

- [x] `go test ./internal/sync/compilation/...`