### PR TITLE
Add anti-hardcode guidance and examples to writing rule (PR 2/4)

### DIFF
--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -167,12 +167,12 @@ Architecture docs describe the system as it is now, stating behavior first and l
 
 **Bad** (hardcoded symbol and path):
 
-> `formatOverloadMessage` in `internal/api/errors.go` and its test hold the enforced wording.
+> `saveSettings` in `src/settings/store.ts` and its test hold the enforced wording.
 
 **Good** (behavior and contract):
 
-> The ingress returns every upstream failure as an HTTP 400 with an `invalid_request_error` body, so the real reason reaches the chat.
+> Saving settings shows a confirmation message once the write succeeds, so the user knows it was stored.
 
 **Good** (reworded, link only if truly needed):
 
-> The ingress rewords upstream capacity sheds into a plain message, and a test locks that wording so it cannot regress.
+> Saving settings confirms success with a short message, and a test locks that wording so it cannot regress.

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -53,7 +53,7 @@ A detail belongs when it helps the reviewer understand, verify, or ship safely.
 - Implementation detail stays at the system level.
 - The prose explains behavior before naming code.
 - Prose should not narrate literal code.
-- Code anchors appear only when they help the reader orient.
+- Code anchors appear only when they help the reader orient, not on every statement.
 - The code carries line-level detail.
 
 ## Order information
@@ -155,8 +155,24 @@ Architecture docs describe the system as it is now, and link to the code or test
 - A short entry pointer in `README.md` or `AGENTS.md` links to each area overview.
 - Doc path segments are single words. Use paths like `docs/deadcode/overview.md`, and never use paths like `docs/dead-code/overview.md`.
 - The overview states what the area does today, in present tense.
-- Each statement links to the source file, test, or doc that holds the truth.
+- Each statement describes current behavior first, and adds a durable doc or test link only where a reader needs to verify it.
+- A behavior doc is not an index of code locations, so do not append a symbol name or file path to every statement.
+- Name a code symbol or file path only when it is the shortest way to help a reader orient, never as the default.
 - The enforcing test or rule is the source of truth, and the doc never copies the invariant it enforces.
 - A copied detail drifts, so link to it instead of restating it.
 - The doc describes what is, not how the decision was reached.
 - Decision history stays out unless current work needs it.
+
+## Examples
+
+**Bad** (hardcoded symbol and path):
+
+> `anthropicOverloadedClientMessage` in `internal/adapter/anthropic_provider_dispatch.go` and its test hold the enforced wording.
+
+**Good** (behavior and contract):
+
+> The ingress returns every upstream failure as an HTTP 400 with an `invalid_request_error` body, so the real reason reaches the chat.
+
+**Good** (reworded, link only if truly needed):
+
+> The ingress rewords Anthropic capacity sheds into a plain message, and a test locks that wording so it cannot regress.

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -149,7 +149,7 @@ Links work best when another local source is the stable home for the detail.
 
 ## Document architecture as current state
 
-Architecture docs describe the system as it is now, stating behavior first and linking to the code or test that holds a detail only where a reader needs to verify it, so the doc cannot drift from the code.
+Architecture docs describe the system as it is now, stating behavior first and linking to the code or test that holds a detail only where a reader needs to verify it. Linking to the source that way keeps the doc easy to verify and reduces drift from the code.
 
 - One `overview.md` per area lives at `docs/<area>/overview.md`.
 - A short entry pointer in `README.md` or `AGENTS.md` links to each area overview.
@@ -163,7 +163,7 @@ Architecture docs describe the system as it is now, stating behavior first and l
 - The doc describes what is, not how the decision was reached.
 - Decision history stays out unless current work needs it.
 
-## Examples
+### Examples
 
 **Bad** (hardcoded symbol and path):
 

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -149,7 +149,7 @@ Links work best when another local source is the stable home for the detail.
 
 ## Document architecture as current state
 
-Architecture docs describe the system as it is now, and link to the code or test that holds each detail, so the doc cannot drift from the code.
+Architecture docs describe the system as it is now, stating behavior first and linking to the code or test that holds a detail only where a reader needs to verify it, so the doc cannot drift from the code.
 
 - One `overview.md` per area lives at `docs/<area>/overview.md`.
 - A short entry pointer in `README.md` or `AGENTS.md` links to each area overview.
@@ -167,7 +167,7 @@ Architecture docs describe the system as it is now, and link to the code or test
 
 **Bad** (hardcoded symbol and path):
 
-> `anthropicOverloadedClientMessage` in `internal/adapter/anthropic_provider_dispatch.go` and its test hold the enforced wording.
+> `formatOverloadMessage` in `internal/api/errors.go` and its test hold the enforced wording.
 
 **Good** (behavior and contract):
 
@@ -175,4 +175,4 @@ Architecture docs describe the system as it is now, and link to the code or test
 
 **Good** (reworded, link only if truly needed):
 
-> The ingress rewords Anthropic capacity sheds into a plain message, and a test locks that wording so it cannot regress.
+> The ingress rewords upstream capacity sheds into a plain message, and a test locks that wording so it cannot regress.


### PR DESCRIPTION
## Summary

Updates `corpus/rules/writing.mdc` so behavior-first prose is the default and hardcoded symbol or file path references are the exception.

## Changes

- Replace the over-indexed "link every statement to source" bullet with behavior-first guidance.
- Tighten the code-anchor bullet to forbid anchors on every statement.
- Reconcile the architecture-doc intro sentence with the new behavior-first bullets so the section no longer gives conflicting guidance.
- Add a good/bad example pair using a generic placeholder symbol and path, not one drawn from a specific repo.

## Test plan

- [x] Corpus sync renders updated `writing` rule copies with the new examples.