### PR TITLE
Inline writing rule in enforce-rules skill via RuleBody (PR 3/4)

### DIFF
--- a/corpus/skills/enforce-rules/SKILL.md.tmpl
+++ b/corpus/skills/enforce-rules/SKILL.md.tmpl
@@ -15,8 +15,6 @@ Also read the redo command and apply it as the review standard for any regenerat
 
 Follow every rule file for the duration of this task.
 
-## Writing
-
 {{.RuleBody "writing"}}
 
 ## Dash Prohibition

--- a/corpus/skills/enforce-rules/SKILL.md.tmpl
+++ b/corpus/skills/enforce-rules/SKILL.md.tmpl
@@ -15,6 +15,10 @@ Also read the redo command and apply it as the review standard for any regenerat
 
 Follow every rule file for the duration of this task.
 
+## Writing
+
+{{.RuleBody "writing"}}
+
 ## Dash Prohibition
 
 Never use em dashes (Unicode U+2014), en dashes (Unicode U+2013), or any other Unicode dash variant in output. This includes:


### PR DESCRIPTION
## Summary

Inlines the corpus `writing` rule body into the `enforce-rules` skill template via the new `RuleBody` helper, so the enforce-rules skill carries the full writing guidance instead of only linking to it.

## Change

`corpus/skills/enforce-rules/SKILL.md.tmpl` now calls `{{.RuleBody "writing"}}` between the "Before Starting" and "Dash Prohibition" sections. The transcluded rule body already begins with its own `# Technical documentation writing` heading, so no extra wrapper heading is added, which avoids nesting an H1 under an H2.

## Testing

- [x] Corpus sync renders the enforce-rules skill with the writing rule body inlined.