### PR TITLE
Add writing skill that inlines corpus writing rule (PR 4/4)

### DIFF
--- a/corpus/skills/enforce-rules/SKILL.md.tmpl
+++ b/corpus/skills/enforce-rules/SKILL.md.tmpl
@@ -15,8 +15,6 @@ Also read the redo command and apply it as the review standard for any regenerat
 
 Follow every rule file for the duration of this task.
 
-## Writing
-
 {{.RuleBody "writing"}}
 
 ## Dash Prohibition

--- a/corpus/skills/enforce-rules/SKILL.md.tmpl
+++ b/corpus/skills/enforce-rules/SKILL.md.tmpl
@@ -15,6 +15,10 @@ Also read the redo command and apply it as the review standard for any regenerat
 
 Follow every rule file for the duration of this task.
 
+## Writing
+
+{{.RuleBody "writing"}}
+
 ## Dash Prohibition
 
 Never use em dashes (Unicode U+2014), en dashes (Unicode U+2013), or any other Unicode dash variant in output. This includes:

--- a/corpus/skills/writing/SKILL.md.tmpl
+++ b/corpus/skills/writing/SKILL.md.tmpl
@@ -1,0 +1,12 @@
+---
+name: writing
+description: Apply the corpus writing rules to a doc or response. Use when the user invokes /writing or asks to apply the writing rules.
+---
+
+# Writing
+
+Apply the corpus writing rules to the current task.
+
+{{.RuleBody "writing"}}
+
+Related skills: {{.Skill "make-readable"}}, {{.Skill "plain"}}, {{.Skill "remove-emdashes"}}


### PR DESCRIPTION
## Summary

Adds a dedicated `/writing` skill that inlines the corpus writing rule and links sibling readability skills.

## Changes

- Create `corpus/skills/writing/SKILL.md.tmpl` with `{{.RuleBody "writing"}}` plus links to `make-readable`, `plain`, and `remove-emdashes`.

## Test plan

- [x] `./sync.sh --quick --skip-git` renders `~/.agents/skills/writing/SKILL.md` and `~/.claude/skills/writing/SKILL.md` with inlined rule body and one generated marker.