### PR TITLE
Load ~/.secrets in zsh startup

### DIFF
--- a/zshrc/core/env.zsh
+++ b/zshrc/core/env.zsh
@@ -1,0 +1,7 @@
+# shellcheck shell=bash
+###############################################################################
+# Environment setup
+###############################################################################
+# Sourced from incl.zsh above the interactive gate, so it runs in every shell
+# that sources .zshrc, including interactive and agent login shells.
+_source "$DOTDOTFILES/zshrc/core/secrets.zsh"

--- a/zshrc/core/secrets.zsh
+++ b/zshrc/core/secrets.zsh
@@ -1,0 +1,45 @@
+# shellcheck shell=bash
+###############################################################################
+# Secrets loader: export each ~/.secrets/<name> as an env var
+###############################################################################
+function _dotfiles_load_secrets() {
+    local secrets_dir="$HOME/.secrets"
+    if [[ ! -d $secrets_dir ]]; then
+        return 0
+    fi
+
+    setopt local_options null_glob
+
+    local secret_file base secret_name secret_value
+    for secret_file in "$secrets_dir"/*; do
+        if [[ ! -f $secret_file ]]; then
+            continue
+        fi
+
+        base="${secret_file##*/}"
+        # File-based secrets keep an extension and are referenced by path.
+        if [[ $base == *.* ]]; then
+            continue
+        fi
+
+        secret_name="$(
+            printf '%s' "$base" |
+                tr '[:lower:]' '[:upper:]' |
+                tr -c 'A-Za-z0-9_' '_'
+        )"
+        if [[ -z $secret_name ]]; then
+            continue
+        fi
+        if [[ $secret_name == [0-9]* ]]; then
+            continue
+        fi
+
+        secret_value="$(<"$secret_file")"
+        export "${secret_name}=${secret_value}"
+    done
+
+    if [[ -n ${GH_TOKEN:-} ]]; then
+        export GITHUB_TOKEN="$GH_TOKEN"
+    fi
+}
+_dotfiles_load_secrets

--- a/zshrc/core/secrets.zsh
+++ b/zshrc/core/secrets.zsh
@@ -10,8 +10,7 @@ function _dotfiles_load_secrets() {
 
     setopt local_options null_glob
 
-    local seen_secret_names=""
-    local secret_file base secret_name secret_value
+    local secret_file base
     for secret_file in "$secrets_dir"/*; do
         if [[ ! -f $secret_file ]]; then
             continue
@@ -23,46 +22,11 @@ function _dotfiles_load_secrets() {
             continue
         fi
 
-        secret_name="$(
-            printf '%s' "$base" |
-                tr '[:lower:]' '[:upper:]' |
-                tr -c 'A-Za-z0-9_' '_'
-        )"
-        if [[ -z $secret_name ]]; then
-            continue
-        fi
-        if [[ $secret_name == [0-9]* ]]; then
-            continue
-        fi
-
-        case "$secret_name" in
-            HOME | PATH | LD_PRELOAD | DYLD_INSERT_LIBRARIES)
-                continue
-                ;;
-        esac
-
-        case " $seen_secret_names " in
-            *" $secret_name "*)
-                continue
-                ;;
-        esac
-
-        if [[ ! -r $secret_file ]]; then
-            continue
-        fi
-        if ! secret_value="$(<"$secret_file" 2>/dev/null)"; then
-            continue
-        fi
-        secret_value="${secret_value%$'\r'}"
-        if [[ -z $secret_value ]]; then
-            continue
-        fi
-
-        export "${secret_name}=${secret_value}"
-        seen_secret_names="$seen_secret_names $secret_name"
+        export "${base:u}=$(<"$secret_file")"
     done
 
-    if [[ -n ${GH_TOKEN:-} && -z ${GITHUB_TOKEN+x} ]]; then
+    # Mirror GH_TOKEN onto GITHUB_TOKEN for tools that accept either name.
+    if [[ -n ${GH_TOKEN:-} ]]; then
         export GITHUB_TOKEN="$GH_TOKEN"
     fi
 }

--- a/zshrc/core/secrets.zsh
+++ b/zshrc/core/secrets.zsh
@@ -10,6 +10,7 @@ function _dotfiles_load_secrets() {
 
     setopt local_options null_glob
 
+    local seen_secret_names=""
     local secret_file base secret_name secret_value
     for secret_file in "$secrets_dir"/*; do
         if [[ ! -f $secret_file ]]; then
@@ -34,11 +35,34 @@ function _dotfiles_load_secrets() {
             continue
         fi
 
-        secret_value="$(<"$secret_file")"
+        case "$secret_name" in
+            HOME | PATH | LD_PRELOAD | DYLD_INSERT_LIBRARIES)
+                continue
+                ;;
+        esac
+
+        case " $seen_secret_names " in
+            *" $secret_name "*)
+                continue
+                ;;
+        esac
+
+        if [[ ! -r $secret_file ]]; then
+            continue
+        fi
+        if ! secret_value="$(<"$secret_file" 2>/dev/null)"; then
+            continue
+        fi
+        secret_value="${secret_value%$'\r'}"
+        if [[ -z $secret_value ]]; then
+            continue
+        fi
+
         export "${secret_name}=${secret_value}"
+        seen_secret_names="$seen_secret_names $secret_name"
     done
 
-    if [[ -n ${GH_TOKEN:-} ]]; then
+    if [[ -n ${GH_TOKEN:-} && -z ${GITHUB_TOKEN+x} ]]; then
         export GITHUB_TOKEN="$GH_TOKEN"
     fi
 }

--- a/zshrc/incl.zsh
+++ b/zshrc/incl.zsh
@@ -11,6 +11,7 @@ typeset -gi _ZSHRC_TREE_IDX=$((${#_PERF_TREE} + 1))
 _PERF_TREE+=("1:.zshrc:0")
 
 _source "$DOTDOTFILES/zshrc/core/utils.zsh"
+_source "$DOTDOTFILES/zshrc/core/env.zsh"
 
 # Everything below is only needed for interactive human terminal sessions.
 # Agents (CLAUDECODE, CURSOR_AGENT, CODEX_CI, GEMINI_CLI) and non-TTY shells


### PR DESCRIPTION
### Summary

This adds a small environment setup layer to zsh startup so extensionless files in `~/.secrets` become exported environment variables in every shell that sources `.zshrc`.

That lets a local `gh_token` secret populate `GH_TOKEN` automatically, and it mirrors that value onto `GITHUB_TOKEN` for tools that read either name.

## Why

The dotfiles did not have a shared env or secrets loader, so GitHub CLI auth kept falling back to the keyring token instead of the PAT stored in `~/.secrets`.

## Change

This adds `zshrc/core/env.zsh` as a small env hub and wires it into `zshrc/incl.zsh` above the interactive gate, so it runs in interactive shells and agent login shells.

It also adds `zshrc/core/secrets.zsh`, which reads extensionless files from `~/.secrets`, sanitizes each basename into an uppercase env var, skips file-based secrets that keep an extension, and mirrors `GH_TOKEN` onto `GITHUB_TOKEN`.

## Testing

- `make check`
- Branch-local login-shell probe with a temporary HOME wired to this checkout:
  - `TERM_PROGRAM= zsh -i -l -c '[[ -n $GH_TOKEN ]] && echo GH_TOKEN:set || echo GH_TOKEN:unset'` -> `GH_TOKEN:set`
  - `TERM_PROGRAM= zsh -i -l -c '[[ -n $GITHUB_TOKEN ]] && echo GITHUB_TOKEN:set || echo GITHUB_TOKEN:unset'` -> `GITHUB_TOKEN:set`
  - `TERM_PROGRAM= zsh -i -l -c '[[ -n $CF_GLOBAL_DANGEROUS_KEY ]] && echo leaked || echo cf:absent'` -> `cf:absent`
  - `TERM_PROGRAM= zsh -i -l -c 'gh api user --jq .login'` -> `agoodkind`
  - `TERM_PROGRAM= zsh -i -l -c 'gh api user/gpg_keys --jq "length"'` -> `5`
