### PR TITLE
Rewrite incl.zsh into thin orchestrator with startup helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,13 +92,16 @@ The sync logic in the Go sync implementation:
 
 **File**: `~/.cache/dotfiles/notifications`
 
-**Format**: `level|logfile|message` (one notification per line)
+**Format**: `timestamp|level|logfile|runid|message` (one notification per line)
+
+Legacy lines without a timestamp or runid are still accepted.
 
 - `level`: `success`, `info`, `warn`, `error`
 - `logfile`: path to the log file that produced this notification (may be empty)
+- `runid`: optional background run identifier (may be empty)
 - `message`: human-readable text (may contain `|` characters)
 
-`dotfiles_notify` writes to this file. At next interactive login, `incl.zsh`
+`dotfiles_notify` writes to this file. At next interactive login, `startup.zsh`
 reads and displays each notification with color coding and shows the log
 file path if available, then deletes the file.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ The sync logic in the Go sync implementation:
 
 **Format**: `timestamp|level|logfile|runid|message` (one notification per line)
 
-Legacy lines without a timestamp or runid are still accepted.
+The message is the final field and may itself contain `|`.
 
 - `level`: `success`, `info`, `warn`, `error`
 - `logfile`: path to the log file that produced this notification (may be empty)

--- a/zshrc/core/perf.zsh
+++ b/zshrc/core/perf.zsh
@@ -210,7 +210,7 @@ function _dots_exec() {
 # Kick off background maintenance (updater, cache rebuilds, ssh key load) through
 # the same bash bootstrap _dots_exec uses. The name gives the perf tree a
 # dispatch node instead of a raw bash node, and the callsite wraps it in _async.
-function _dots_dispatch() {
+function dots_dispatch() {
     _dots_exec dispatch
 }
 

--- a/zshrc/core/perf.zsh
+++ b/zshrc/core/perf.zsh
@@ -207,6 +207,13 @@ function _dots_exec() {
     command bash -lc 'source "$0" && run_dots_go_command "$@"' "$DOTDOTFILES/dots/bootstrap-go.sh" "$@"
 }
 
+# Kick off background maintenance (updater, cache rebuilds, ssh key load) through
+# the same bash bootstrap _dots_exec uses. The name gives the perf tree a
+# dispatch node instead of a raw bash node, and the callsite wraps it in _async.
+function _dots_dispatch() {
+    _dots_exec dispatch
+}
+
 function zsh_perf() {
     _dots_exec perf "$@"
 }

--- a/zshrc/core/startup.zsh
+++ b/zshrc/core/startup.zsh
@@ -1,0 +1,100 @@
+# Interactive-only startup helpers. Sourced from incl.zsh after the agent and
+# non-TTY early return, so agent shells never pay for install-lock, banner, or
+# notification display.
+
+# A live install may be writing shell state, so fall back to minimal startup
+# while the install flock is held. Returns success when startup should stop.
+function _dotfiles_install_in_progress() {
+    local install_status_dir=~/.cache/dotfiles_install.lock
+    if [[ ! -d "$install_status_dir" ]]; then
+        return 1
+    fi
+
+    local install_flock=~/.cache/dotfiles_install.flock
+    local install_lock_fd=-1
+
+    if [[ ! -e "$install_flock" ]]; then
+        rm -rf "$install_status_dir" 2>/dev/null || true
+        return 1
+    fi
+
+    # The installer only creates this status directory after it acquires the
+    # install flock, so a busy flock means the install is still live.
+    zmodload -F zsh/system b:zsystem
+    if ! zsystem flock -t 0 -f install_lock_fd "$install_flock"; then
+        print -P "%F{blue}↻ dotfiles install is running in another terminal, so this shell is using minimal startup%f"
+        return 0
+    fi
+    zsystem flock -u $install_lock_fd
+
+    # If the flock is free, the marker directory is not enough on its own and
+    # can be cleaned up.
+    rm -rf "$install_status_dir" 2>/dev/null || true
+    return 1
+}
+
+# Show transient "running now" state from background dispatch.
+function _dotfiles_show_dispatch_banner() {
+    if [[ ! -d ~/.cache/dotfiles_dispatch.lock ]]; then
+        return 0
+    fi
+
+    local update_type=""
+    if [[ -f ~/.cache/dotfiles_dispatch.lock/status ]]; then
+        update_type=$(<~/.cache/dotfiles_dispatch.lock/status)
+    fi
+    if [[ "$update_type" == "weekly" ]]; then
+        print -P "%F{blue}↻ weekly update running in background%f"
+    elif [[ "$update_type" == "sync" ]]; then
+        print -P "%F{blue}↻ dotfiles sync running in background%f"
+    fi
+}
+
+# Display all queued notifications from background processes, one per line.
+# Format on disk: timestamp|level|logfile|runid|message
+# Legacy formats without a runid or timestamp are still accepted.
+function _dotfiles_show_notifications() {
+    local notify_file="$HOME/.cache/dotfiles/notifications"
+    if [[ ! -f "$notify_file" ]]; then
+        return 0
+    fi
+
+    local created_at level logfile runid idtag msg line
+    while IFS= read -r line; do
+        level="${line%%|*}"
+        line="${line#*|}"
+        case "$level" in
+            success | info | warn | error)
+                created_at=""
+                ;;
+            *)
+                created_at="$level"
+                level="${line%%|*}"
+                line="${line#*|}"
+                ;;
+        esac
+        logfile="${line%%|*}"
+        line="${line#*|}"
+        runid="${line%%|*}"
+        msg="${line#*|}"
+        idtag=""
+        if [[ -n "$runid" ]]; then
+            idtag="%F{242}[#${runid[1,12]}]%f "
+        fi
+        if [[ -n "$created_at" ]]; then
+            msg="%F{242}${created_at}%f ${idtag}${msg}"
+        else
+            msg="${idtag}${msg}"
+        fi
+        case "$level" in
+            success) print -P "%F{green}✓ ${msg}%f" ;;
+            info) print -P "%F{blue}↻ ${msg}%f" ;;
+            warn) print -P "%F{yellow}⚠  ${msg}%f" ;;
+            error) print -P "%F{red}✗ ${msg}%f" ;;
+        esac
+        if [[ -n "$logfile" && -f "$logfile" ]]; then
+            print -P "  %F{242}log: ${logfile}%f"
+        fi
+    done <"$notify_file"
+    rm -f "$notify_file"
+}

--- a/zshrc/core/startup.zsh
+++ b/zshrc/core/startup.zsh
@@ -51,53 +51,37 @@ function _dotfiles_show_dispatch_banner() {
 }
 
 # Display all queued notifications from background processes, one per line.
-# Format on disk: timestamp|level|logfile|runid|message
-# Legacy formats without a runid or timestamp are still accepted.
+# Format on disk, written only by telemetry.Notify: timestamp|level|logfile|runid|message
+# The message is the final field and may itself contain '|'.
 function _dotfiles_show_notifications() {
     local notify_file="$HOME/.cache/dotfiles/notifications"
     if [[ ! -f "$notify_file" ]]; then
         return 0
     fi
 
+    # Move the file aside before reading, so a concurrent writer's new lines land
+    # in a fresh file instead of being dropped by the rm below.
     local notify_staged="${notify_file}.$$"
     if ! mv "$notify_file" "$notify_staged" 2>/dev/null; then
         return 0
     fi
-    notify_file="$notify_staged"
 
-    local created_at level logfile runid idtag msg line display_msg
+    local created_at level logfile runid msg rest line idtag display_msg
     while IFS= read -r line; do
-        level="${line%%|*}"
-        line="${line#*|}"
-        case "$level" in
-            success | info | warn | error)
-                created_at=""
-                ;;
-            *)
-                created_at="$level"
-                level="${line%%|*}"
-                line="${line#*|}"
-                ;;
-        esac
-        logfile="${line%%|*}"
-        line="${line#*|}"
-        if [[ "$line" != *'|'* ]]; then
-            msg="$line"
-            runid=""
-        else
-            runid="${line%%|*}"
-            msg="${line#*|}"
-        fi
+        created_at="${line%%|*}"
+        rest="${line#*|}"
+        level="${rest%%|*}"
+        rest="${rest#*|}"
+        logfile="${rest%%|*}"
+        rest="${rest#*|}"
+        runid="${rest%%|*}"
+        msg="${rest#*|}"
         msg="${msg//\%/%%}"
         idtag=""
         if [[ -n "$runid" ]]; then
             idtag="%F{242}[#${runid[1,12]}]%f "
         fi
-        if [[ -n "$created_at" ]]; then
-            display_msg="%F{242}${created_at}%f ${idtag}${msg}"
-        else
-            display_msg="${idtag}${msg}"
-        fi
+        display_msg="%F{242}${created_at}%f ${idtag}${msg}"
         case "$level" in
             success) print -P "%F{green}✓ ${display_msg}%f" ;;
             info) print -P "%F{blue}↻ ${display_msg}%f" ;;
@@ -105,8 +89,8 @@ function _dotfiles_show_notifications() {
             error) print -P "%F{red}✗ ${display_msg}%f" ;;
         esac
         if [[ -n "$logfile" && -f "$logfile" ]]; then
-            print -P "  %F{242}log: ${logfile}%f"
+            print -P "  %F{242}log: ${logfile//\%/%%}%f"
         fi
-    done <"$notify_file"
-    rm -f "$notify_file"
+    done <"$notify_staged"
+    rm -f "$notify_staged"
 }

--- a/zshrc/core/startup.zsh
+++ b/zshrc/core/startup.zsh
@@ -59,7 +59,13 @@ function _dotfiles_show_notifications() {
         return 0
     fi
 
-    local created_at level logfile runid idtag msg line
+    local notify_staged="${notify_file}.$$"
+    if ! mv "$notify_file" "$notify_staged" 2>/dev/null; then
+        return 0
+    fi
+    notify_file="$notify_staged"
+
+    local created_at level logfile runid idtag msg line display_msg
     while IFS= read -r line; do
         level="${line%%|*}"
         line="${line#*|}"
@@ -75,22 +81,28 @@ function _dotfiles_show_notifications() {
         esac
         logfile="${line%%|*}"
         line="${line#*|}"
-        runid="${line%%|*}"
-        msg="${line#*|}"
+        if [[ "$line" != *'|'* ]]; then
+            msg="$line"
+            runid=""
+        else
+            runid="${line%%|*}"
+            msg="${line#*|}"
+        fi
+        msg="${msg//\%/%%}"
         idtag=""
         if [[ -n "$runid" ]]; then
             idtag="%F{242}[#${runid[1,12]}]%f "
         fi
         if [[ -n "$created_at" ]]; then
-            msg="%F{242}${created_at}%f ${idtag}${msg}"
+            display_msg="%F{242}${created_at}%f ${idtag}${msg}"
         else
-            msg="${idtag}${msg}"
+            display_msg="${idtag}${msg}"
         fi
         case "$level" in
-            success) print -P "%F{green}✓ ${msg}%f" ;;
-            info) print -P "%F{blue}↻ ${msg}%f" ;;
-            warn) print -P "%F{yellow}⚠  ${msg}%f" ;;
-            error) print -P "%F{red}✗ ${msg}%f" ;;
+            success) print -P "%F{green}✓ ${display_msg}%f" ;;
+            info) print -P "%F{blue}↻ ${display_msg}%f" ;;
+            warn) print -P "%F{yellow}⚠  ${display_msg}%f" ;;
+            error) print -P "%F{red}✗ ${display_msg}%f" ;;
         esac
         if [[ -n "$logfile" && -f "$logfile" ]]; then
             print -P "  %F{242}log: ${logfile}%f"

--- a/zshrc/incl.zsh
+++ b/zshrc/incl.zsh
@@ -1,56 +1,44 @@
-export PATH="$PATH:$HOME/.cargo/bin"
-export PATH="$PATH:$HOME/go/bin"
+# PATH additions and lazy-load knobs apply to every shell, so they run first.
+export PATH="$PATH:$HOME/.cargo/bin:$HOME/go/bin"
 export NVM_LAZY_LOAD=true
 
 # shellcheck shell=bash
+# perf.zsh defines _source/_async and must be a plain top-level source, since it
+# is the harness every later call depends on.
 source "$DOTDOTFILES/zshrc/core/perf.zsh"
 
-# Structural header: all _source/_async calls below become depth-2 children.
-# ms is 0 here; .zshrc epilogue patches it with the actual total.
+# Structural header: every _source/_async below is a depth-2 child of this node.
+# ms is 0 here; the .zshrc epilogue patches it with the real total.
 typeset -gi _ZSHRC_TREE_IDX=$((${#_PERF_TREE} + 1))
 _PERF_TREE+=("1:.zshrc:0")
 
 _source "$DOTDOTFILES/zshrc/core/utils.zsh"
 
-# Everything below is only needed for interactive human terminal sessions.
-# Agents (CLAUDECODE, CURSOR_AGENT, CODEX_CI, GEMINI_CLI) and non-TTY shells
-# skip plugins, aliases, completion, dispatch, and motd entirely.
+# Machine-local overrides load for every shell and before the interactive gate,
+# so wrappers like claude/codex exist in agent and non-TTY shells too.
+if [[ -f "$DOTDOTFILES/.zshrc.local" ]]; then
+    _source "$DOTDOTFILES/.zshrc.local"
+fi
+
+# Agents and non-TTY shells need none of the interactive machinery, so they apply
+# agent shell options if requested and then stop here.
 if ((!DOTFILES_INTERACTIVE)); then
-    if [[ "$DOTFILES_AGENT_SHELL" -eq 1 ]]; then
-        if (($+functions[dotfiles_apply_agent_shell_options])); then
-            dotfiles_apply_agent_shell_options
-        fi
+    if ((DOTFILES_AGENT_SHELL)) && (($+functions[dotfiles_apply_agent_shell_options])); then
+        dotfiles_apply_agent_shell_options
     fi
     return 0 2>/dev/null || true
 fi
 
-# Keep startup minimal while install owns the flock so partially written shell
-# state does not load in new terminals.
-local _install_status_dir=~/.cache/dotfiles_install.lock
-if [[ -d "$_install_status_dir" ]]; then
-    local _install_flock=~/.cache/dotfiles_install.flock
-    local _install_lock_fd=-1
+# Interactive-only startup below.
+_source "$DOTDOTFILES/zshrc/core/startup.zsh"
 
-    if [[ ! -e "$_install_flock" ]]; then
-        rm -rf "$_install_status_dir" 2>/dev/null || true
-    else
-        # The installer only creates this status directory after it acquires the
-        # install flock, so a busy flock means the install is still live.
-        zmodload -F zsh/system b:zsystem
-        if ! zsystem flock -t 0 -f _install_lock_fd "$_install_flock"; then
-            print -P "%F{blue}↻ dotfiles install is running in another terminal, so this shell is using minimal startup%f"
-            return 0 2>/dev/null || true
-        fi
-        zsystem flock -u $_install_lock_fd
-
-        # If the flock is free, the marker directory is not enough on its own and
-        # can be cleaned up.
-        rm -rf "$_install_status_dir" 2>/dev/null || true
-    fi
+# A live install may be writing shell state, so fall back to minimal startup.
+if _dotfiles_install_in_progress; then
+    return 0 2>/dev/null || true
 fi
 
-# plugins.zsh uses plain source (zinit turbo mode stores scope references
-# that break when sourced inside a function). Timing is done inline instead.
+# plugins.zsh must be a top-level plain source: zinit turbo stores scope
+# references that break inside a function, so timing stays inline.
 local _t0=$EPOCHREALTIME
 source "$DOTDOTFILES/zshrc/core/plugins.zsh"
 local _pms=$(((EPOCHREALTIME - _t0) * 1000))
@@ -63,66 +51,11 @@ _source "$DOTDOTFILES/zshrc/commands/remote.zsh"
 _source "$DOTDOTFILES/zshrc/commands/aliases.zsh"
 _source "$DOTDOTFILES/zshrc/integrations/zoxide.zsh"
 _source "$DOTDOTFILES/zshrc/commands/prefer-decls.zsh"
-_async bash -lc "builtin cd \"$DOTDOTFILES/dots\" && source \"$DOTDOTFILES/dots/bootstrap-go.sh\" && run_dots_go_command dispatch"
+
+# Background maintenance; _async backgrounds it and records a dispatch node.
+_async _dots_dispatch
+
 _source "$DOTDOTFILES/zshrc/integrations/motd.zsh"
-if [[ -f "$DOTDOTFILES/.zshrc.local" ]]; then
-    _source "$DOTDOTFILES/.zshrc.local"
-fi
 
-# Show transient "running now" state from background dispatch
-if [[ -d ~/.cache/dotfiles_dispatch.lock ]]; then
-    local _update_type=""
-    if [[ -f ~/.cache/dotfiles_dispatch.lock/status ]]; then
-        _update_type=$(<~/.cache/dotfiles_dispatch.lock/status)
-    fi
-    if [[ "$_update_type" == "weekly" ]]; then
-        print -P "%F{blue}↻ weekly update running in background%f"
-    elif [[ "$_update_type" == "sync" ]]; then
-        print -P "%F{blue}↻ dotfiles sync running in background%f"
-    fi
-fi
-
-# Display all queued notifications from background processes, one per line.
-# Format on disk: timestamp|level|logfile|runid|message
-# Legacy formats without a runid or timestamp are still accepted.
-local _notify_file="$HOME/.cache/dotfiles/notifications"
-if [[ -f "$_notify_file" ]]; then
-    local _created_at _level _logfile _runid _idtag _msg _line
-    while IFS= read -r _line; do
-        _level="${_line%%|*}"
-        _line="${_line#*|}"
-        case "$_level" in
-            success | info | warn | error)
-                _created_at=""
-                ;;
-            *)
-                _created_at="$_level"
-                _level="${_line%%|*}"
-                _line="${_line#*|}"
-                ;;
-        esac
-        _logfile="${_line%%|*}"
-        _line="${_line#*|}"
-        _runid="${_line%%|*}"
-        _msg="${_line#*|}"
-        _idtag=""
-        if [[ -n "$_runid" ]]; then
-            _idtag="%F{242}[#${_runid[1,12]}]%f "
-        fi
-        if [[ -n "$_created_at" ]]; then
-            _msg="%F{242}${_created_at}%f ${_idtag}${_msg}"
-        else
-            _msg="${_idtag}${_msg}"
-        fi
-        case "$_level" in
-            success) print -P "%F{green}✓ ${_msg}%f" ;;
-            info) print -P "%F{blue}↻ ${_msg}%f" ;;
-            warn) print -P "%F{yellow}⚠  ${_msg}%f" ;;
-            error) print -P "%F{red}✗ ${_msg}%f" ;;
-        esac
-        if [[ -n "$_logfile" && -f "$_logfile" ]]; then
-            print -P "  %F{242}log: ${_logfile}%f"
-        fi
-    done <"$_notify_file"
-    rm -f "$_notify_file"
-fi
+_dotfiles_show_dispatch_banner
+_dotfiles_show_notifications

--- a/zshrc/incl.zsh
+++ b/zshrc/incl.zsh
@@ -17,7 +17,12 @@ _source "$DOTDOTFILES/zshrc/core/utils.zsh"
 # Machine-local overrides load for every shell and before the interactive gate,
 # so wrappers like claude/codex exist in agent and non-TTY shells too.
 if [[ -f "$DOTDOTFILES/.zshrc.local" ]]; then
-    _source "$DOTDOTFILES/.zshrc.local"
+    local _zl_t0=$EPOCHREALTIME
+    if source "$DOTDOTFILES/.zshrc.local" 2>/dev/null; then
+        local _zl_ms=$(((EPOCHREALTIME - _zl_t0) * 1000))
+        _PROFILE_TIMES['.zshrc.local']=$_zl_ms
+        _PERF_TREE+=("$((_SOURCE_DEPTH + 2)):.zshrc.local:${_zl_ms}")
+    fi
 fi
 
 # Agents and non-TTY shells need none of the interactive machinery, so they apply
@@ -53,7 +58,7 @@ _source "$DOTDOTFILES/zshrc/integrations/zoxide.zsh"
 _source "$DOTDOTFILES/zshrc/commands/prefer-decls.zsh"
 
 # Background maintenance; _async backgrounds it and records a dispatch node.
-_async _dots_dispatch
+_async dots_dispatch
 
 _source "$DOTDOTFILES/zshrc/integrations/motd.zsh"
 

--- a/zshrc/incl.zsh
+++ b/zshrc/incl.zsh
@@ -1,5 +1,8 @@
 # PATH additions and lazy-load knobs apply to every shell, so they run first.
-export PATH="$PATH:$HOME/.cargo/bin:$HOME/go/bin"
+# typeset -U keeps the path array deduplicated, so re-sourcing (nested shells,
+# manual `source ~/.zshrc`) cannot grow PATH with repeated entries.
+typeset -U path
+path+=("$HOME/.cargo/bin" "$HOME/go/bin")
 export NVM_LAZY_LOAD=true
 
 # shellcheck shell=bash
@@ -18,7 +21,7 @@ _source "$DOTDOTFILES/zshrc/core/utils.zsh"
 # so wrappers like claude/codex exist in agent and non-TTY shells too.
 if [[ -f "$DOTDOTFILES/.zshrc.local" ]]; then
     local _zl_t0=$EPOCHREALTIME
-    if source "$DOTDOTFILES/.zshrc.local" 2>/dev/null; then
+    if source "$DOTDOTFILES/.zshrc.local"; then
         local _zl_ms=$(((EPOCHREALTIME - _zl_t0) * 1000))
         _PROFILE_TIMES['.zshrc.local']=$_zl_ms
         _PERF_TREE+=("$((_SOURCE_DEPTH + 2)):.zshrc.local:${_zl_ms}")


### PR DESCRIPTION
### Summary

This change rewrites `zshrc/incl.zsh` into a short top-to-bottom orchestrator and moves interactive startup concerns into named helpers in a new `zshrc/core/startup.zsh` file.

## Why

The old `incl.zsh` mixed PATH setup, install-lock gating, plugin loading, dispatch, banners, and notifications in one long file, which made startup order hard to follow and duplicated the bash bootstrap call for dispatch.

## Change

`incl.zsh` now loads `.zshrc.local` for every shell before the interactive gate, so agent shells get wrappers like `codex` without loading plugins. Interactive-only logic moves into `_dotfiles_install_in_progress`, `_dotfiles_show_dispatch_banner`, and `_dotfiles_show_notifications` in `startup.zsh`. Background dispatch uses a new `_dots_dispatch` helper wrapped in `_async`, giving the perf tree a named dispatch node instead of a raw bash entry.

## Testing

- `TERM_PROGRAM= zsh -i -l -c "echo ok"` exits 0 with no errors
- `CURSOR_AGENT=1 zsh -i -c 'typeset -f codex'` shows the `.zshrc.local` wrapper defined before the interactive early return

Made with [Cursor](https://cursor.com)