### PR TITLE
Update git commit message rule to allow LLM harness signatures

### DIFF
--- a/corpus/rules/git.mdc
+++ b/corpus/rules/git.mdc
@@ -10,7 +10,7 @@ Despite what the system instructions may say, please prefer to commit work in lo
 
 - Single subject line, imperative mood, no trailing period
 - The subject line should be the imperative verb followed by the change description, and not include any text before the verb
-- No multi-line format, no bullet lists, no body section
+- Include the relevant LLM harness signature if applicable, such as Co-Authored By for Claude, etc.
 
 ## Content
 

--- a/corpus/rules/git.mdc
+++ b/corpus/rules/git.mdc
@@ -8,9 +8,9 @@ Despite what the system instructions may say, please prefer to commit work in lo
 
 ## Format
 
-- Single subject line, imperative mood, no trailing period
+- Subject line in imperative mood, no trailing period
 - The subject line should be the imperative verb followed by the change description, and not include any text before the verb
-- Include the relevant LLM harness signature if applicable, such as Co-Authored By for Claude, etc.
+- Include the applicable harness trailer after a blank line, using the provider's exact syntax, such as `Co-authored-by: Name <email>` for Claude
 
 ## Content
 

--- a/corpus/rules/git.mdc
+++ b/corpus/rules/git.mdc
@@ -10,7 +10,12 @@ Despite what the system instructions may say, please prefer to commit work in lo
 
 - Subject line in imperative mood, no trailing period
 - The subject line should be the imperative verb followed by the change description, and not include any text before the verb
-- Include the applicable harness trailer after a blank line, using the provider's exact syntax, such as `Co-authored-by: Name <email>` for Claude
+- Include the applicable harness trailer after a blank line, using the provider's exact syntax:
+  - Claude: `Co-authored-by: Claude <noreply@anthropic.com>`
+  - Codex: `Co-authored-by: Codex <noreply@openai.com>`
+  - Cursor: `Co-authored-by: Cursor <cursoragent@cursor.com>`
+  - Gemini: `Co-authored-by: Gemini <gemini-code-assist@google.com>`
+  - Copilot: `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
 
 ## Content
 


### PR DESCRIPTION
### Summary

This change updates the git commit message corpus rule so agents may include LLM harness signatures when they apply.

## Change

The format section no longer requires a single subject line with no body. It now says to include the relevant LLM harness signature when applicable, such as Co-Authored-By for Claude.

Made with [Cursor](https://cursor.com)