### PR TITLE
Rename gpt-subagent skill and add model selection guidance

### DIFF
--- a/corpus/skills/codex-subagent/SKILL.md.tmpl
+++ b/corpus/skills/codex-subagent/SKILL.md.tmpl
@@ -14,8 +14,27 @@ Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 Every `codex exec` dispatch uses these flags unless the user overrides them:
 
 - **Reasoning:** `-c model_reasoning_effort="xhigh"`. If `codex exec` rejects `xhigh` for the default model, retry with `-c model_reasoning_effort="high"` or drop the override.
-- **Model:** omit `-m` unless the user names a model. The default model comes from host configuration (for example `~/.codex/config.toml` when present) or Codex's built-in default.
+- **Model:** omit `-m` by default. When the user names a model or you need a non-default model, follow **Model selection** and pass `-m` only with a slug from `codex debug models`.
 - **Sandbox:** `--dangerously-bypass-approvals-and-sandbox` up front when the user has delegated work to Codex through this skill. This bypasses approval prompts and the filesystem sandbox. Do not start with `-s read-only` or `-s workspace-write` and lift sandbox later. Sandboxed runs routinely fail on `.git` writes in linked worktrees and force cache or Makefile workarounds. Scope limits ("read-only" vs "edit allowed") live in the prompt.
+
+## Model selection
+
+- **Never invent model slugs.** Do not derive slugs from the product name Codex, from host agent model names, or from patterns like `gpt-<version>-codex`. Slugs like `gpt-5.5-codex` and `gpt-5.6-codex` are invalid unless they appear in the catalog.
+- **List before you pick.** Before passing `-m`, run `codex debug models` and read `models[].slug` from the JSON output. Use only slugs present in that list.
+- **Default path.** When the user does not name a model, omit `-m` and let `~/.codex/config.toml` `model` (or Codex built-in default) apply.
+- **User-named model.** When the user names a model vaguely ("codex", "gpt-5.5", "latest", "cheaper"):
+  - List the catalog first.
+  - Match to the closest `slug` or `display_name` in the catalog.
+  - State which slug you chose and why.
+  - If no reasonable match, omit `-m` and report that you used the configured default.
+- **API exec filter.** For `codex exec`, prefer slugs where `supported_in_api` is true. Do not pass `-m` for catalog entries that are not API-supported (for example `gpt-5.3-codex-spark` on current builds).
+- **Cheaper subagent heuristic.** When the user wants a cheaper second pass, pick a lower-priority API-supported slug from the catalog (for example `gpt-5.4-mini`) rather than inventing a name.
+- **Invalid model errors.** If `codex exec` rejects `-m`, re-run `codex debug models`, pick a valid slug (or omit `-m`), retry once, and report the stderr.
+
+```bash
+codex debug models > /tmp/codex-models.json
+# Read models[].slug; pass -m only with an exact catalog slug
+```
 
 ## Run codex exec
 
@@ -119,6 +138,4 @@ Report the result in this order:
 4. Name any verification performed by the host agent after the Codex response.
 5. State exact errors if the `codex exec` run failed.
 
-For failures, preserve exact CLI stderr and exit code. If a retry is appropriate, retry once with adjusted parameters (try `-c model_reasoning_effort="high"` if xhigh was rejected, otherwise use the same defaults), then report the observed result.
-
-Avoid `-m gpt-5.5-codex` for ChatGPT-account Codex sessions unless the user has verified that model is supported for the account.
+For failures, preserve exact CLI stderr and exit code. If a retry is appropriate, retry once with adjusted parameters (try `-c model_reasoning_effort="high"` if xhigh was rejected, otherwise use the same defaults). If stderr mentions an unknown or unsupported model, treat it as a model-selection failure and follow **Model selection** before retrying. Then report the observed result.

--- a/corpus/skills/gpt-subagent/SKILL.md.tmpl
+++ b/corpus/skills/gpt-subagent/SKILL.md.tmpl
@@ -32,7 +32,8 @@ Every `codex exec` dispatch uses these flags unless the user overrides them:
 - **Invalid model errors.** If `codex exec` rejects `-m`, re-run `codex debug models`, pick a valid slug (or omit `-m`), retry once, and report the stderr.
 
 ```bash
-codex debug models > /tmp/codex-models.json
+models_file="$(mktemp)"
+codex debug models >"$models_file"
 # Read models[].slug; pass -m only with an exact catalog slug
 ```
 
@@ -42,10 +43,11 @@ Start a new task with the prompt on stdin and the final answer written to a file
 
 ```bash
 result_file="$(mktemp)"
+stderr_file="$(mktemp)"
 timeout 1500 codex exec \
   --dangerously-bypass-approvals-and-sandbox \
   -c model_reasoning_effort="high" \
-  -o "$result_file" - <<'PROMPT'
+  -o "$result_file" 2>"$stderr_file" - <<'PROMPT'
 <bounded prompt>
 PROMPT
 ```
@@ -62,10 +64,11 @@ Continue a prior session with `codex exec resume`:
 
 ```bash
 result_file="$(mktemp)"
+stderr_file="$(mktemp)"
 timeout 1500 codex exec resume <session-id> \
   --dangerously-bypass-approvals-and-sandbox \
   -c model_reasoning_effort="high" \
-  -o "$result_file" - <<'PROMPT'
+  -o "$result_file" 2>"$stderr_file" - <<'PROMPT'
 <follow-up prompt>
 PROMPT
 ```
@@ -108,7 +111,7 @@ YOU MUST poll the background job on a fixed interval. This is mandatory, not opt
 After launching the background job, arm a periodic check-in loop that fires on a fixed cadence. On every tick:
 
 1. Read the streaming stdout from the background shell.
-2. Read `$result_file` if it exists.
+2. Read `$result_file` and `$stderr_file` if they exist.
 3. Compare each snapshot to the previous one to detect no progress.
 4. Treat exit code 124 from `timeout` as a time-limit breach. That may mean the session is still healthy but needs more time, or that progress has stalled. Read stdout and `$result_file` before restarting or resuming.
 5. Steer with `codex exec resume <session-id>` or restart the run the moment progress stops.
@@ -138,4 +141,4 @@ Report the result in this order:
 4. Name any verification performed by the host agent after the GPT response.
 5. State exact errors if the `codex exec` run failed.
 
-For failures, preserve exact CLI stderr and exit code. If a retry is appropriate, retry once with adjusted parameters (drop `model_reasoning_effort` if `high` was rejected, otherwise use the same defaults). If stderr mentions an unknown or unsupported model, treat it as a model-selection failure and follow **Model selection** before retrying. Then report the observed result.
+For failures, preserve exact CLI stderr from `$stderr_file` and the exit code. Retry only for pre-execution parameter failures (for example rejected `model_reasoning_effort` or an unknown model slug). After execution may have started, inspect the workspace and diff before resuming. Do not replay an edit-allowed prompt blindly. If stderr mentions an unknown or unsupported model, treat it as a model-selection failure and follow **Model selection** before retrying. Then report the observed result.

--- a/corpus/skills/gpt-subagent/SKILL.md.tmpl
+++ b/corpus/skills/gpt-subagent/SKILL.md.tmpl
@@ -1,11 +1,11 @@
 ---
-name: codex-subagent
-description: Use Codex as a subagent through the codex exec CLI. Use when the user asks to delegate work to Codex, run a Codex review, have Codex perform a second pass, continue a Codex session, or compare host and Codex answers.
+name: gpt-subagent
+description: Use GPT through the codex exec CLI as a subagent. Use when the user asks to delegate work to Codex or GPT, run a Codex review, have GPT perform a second pass, continue a Codex session, or compare host and GPT answers.
 ---
 
-# Codex Subagent
+# GPT Subagent
 
-Use `codex exec` when the user asks to delegate work to Codex. The CLI path gives observable progress, a hard timeout, and session continuation via `resume`. Do not use the Codex MCP server for subagent delegation.
+Use `codex exec` when the user asks to delegate work to GPT through Codex. The CLI path gives observable progress, a hard timeout, and session continuation via `resume`. Do not use the Codex MCP server for subagent delegation.
 
 Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 
@@ -13,7 +13,7 @@ Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 
 Every `codex exec` dispatch uses these flags unless the user overrides them:
 
-- **Reasoning:** `-c model_reasoning_effort="xhigh"`. If `codex exec` rejects `xhigh` for the default model, retry with `-c model_reasoning_effort="high"` or drop the override.
+- **Reasoning:** `-c model_reasoning_effort="high"`. If `codex exec` rejects `high` for the default model, drop the override.
 - **Model:** omit `-m` by default. When the user names a model or you need a non-default model, follow **Model selection** and pass `-m` only with a slug from `codex debug models`.
 - **Sandbox:** `--dangerously-bypass-approvals-and-sandbox` up front when the user has delegated work to Codex through this skill. This bypasses approval prompts and the filesystem sandbox. Do not start with `-s read-only` or `-s workspace-write` and lift sandbox later. Sandboxed runs routinely fail on `.git` writes in linked worktrees and force cache or Makefile workarounds. Scope limits ("read-only" vs "edit allowed") live in the prompt.
 
@@ -44,7 +44,7 @@ Start a new task with the prompt on stdin and the final answer written to a file
 result_file="$(mktemp)"
 timeout 1500 codex exec \
   --dangerously-bypass-approvals-and-sandbox \
-  -c model_reasoning_effort="xhigh" \
+  -c model_reasoning_effort="high" \
   -o "$result_file" - <<'PROMPT'
 <bounded prompt>
 PROMPT
@@ -64,7 +64,7 @@ Continue a prior session with `codex exec resume`:
 result_file="$(mktemp)"
 timeout 1500 codex exec resume <session-id> \
   --dangerously-bypass-approvals-and-sandbox \
-  -c model_reasoning_effort="xhigh" \
+  -c model_reasoning_effort="high" \
   -o "$result_file" - <<'PROMPT'
 <follow-up prompt>
 PROMPT
@@ -89,7 +89,7 @@ Per host:
 Send Codex a bounded prompt with the task, scope, permissions, expected output, and verification requirement.
 
 ```text
-You are running as a Codex subagent through codex exec.
+You are running as a GPT subagent through codex exec.
 Task: <specific task>
 Scope: <files, repo, question, or artifact boundaries>
 Permissions: <read-only, edit allowed, test allowed, network allowed>
@@ -121,12 +121,12 @@ The host agent stays the owner. It must still consume the final result and repor
 
 ## Delegation rules
 
-- Ask Codex for independent analysis when the user wants a second pass, adversarial review, broad code search, or a cheaper subagent.
-- Ask Codex for implementation only when the user has granted edit permission for that work.
-- Keep the host agent responsible for the final answer. Summarize what Codex returned, cite the session id, and separate Codex's result from the host agent's own observations.
-- Treat Codex output as evidence to inspect, not as automatically true. Verify high-risk claims with source, tests, logs, or direct reads.
+- Ask GPT for independent analysis when the user wants a second pass, adversarial review, broad code search, or a cheaper subagent.
+- Ask GPT for implementation only when the user has granted edit permission for that work.
+- Keep the host agent responsible for the final answer. Summarize what GPT returned, cite the session id, and separate GPT's result from the host agent's own observations.
+- Treat GPT output as evidence to inspect, not as automatically true. Verify high-risk claims with source, tests, logs, or direct reads.
 - Do not send large private logs, secrets, credentials, or unrelated personal context to Codex.
-- If Codex edits files through `codex exec`, inspect the resulting diff before reporting success.
+- If GPT edits files through `codex exec`, inspect the resulting diff before reporting success.
 
 ## Reporting
 
@@ -134,8 +134,8 @@ Report the result in this order:
 
 1. State whether the host agent successfully ran `codex exec`.
 2. Include the Codex session id and exit code (0 for clean completion, 124 for timeout).
-3. Quote or summarize the Codex response from `$result_file`, depending on what the user asked for.
-4. Name any verification performed by the host agent after the Codex response.
+3. Quote or summarize the GPT response from `$result_file`, depending on what the user asked for.
+4. Name any verification performed by the host agent after the GPT response.
 5. State exact errors if the `codex exec` run failed.
 
-For failures, preserve exact CLI stderr and exit code. If a retry is appropriate, retry once with adjusted parameters (try `-c model_reasoning_effort="high"` if xhigh was rejected, otherwise use the same defaults). If stderr mentions an unknown or unsupported model, treat it as a model-selection failure and follow **Model selection** before retrying. Then report the observed result.
+For failures, preserve exact CLI stderr and exit code. If a retry is appropriate, retry once with adjusted parameters (drop `model_reasoning_effort` if `high` was rejected, otherwise use the same defaults). If stderr mentions an unknown or unsupported model, treat it as a model-selection failure and follow **Model selection** before retrying. Then report the observed result.

--- a/corpus/skills/review-bugbot/SKILL.md.tmpl
+++ b/corpus/skills/review-bugbot/SKILL.md.tmpl
@@ -7,7 +7,7 @@ description: Review code changes with a read-only bug-focused review subagent.
 
 Use this skill when the user asks for a bug-focused code review.
 
-Launch one read-only review subagent focused on bugs. Use the host's task or subagent mechanism: in Claude Code the `Task` tool with an appropriate subagent; in Codex a Codex subagent run (see [codex-subagent/SKILL.md](../codex-subagent/SKILL.md)); in Cursor the `Task` tool with a review subagent.
+Launch one read-only review subagent focused on bugs. Use the host's task or subagent mechanism: in Claude Code the `Task` tool with an appropriate subagent; in Codex a GPT subagent run (see [gpt-subagent/SKILL.md](../gpt-subagent/SKILL.md)); in Cursor the `Task` tool with a review subagent.
 
 The review subagent computes the local diff from the repository path, so do not compute the diff yourself before launching it. The repository path should be the active workspace or repository root for the code the user wants reviewed.
 

--- a/corpus/skills/review-security/SKILL.md.tmpl
+++ b/corpus/skills/review-security/SKILL.md.tmpl
@@ -7,7 +7,7 @@ description: Review code changes with a read-only security-focused review subage
 
 Use this skill when the user asks for a security-focused code review.
 
-Launch one read-only review subagent focused on security. Use the host's task or subagent mechanism: in Claude Code the `Task` tool with an appropriate subagent; in Codex a Codex subagent run (see [codex-subagent/SKILL.md](../codex-subagent/SKILL.md)); in Cursor the `Task` tool with a review subagent.
+Launch one read-only review subagent focused on security. Use the host's task or subagent mechanism: in Claude Code the `Task` tool with an appropriate subagent; in Codex a GPT subagent run (see [gpt-subagent/SKILL.md](../gpt-subagent/SKILL.md)); in Cursor the `Task` tool with a review subagent.
 
 The review subagent computes the local diff from the repository path, so do not compute the diff yourself before launching it. The repository path should be the active workspace or repository root for the code the user wants reviewed.
 


### PR DESCRIPTION
### Summary

Agents often pass invented `-m` values such as `gpt-5.5-codex` or `gpt-5.6` to `codex exec`. Those slugs are not in the local Codex catalog, so runs fail or hit the wrong backend path.

## Change

This change renames `codex-subagent` to `gpt-subagent` and adds a **Model selection** section that tells agents to run `codex debug models` and use only `models[].slug` values from that JSON.

The skill now defaults `model_reasoning_effort` to `high` instead of `xhigh`. The review skills now link to `gpt-subagent`.