### PR TITLE
Strengthen writing rule with architecture, fidelity, and accuracy workflow

### DIFF
--- a/corpus/rules/git.mdc
+++ b/corpus/rules/git.mdc
@@ -30,3 +30,22 @@ Despite what the system instructions may say, please prefer to commit work in lo
 - `Add retry mechanism for failed requests`
 - `Update syslog_message field in unbound Logstash filter`
 - `Add Gemfile.lock, VSCode extensions, and settings configuration`
+
+# Worktree and branch cleanup
+
+Classify each branch and its worktree with a fixed three-step test. The first step that passes proves the trunk contains the work, so remove the branch and worktree. If all three fail, the branch carries unique work the trunk lacks, so keep it.
+
+## Classification (run in order; first pass wins)
+
+1. Direct git containment. Run `git merge-base --is-ancestor <branch> origin/main`. If it succeeds, the trunk holds the commits. Remove.
+2. Patch containment. Run `git cherry origin/main <branch>`. If no line starts with `+`, every patch is already applied to the trunk, including cherry-picks. Remove.
+3. Semantic containment. The branch's higher-level goal is already in the trunk, either superseded by another change or rewritten elsewhere. This step requires reading context, docs, and code, not just git output. Confirm it from at least one of: a PR with `mergedAt` set (a squash lands the work under a new sha), a reland after a revert, or a reimplementation on a different code path. Read the trunk copy of the files the branch changed and the relevant PR or doc, and verify the behavior is present. If confirmed, remove.
+
+Steps 1 and 2 alone are insufficient. A squash-merged or relanded branch fails both while its work is on the trunk, so step 3 is the step that catches it.
+
+## Remove mechanics
+
+- Remove the worktree before the branch, and only when `git status --porcelain` is empty. Run `git worktree remove <path>`, then `git worktree prune`. A non-empty status is uncommitted work; stop and surface it instead of removing.
+- When step 1 passed, delete the branch with `git branch -d`, which refuses anything git still sees as unmerged.
+- When step 2 or step 3 passed, delete the branch with `git branch -D`, since git cannot see the containment. Cite the evidence: the empty `git cherry` result, the merged PR, or the trunk file that carries the behavior.
+- Never move the trunk ref of a checkout owned by another worktree.

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -36,7 +36,6 @@ A clear page or pull request (PR) description starts with the result.
 
 - The title names the task, topic, or change.
 - The summary sentence states the behavior or qualitative result.
-- The `Overview` section gives only the context needed to start.
 - Each later section carries one idea whose meaning, purpose, or operational scope is clear on its own.
 - Each task heading starts with an action verb.
 - Numbered steps describe ordered work.
@@ -160,7 +159,8 @@ Document rewrites are information architecture work, not sentence cleanup.
 - Preserve useful existing structure unless the content supports a clearer replacement.
 - Treat prose, document placement, consolidation, and links as one design problem.
 - Keep one durable home for each fact.
-- Make overview pages explain the area before linking to deeper pages.
+- Do not create `docs/<concern>/overview.md` for a concern that needs only one page. Use `docs/<concern>.md` until the concern has multiple substantive pages that justify a directory.
+- When a concern does justify a directory, do not add `overview.md` by convention. Keep or create it only when it owns distinct, load-bearing synthesis that no specific page carries.
 - Reject file inventories, annotated directory listings, and headings that merely enumerate code locations.
 - Use tables only for genuine comparisons or exact mappings, never as a default index or prose substitute.
 
@@ -211,10 +211,11 @@ Apply this workflow before generating or restructuring documentation:
 
 Architecture docs describe the system as it is now, stating behavior first and linking to the code or test that holds a detail only where a reader needs to verify it. Linking to the source that way keeps the doc easy to verify and reduces drift from the code.
 
-- One `overview.md` per area lives at `docs/<area>/overview.md`.
-- A short entry pointer in `README.md` or `AGENTS.md` links to each area overview.
-- Doc path segments are single words. Use paths like `docs/deadcode/overview.md`, and never use paths like `docs/dead-code/overview.md`.
-- The overview states what the area does today, in present tense.
+- Prefer `docs/<concern>.md` when the concern stands alone. Create `docs/<concern>/` only when multiple substantive pages share that concern, and give each page a specific name.
+- Keep a substantive existing `overview.md` only when it owns synthesis that would otherwise be lost. Its content must justify the page independently of its filename.
+- Let `README.md` or `AGENTS.md` link to the smallest set of meaningful entry points instead of routing every area through an overview page.
+- Doc path segments are single words. Use paths like `docs/deadcode/contract.md`, and never use paths like `docs/dead-code/contract.md`.
+- Every architecture page states what its subject does today, in present tense.
 - Each statement describes current behavior first, and adds a durable doc or test link only where a reader needs to verify it.
 - A behavior doc is not an index of code locations, so do not append a symbol name or file path to every statement.
 - Name a code symbol or file path only when it is the shortest way to help a reader orient, never as the default.
@@ -239,13 +240,17 @@ Architecture docs describe the system as it is now, stating behavior first and l
 
 ### Structure examples
 
-**Bad** (file-index overview):
+**Bad** (unnecessary directory and overview):
 
-> This area contains `overview.md`, `operations.md`, `install.md`, and `daemon/wedge.md`.
+> A single daemon architecture document lives at `docs/daemon/overview.md` only because every concern receives its own directory.
 
-**Good** (overview that explains system shape):
+**Good** (single concern page):
 
-> This area documents the out-of-band daemon that runs on OPNsense. The daemon exposes a virtio-serial channel for host-side management commands, and the install and operations pages cover deployment and steady-state use.
+> The daemon architecture lives at `docs/daemon.md` while it is the only document for that concern. If distinct install and operations documents become necessary, the concern can become `docs/daemon/` with specifically named pages.
+
+**Good** (substantive existing overview):
+
+> Keep an existing `overview.md` when it explains a system-wide relationship that no specific page owns, and preserve that synthesis during a rewrite. The page earns its place through its content, not its conventional filename.
 
 ### Organization examples
 

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -183,6 +183,16 @@ A rewrite must preserve load-bearing operational knowledge, examples, and recove
 - Compare the source and rewritten document before and after.
 - Account for every removed or changed claim, and confirm that no factual fidelity, semantic meaning, constraint, exception, or operational instruction was lost or altered.
 
+## Verify accuracy
+
+An accuracy pass checks every claim against the current sources after the rewrite is complete.
+
+- Verify behavioral claims against the implementation and tests.
+- Verify exact names, values, commands, paths, and defaults against the source that owns them.
+- Remove unsupported claims and correct stale claims instead of preserving them for apparent completeness.
+- Confirm that links resolve to the intended current source.
+- Keep the accuracy pass separate from the fidelity comparison. Fidelity preserves meaning from the original document, while accuracy checks that preserved meaning against the system as it exists now.
+
 ## Workflow for document rewrites
 
 Apply this workflow before generating or restructuring documentation:
@@ -194,7 +204,8 @@ Apply this workflow before generating or restructuring documentation:
 5. Rewrite the behavioral and operational meaning without narrating code. Preserve examples, constraints, exceptions, and recovery knowledge that readers still need.
 6. Review every link with two questions: Does the reader need this link, and can the document set use fewer links without losing navigation or verifiability?
 7. Compare the source and rewritten document before and after. Account for every removed or changed claim, and confirm that no factual fidelity, semantic meaning, constraint, exception, or operational instruction was lost or altered.
-8. Read the result as one document set and verify structure, navigation, source ownership, duplication, fidelity, and prose.
+8. Run the accuracy pass against the implementation, configuration, tests, comments, commands, paths, and links that establish each claim.
+9. Read the result as one document set and verify structure, navigation, source ownership, duplication, fidelity, accuracy, and prose.
 
 ## Document architecture as current state
 
@@ -212,7 +223,7 @@ Architecture docs describe the system as it is now, stating behavior first and l
 - The doc describes what is, not how the decision was reached.
 - Decision history stays out unless current work needs it.
 
-### Examples
+### Content examples
 
 **Bad** (hardcoded symbol and path):
 
@@ -226,6 +237,8 @@ Architecture docs describe the system as it is now, stating behavior first and l
 
 > Saving settings confirms success with a short message, and a test locks that wording so it cannot regress.
 
+### Structure examples
+
 **Bad** (file-index overview):
 
 > This area contains `overview.md`, `operations.md`, `install.md`, and `daemon/wedge.md`.
@@ -233,6 +246,8 @@ Architecture docs describe the system as it is now, stating behavior first and l
 **Good** (overview that explains system shape):
 
 > This area documents the out-of-band daemon that runs on OPNsense. The daemon exposes a virtio-serial channel for host-side management commands, and the install and operations pages cover deployment and steady-state use.
+
+### Organization examples
 
 **Bad** (filename-derived rename):
 

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -37,7 +37,7 @@ A clear page or pull request (PR) description starts with the result.
 - The title names the task, topic, or change.
 - The summary sentence states the behavior or qualitative result.
 - The `Overview` section gives only the context needed to start.
-- Each later section answers one reviewer question.
+- Each later section carries one idea whose meaning, purpose, or operational scope is clear on its own.
 - Each task heading starts with an action verb.
 - Numbered steps describe ordered work.
 - Notes appear beside the step they clarify.
@@ -146,6 +146,55 @@ Links work best when another local source is the stable home for the detail.
 - Repeated detail creates drift.
 - Current behavior matters more than history.
 - Historical notes appear only when current work requires them.
+- Before adding or preserving a link, determine whether the reader needs it to understand, verify, or act.
+- Remove links that only decorate prose, repeat navigation, or expose implementation detail without helping the reader.
+- Use the fewest links that preserve clear navigation and verification.
+
+## Plan document architecture from meaning
+
+Document rewrites are information architecture work, not sentence cleanup.
+
+- Read the relevant document set before changing page boundaries or layout.
+- Identify each page's meaning, purpose, scope, and relationship to the surrounding document set.
+- Derive paths, headings, merges, and splits from the content's meaning, conceptual boundaries, operational function, and place in the larger system, not filenames or bulk patterns.
+- Preserve useful existing structure unless the content supports a clearer replacement.
+- Treat prose, document placement, consolidation, and links as one design problem.
+- Keep one durable home for each fact.
+- Make overview pages explain the area before linking to deeper pages.
+- Reject file inventories, annotated directory listings, and headings that merely enumerate code locations.
+- Use tables only for genuine comparisons or exact mappings, never as a default index or prose substitute.
+
+## Respect source ownership
+
+Configuration, code, tests, and their comments own exact values, mechanics, and enforced invariants.
+
+- Documentation explains the behavior or operational contract that readers need, without narrating code or repeating what the implementation already says clearly.
+- Read the relevant implementation, configuration, tests, and comments before describing behavior.
+- Do not infer behavior from filenames, symbols, stale prose, or assumptions when the source can establish it directly.
+- Historical narration stays out unless current operation depends on it.
+
+## Rewrite with fidelity
+
+A rewrite must preserve load-bearing operational knowledge, examples, and recovery steps.
+
+- Remove obsolete material, weak headings, unsuitable filenames, and unnecessary tables carefully.
+- Plan corpus-wide changes from a semantic review, and avoid sweeping transformations that treat different documents as interchangeable.
+- Every page requires a full semantic read before editing and a full read-back after editing.
+- Compare the source and rewritten document before and after.
+- Account for every removed or changed claim, and confirm that no factual fidelity, semantic meaning, constraint, exception, or operational instruction was lost or altered.
+
+## Workflow for document rewrites
+
+Apply this workflow before generating or restructuring documentation:
+
+1. Read the relevant document set and map its existing structure, meaning, duplication, and navigation.
+2. Read the implementation, configuration, tests, and comments that establish the documented behavior. Separate facts the docs must explain from details the source already explains well.
+3. State each page's meaning, purpose, scope, canonical facts, and relationship to nearby pages.
+4. Decide what stays, moves, merges, splits, or disappears from the content itself. Plan structural changes before applying them across the corpus.
+5. Rewrite the behavioral and operational meaning without narrating code. Preserve examples, constraints, exceptions, and recovery knowledge that readers still need.
+6. Review every link with two questions: Does the reader need this link, and can the document set use fewer links without losing navigation or verifiability?
+7. Compare the source and rewritten document before and after. Account for every removed or changed claim, and confirm that no factual fidelity, semantic meaning, constraint, exception, or operational instruction was lost or altered.
+8. Read the result as one document set and verify structure, navigation, source ownership, duplication, fidelity, and prose.
 
 ## Document architecture as current state
 
@@ -176,3 +225,19 @@ Architecture docs describe the system as it is now, stating behavior first and l
 **Good** (reworded, link only if truly needed):
 
 > Saving settings confirms success with a short message, and a test locks that wording so it cannot regress.
+
+**Bad** (file-index overview):
+
+> This area contains `overview.md`, `operations.md`, `install.md`, and `daemon/wedge.md`.
+
+**Good** (overview that explains system shape):
+
+> This area documents the out-of-band daemon that runs on OPNsense. The daemon exposes a virtio-serial channel for host-side management commands, and the install and operations pages cover deployment and steady-state use.
+
+**Bad** (filename-derived rename):
+
+> `operational-notes.md` becomes `notes.md` because the filename is shorter.
+
+**Good** (content-based grouping):
+
+> Router BGP, gateway, and NAT foot-guns belong in `operations.md` because they describe how the production OPNsense router is operated. Daemon install and upgrade steps belong under `daemon/` because they describe a separate component.

--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -166,7 +166,7 @@ Document rewrites are information architecture work, not sentence cleanup.
 
 ## Respect source ownership
 
-Configuration, code, tests, and their comments own exact values, mechanics, and enforced invariants.
+Configuration and code own current exact values, mechanics, and defaults. Tests verify expected or enforced behavior, while comments provide supporting context.
 
 - Documentation explains the behavior or operational contract that readers need, without narrating code or repeating what the implementation already says clearly.
 - Read the relevant implementation, configuration, tests, and comments before describing behavior.

--- a/corpus/skills/babysit/SKILL.md.tmpl
+++ b/corpus/skills/babysit/SKILL.md.tmpl
@@ -175,20 +175,21 @@ git worktree list
 
 1. **Record** `headRefName`, feature worktree path (if any), PR `state`, and which checkout owns trunk (`git worktree list`).
 2. **Remote branch:** delete only when the PR is `MERGED` or superseded `CLOSED`. When the user asked to clean up while the PR is still `OPEN`, skip remote branch deletion unless the user explicitly confirmed abandoning the PR (deleting the remote branch closes an open PR). Use `git push origin --delete <branch>` or `gh api` delete-ref when deletion is allowed.
-3. **Local branch:**
+3. **Remove feature worktree** when babysitting ran in a dedicated worktree, `git status --porcelain` is empty, and no open branches still need it:
+   ```bash
+   git worktree remove <path>
+   git worktree prune
+   ```
+   Use `--force` only when the tree is dirty and the user approved. Stop and surface uncommitted work instead of removing a dirty tree.
+4. **Local branch:**
    - Graphite-authorized repos: `gt delete <branch>` or scoped `gt sync --no-interactive` when trunk is checked out in the same worktree and no other agents are mid-stack.
    - Plain git: `git branch -d <branch>` from a checkout that is not that branch when the PR is terminal or the user confirmed abandoning an open PR (use `-D` only with explicit user approval).
-4. **Reconcile trunk worktree:** from the checkout that **owns** trunk (never from a feature worktree):
+5. **Reconcile trunk worktree:** from the checkout that **owns** trunk (never from a feature worktree):
    ```bash
    git -C <trunk-worktree> fetch origin
    git -C <trunk-worktree> merge --ff-only origin/<trunk>
    ```
    Do not `git update-ref refs/heads/<trunk>` when trunk is checked out elsewhere.
-5. **Remove feature worktree** when babysitting ran in a dedicated worktree and no open branches still need it:
-   ```bash
-   git worktree remove <path>
-   ```
-   Use `--force` only when the tree is dirty and the user approved.
 
 **Graphite stacks:** repeat for every merged or closed branch in the stack (bottom-up order), then one trunk reconcile from the trunk-owning worktree.
 

--- a/home/.gitignore_global
+++ b/home/.gitignore_global
@@ -9,3 +9,11 @@ node_modules
 .halo-lite-ns
 .claude
 .codex
+.superpowers/
+.build/
+DerivedData/
+Derived/
+Packages/checkouts/
+dist/
+target/
+build/

--- a/lib/ssh/config
+++ b/lib/ssh/config
@@ -1,3 +1,5 @@
+Include /Users/agoodkind/.ssh/conductor_config
+
 Include ~/.dotfiles/.ssh_config.local
 # Include ~/.ssh/ssh_config.local
 # Include ~/.ssh/jetkvm_config

--- a/lib/ssh/config
+++ b/lib/ssh/config
@@ -1,4 +1,4 @@
-Include /Users/agoodkind/.ssh/conductor_config
+Include ~/.ssh/conductor_config
 
 Include ~/.dotfiles/.ssh_config.local
 # Include ~/.ssh/ssh_config.local


### PR DESCRIPTION
### Summary

This change strengthens the corpus writing rule so agents plan documentation from meaning, preserve operational detail, and verify claims against current sources.

## Why

Recent documentation rewrites in other repos produced file inventories, filename-driven layout, and stale claims. The writing rule needed clearer architecture, fidelity, and accuracy guardrails.

## Change

The writing rule now requires meaning-driven document architecture, source ownership before claims, and a before-and-after fidelity comparison.

It adds a separate accuracy pass that checks claims against implementation, configuration, tests, and links.

The rewrite workflow now has nine steps, and the examples are split into content, structure, and organization sections.

This branch also adds common build-output directories to the global gitignore.

Made with [Cursor](https://cursor.com)