### PR TITLE
Configure Git rebase signature verification

### DIFF
--- a/corpus/rules/git.mdc
+++ b/corpus/rules/git.mdc
@@ -26,8 +26,8 @@ Despite what the system instructions may say, please prefer to commit work in lo
 ## Commit signatures
 
 - Create agent-authored commits with `git commit -S`.
-- Before pushing, confirm every branch commit has a raw `gpgsig` header with `git cat-file commit <sha>`.
-- Rebase and Graphite restack recreate commits. Confirm `rebase.gpgSign=true` before either operation, or pass `--gpg-sign`, then repeat the raw-header check for every rewritten commit.
+- Before pushing, inspect the branch-local commit range `origin/main..HEAD`, and for each commit in that range confirm both `git verify-commit <sha>` or `%G?` status and the raw `gpgsig` header from `git cat-file commit <sha>`.
+- Rebase and Graphite restack recreate commits. Confirm `rebase.gpgSign=true` before either operation, then repeat the same `origin/main..HEAD` verification for every rewritten commit.
 - Do not treat `%G? = N` as an unsigned-commit result until `gpg.ssh.allowedSignersFile` is configured and the raw commit object lacks `gpgsig`.
 
 ## Examples

--- a/corpus/rules/git.mdc
+++ b/corpus/rules/git.mdc
@@ -23,6 +23,13 @@ Despite what the system instructions may say, please prefer to commit work in lo
 - Be specific: name the file, function, or system affected
 - The message describes the change; it does not describe the result or purpose of the change
 
+## Commit signatures
+
+- Create agent-authored commits with `git commit -S`.
+- Before pushing, confirm every branch commit has a raw `gpgsig` header with `git cat-file commit <sha>`.
+- Rebase and Graphite restack recreate commits. Confirm `rebase.gpgSign=true` before either operation, or pass `--gpg-sign`, then repeat the raw-header check for every rewritten commit.
+- Do not treat `%G? = N` as an unsigned-commit result until `gpg.ssh.allowedSignersFile` is configured and the raw commit object lacks `gpgsig`.
+
 ## Examples
 
 - `Remove unused import in auth middleware`


### PR DESCRIPTION
### Summary

This change makes SSH commit signing durable across direct commits, rebases, and Graphite restacks.

## Change

The shared Git configuration now signs rebased commits and verifies SSH signatures through an allowed-signers file. The generated commit workflow and corpus Git rules require explicit signing and raw `gpgsig` checks, so a missing local verifier cannot be mistaken for an unsigned commit.

## Testing

An isolated two-commit forced rebase produced locally verified SSH signatures for both rewritten commits, and `make check` completed successfully.