### PR TITLE
Wait out a discovered or building semantic index before asking to reindex

### DIFF
--- a/corpus/rules/semantic.mdc
+++ b/corpus/rules/semantic.mdc
@@ -7,7 +7,7 @@ always: true
 
 Prefer the semantic MCP server's `search_code` for conceptual repo-wide discovery, but do not use it blindly.
 
-Call `get_indexing_status` on the absolute repository root before relying on semantic results. If the status is "not indexed", stop immediately, ask the user whether to index the codebase, and wait for an explicit yes before calling `index_codebase`. Do not index without permission. If indexing is still running, treat search results as provisional.
+Call `get_indexing_status` on the absolute repository root before relying on semantic results. A newly seen or detached worktree first reports as discovered or building (for example `discovered, not yet indexed`, `Building initial index`, or `Indexing new changes`): the daemon builds it automatically and it is usually ready within a few seconds, and a discovered worktree reuses a sibling worktree's embeddings. Wait a moment and re-check `get_indexing_status` a couple of times a few seconds apart rather than stopping or calling `index_codebase`. Only when the status stays truly not indexed with no build underway should you stop, ask the user whether to index, and wait for an explicit yes before calling `index_codebase`; do not index without permission. Treat results as provisional until the status reads ready to search.
 
 Use `splitter: "ast"` by default when indexing. Do not use `splitter: "langchain"` unless a user-approved diagnostic is given.
 

--- a/dots/go.mod
+++ b/dots/go.mod
@@ -1,6 +1,6 @@
 module goodkind.io/.dotfiles
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
## What

Update the semantic-search rule so an agent waits out a discovered or building index instead of halting to ask for approval.

## Why

The rule told agents that if `get_indexing_status` is "not indexed" they must stop and ask before indexing. That also caught a freshly seen or detached worktree, which reports as `discovered, not yet indexed`. In that state the daemon builds the index automatically within a few seconds, and a discovered worktree reuses a sibling worktree's embeddings (the daemon's own status even says "builds shortly"). Agents were stopping mid-task on exactly this: "discovered but not indexed ... Repository policy requires your approval before I start indexing."

## Change

`corpus/rules/semantic.mdc`: on the transient building states (`discovered`, `Building initial index`, `Indexing new changes`), wait a moment and re-check `get_indexing_status` a couple of times rather than stopping or calling `index_codebase`. The ask-before-`index_codebase` rule stays for a path that is genuinely not indexed with no build underway.

This renders into `~/.claude/rules/semantic.md`, the `CLAUDE.md` semantic section, and the Codex/Cursor equivalents on the next `sync`.
