### PR TITLE
Add path-safe agent worktree placement under ~/.worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,16 @@ All other git read operations (`git status`, `git diff`, `git log`, etc.) work
 normally when run from inside `~/.dotfiles`; only push (and any operation that
 writes to the remote) requires `config`.
 
+### Agent worktree placement
+
+When creating a git worktree for isolated work, prefer a path-based directory
+under `~/.worktrees`. Encode the repository root absolute path in a
+path-safe form: replace every non-alphanumeric character with `-`, collapse
+runs of `-`, then place the result under `~/.worktrees/` (for example
+`/Users/agoodkind/.dotfiles` becomes
+`~/.worktrees/-Users-agoodkind-dotfiles`). Add a branch subdirectory when
+multiple worktrees from the same repository are needed.
+
 ## Smoke Testing zsh Startup
 
 To accurately test that zsh loads without errors on a remote host, allocate a real PTY,

--- a/corpus/rules/git.mdc
+++ b/corpus/rules/git.mdc
@@ -38,6 +38,35 @@ Despite what the system instructions may say, please prefer to commit work in lo
 - `Update syslog_message field in unbound Logstash filter`
 - `Add Gemfile.lock, VSCode extensions, and settings configuration`
 
+# Agent worktree placement
+
+When an agent creates a git worktree for isolated feature work, prefer a path-based directory under `~/.worktrees` instead of a project-local `.worktrees/` directory or ad hoc paths.
+
+Derive the base directory from the repository root absolute path:
+
+1. Resolve the repository root to an absolute path.
+2. Replace every character that is not ASCII alphanumeric (`A` through `Z`, `a` through `z`, `0` through `9`) with `-`.
+3. Collapse consecutive `-` into a single `-`.
+4. Place the result under `~/.worktrees/`.
+
+Examples:
+
+- `/Users/agoodkind/.dotfiles` → `~/.worktrees/-Users-agoodkind-dotfiles`
+- `/Users/agoodkind/src/myapp` → `~/.worktrees/-Users-agoodkind-src-myapp`
+- `/Users/agoodkind/my project/foo` → `~/.worktrees/-Users-agoodkind-my-project-foo`
+
+Portable shell encoding:
+
+```bash
+repo_root=$(cd "$repo_root" && pwd -P)
+encoded=$(printf '%s' "$repo_root" | sed 's/[^A-Za-z0-9]/-/g; s/-\+/-/g')
+worktree_base="$HOME/.worktrees/$encoded"
+```
+
+Create `~/.worktrees` when it does not exist. When multiple branches from the same repository need separate worktrees, add a branch subdirectory under the path-encoded base (for example `~/.worktrees/-Users-agoodkind-dotfiles/my-feature-branch`). Apply the same encoding to branch names when they contain non-alphanumeric characters.
+
+Honor an explicit user override over this default. Skip creation when the session is already in a linked worktree.
+
 # Worktree and branch cleanup
 
 Classify each branch and its worktree with a fixed three-step test. The first step that passes proves the trunk contains the work, so remove the branch and worktree. If all three fail, the branch carries unique work the trunk lacks, so keep it.


### PR DESCRIPTION
### Summary

This change adds agent instructions to create isolated git worktrees under `~/.worktrees` using a path-safe encoding of the repository root.

## Change

`corpus/rules/git.mdc` now tells agents to prefer `~/.worktrees` over project-local `.worktrees/` or ad hoc paths. The rule encodes the repository root absolute path by replacing non-alphanumeric characters with `-`, collapsing runs of `-`, and placing the result under `~/.worktrees/`. It includes examples, a portable shell snippet, and guidance for branch subdirectories when multiple worktrees share one repository.

`AGENTS.md` carries a shorter matching section under Git Operations so agents working directly in this repository see the same convention.

Made with [Cursor](https://cursor.com)