### PR TITLE
Add always-on corpus testing rule for end-to-end coverage

### DIFF
--- a/corpus/rules/testing.mdc
+++ b/corpus/rules/testing.mdc
@@ -1,0 +1,153 @@
+---
+description: Test design rules that favor end-to-end coverage and forbid mock soup and inconsequential tests
+applies_to:
+  - "**/*"
+always: true
+---
+
+# Testing
+
+Tests in every language must exercise real behavior end to end as far as practical. A test should enter through a public boundary, run the code path under review, and assert an observable outcome a user, caller, or downstream system would notice.
+
+Prefer the narrowest real dependency that still proves the behavior. Use in-memory databases, temporary directories, recorded HTTP fixtures, local test servers, and other fakes that preserve the contract. Reach for mocks only at slow, nondeterministic, or unavailable externals, and keep the mocked surface small.
+
+## Forbidden patterns
+
+Do not write mock soup: stacks of mocks, stubs, and spies that only prove collaborators were called in order while the production path stays untested.
+
+Do not write inconsequential tests. These include static file content checks, snapshot tests that only restate the fixture, tests that duplicate compiler or linter guarantees, and tests that lock in behavior that was already removed.
+
+Delete tests for deleted behavior instead of leaving them as documentation.
+
+When a test would not fail if the feature broke, delete it or rewrite it.
+
+## Generic
+
+**Bad:** assert that `README.md` contains the string `Installation`.
+
+**Bad:** call a private helper with five mocked interfaces and assert each mock received one call.
+
+**Good:** invoke the public CLI, HTTP handler, or exported function with realistic input and assert status code, stdout, persisted state, or returned data.
+
+**Good:** run the job or workflow against a temporary workspace and assert the artifact the operator would inspect.
+
+## Go
+
+**Bad:** mock `Store`, `Clock`, `Logger`, `Metrics`, and `Notifier` in one test, then assert `store.Save` was called once.
+
+```go
+func TestHandleOrder_MocksOnly(t *testing.T) {
+    store := &mockStore{}
+    clock := &mockClock{now: time.Unix(1, 0)}
+    logger := &mockLogger{}
+    metrics := &mockMetrics{}
+    notifier := &mockNotifier{}
+
+    handleOrder(store, clock, logger, metrics, notifier, order{ID: "1"})
+
+    if store.saveCount != 1 {
+        t.Fatalf("save count = %d, want 1", store.saveCount)
+    }
+}
+```
+
+**Bad:** read a committed golden file and assert the generator still emits the same bytes without running generation.
+
+**Good:** start `httptest.NewServer` with the real handler, `POST` a realistic body, and assert the HTTP status and JSON fields.
+
+```go
+func TestCreateUser_Returns201(t *testing.T) {
+    server := httptest.NewServer(newApp(testDB(t)))
+    t.Cleanup(server.Close)
+
+    response, err := http.Post(
+        server.URL+"/users",
+        "application/json",
+        strings.NewReader(`{"email":"a@example.com"}`),
+    )
+    if err != nil {
+        t.Fatalf("Post: %v", err)
+    }
+    t.Cleanup(func() { _ = response.Body.Close() })
+
+    if response.StatusCode != http.StatusCreated {
+        t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusCreated)
+    }
+}
+```
+
+**Good:** run the command with `os/exec` against a temp directory and assert the file on disk.
+
+```go
+func TestExportCommand_WritesCSV(t *testing.T) {
+    dir := t.TempDir()
+    out := filepath.Join(dir, "out.csv")
+
+    cmd := exec.Command("go", "run", "./cmd/export", "--out", out)
+    if output, err := cmd.CombinedOutput(); err != nil {
+        t.Fatalf("export: %v\n%s", err, output)
+    }
+
+    body, err := os.ReadFile(out)
+    if err != nil {
+        t.Fatalf("ReadFile: %v", err)
+    }
+    if !bytes.Contains(body, []byte("email")) {
+        t.Fatalf("csv missing header: %q", body)
+    }
+}
+```
+
+## Swift
+
+**Bad:** inject five protocol mocks into a view model test and assert each `didCall` flag flipped.
+
+```swift
+func testSubmit_onlyCallsDependencies() {
+    let store = MockStore()
+    let analytics = MockAnalytics()
+    let clock = MockClock()
+    let viewModel = CheckoutViewModel(store: store, analytics: analytics, clock: clock)
+
+    viewModel.submit(cart: .fixture)
+
+    XCTAssertEqual(store.saveCallCount, 1)
+    XCTAssertTrue(analytics.didTrackSubmit)
+}
+```
+
+**Bad:** assert `Info.plist` contains `CFBundleDisplayName`.
+
+**Bad:** keep a test named `testLegacyCheckoutFlow` after the legacy flow was deleted.
+
+**Good:** drive the real view model with an in-memory store or `ModelContainer` test double and assert persisted state.
+
+```swift
+@MainActor
+func testSubmit_persistsOrder() async throws {
+  let container = try ModelContainer(
+    for: Order.self,
+    configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+  )
+  let viewModel = CheckoutViewModel(modelContext: container.mainContext)
+
+  try await viewModel.submit(cart: Cart.fixture)
+
+  let orders = try container.mainContext.fetch(FetchDescriptor<Order>())
+  XCTAssertEqual(orders.count, 1)
+  XCTAssertEqual(orders.first?.status, .placed)
+}
+```
+
+**Good:** use a UI test or hosted view test that taps the primary control and asserts visible copy or navigation.
+
+```swift
+func testCheckoutButtonShowsConfirmation() throws {
+  let app = XCUIApplication()
+  app.launch()
+
+  app.buttons["Place order"].tap()
+
+  XCTAssertTrue(app.staticTexts["Order placed"].waitForExistence(timeout: 2))
+}
+```


### PR DESCRIPTION
### Summary

This change adds an always-on agent corpus rule that requires tests to exercise real behavior end to end and forbids mock soup and inconsequential tests.

## Change

`corpus/rules/testing.mdc` sets `always: true` and applies to all files. The rule tells agents to enter through public boundaries, prefer contract-preserving fakes over deep mocks, and delete tests that would not fail when the feature breaks.

It lists forbidden patterns such as static file content checks, fixture-only snapshots, and tests for removed behavior. It includes good and bad examples for generic tests, Go, and Swift.

Made with [Cursor](https://cursor.com)