### PR TITLE
Normalize corpus source loading and rendering (PR 2/3)

### DIFF
--- a/dots/cmd/dots/main.go
+++ b/dots/cmd/dots/main.go
@@ -16,6 +16,7 @@ import (
 	"goodkind.io/.dotfiles/internal/runner"
 	syncer "goodkind.io/.dotfiles/internal/sync"
 	"goodkind.io/.dotfiles/internal/sync/compilation"
+	"goodkind.io/.dotfiles/internal/sync/corpus"
 	"goodkind.io/.dotfiles/internal/telemetry"
 	uninstaller "goodkind.io/.dotfiles/internal/uninstall"
 )
@@ -193,9 +194,13 @@ func runCursorSync(args []string) int {
 	if dotfiles == "" {
 		dotfiles = filepath.Join(os.Getenv("HOME"), ".dotfiles")
 	}
-	source := compilation.ResolveCorpusSource(dotfiles)
+	sourceSet, err := corpus.LoadSourceSet(dotfiles)
+	if err != nil {
+		logError("loading corpus for cursor upload", err)
+		return 1
+	}
 	style := compilation.RuleRenderStyle{SkillsRelDir: "../skills"}
-	rules, err := compilation.RenderRulesForUpload(source.Rules, style)
+	rules, err := compilation.RenderRulesForUploadFromSourceSet(sourceSet, style)
 	if err != nil {
 		logError("rendering corpus rules for cursor upload", err)
 		return 1

--- a/dots/internal/sync/compilation/agents.go
+++ b/dots/internal/sync/compilation/agents.go
@@ -1,0 +1,192 @@
+package compilation
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+	"gopkg.in/yaml.v3"
+)
+
+type AgentTargetFormat string
+
+const (
+	AgentTargetClaude  AgentTargetFormat = "claude"
+	AgentTargetCursor  AgentTargetFormat = "cursor"
+	AgentTargetGemini  AgentTargetFormat = "gemini"
+	AgentTargetCodex   AgentTargetFormat = "codex"
+	AgentTargetCopilot AgentTargetFormat = "copilot"
+)
+
+type markdownAgentFrontmatter struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	ReadOnly    bool     `yaml:"readonly,omitempty"`
+	Tools       []string `yaml:"tools,omitempty"`
+}
+
+type codexAgentFile struct {
+	Name                  string `toml:"name"`
+	Description           string `toml:"description"`
+	SandboxMode           string `toml:"sandbox_mode,omitempty"`
+	DeveloperInstructions string `toml:"developer_instructions"`
+}
+
+// ValidateAgentFiles validates provider-specific agent rendering without writing files.
+func ValidateAgentFiles(agents map[string]AgentSource, dst string, format AgentTargetFormat) error {
+	names := make([]string, 0, len(agents))
+	for name := range agents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	extension, err := agentExtension(format)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		if err := validateAgentName(name); err != nil {
+			return err
+		}
+		if _, err := renderAgent(agents[name], format); err != nil {
+			slog.Warn("compilation: validating agent render", "name", name, "format", format, "err", err)
+			return fmt.Errorf("rendering agent %s: %w", name, err)
+		}
+		if err := validateNoNestedSymlink(dst, filepath.Join(dst, name+extension)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RenderAgentFiles(agents map[string]AgentSource, dst string, format AgentTargetFormat) error {
+	slog.Info("compilation: rendering agent files", "dest", dst, "format", string(format))
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		slog.Warn("compilation: creating agent directory", "dest", dst, "err", err)
+		return fmt.Errorf("creating directory %s: %w", dst, err)
+	}
+	names := make([]string, 0, len(agents))
+	for name := range agents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	extension, err := agentExtension(format)
+	if err != nil {
+		return err
+	}
+	activeFiles := make(map[string]struct{}, len(names))
+	renderedAgents := make(map[string]string, len(names))
+	for _, name := range names {
+		if err := validateAgentName(name); err != nil {
+			return err
+		}
+		fileName := name + extension
+		activeFiles[fileName] = struct{}{}
+		rendered, err := renderAgent(agents[name], format)
+		if err != nil {
+			return fmt.Errorf("rendering agent %s: %w", name, err)
+		}
+		renderedAgents[fileName] = rendered
+	}
+	for _, name := range names {
+		fileName := name + extension
+		targetPath := filepath.Join(dst, fileName)
+		if isSymlink(targetPath) {
+			if err := os.Remove(targetPath); err != nil {
+				return fmt.Errorf("removing symlink %s: %w", targetPath, err)
+			}
+		}
+		if err := writeFileIfChanged(targetPath, []byte(renderedAgents[fileName])); err != nil {
+			return err
+		}
+	}
+	return removeMissingManagedFiles(dst, extension, activeFiles)
+}
+
+func agentExtension(format AgentTargetFormat) (string, error) {
+	switch format {
+	case AgentTargetClaude, AgentTargetCursor, AgentTargetGemini:
+		return ".md", nil
+	case AgentTargetCodex:
+		return ".toml", nil
+	case AgentTargetCopilot:
+		return ".agent.md", nil
+	default:
+		return "", fmt.Errorf("unknown agent target format %q", format)
+	}
+}
+
+func renderAgent(agent AgentSource, format AgentTargetFormat) (string, error) {
+	switch format {
+	case AgentTargetClaude:
+		return renderMarkdownAgent(agent, false, readOnlyTools(agent.ReadOnly, []string{"Read", "Grep", "Glob", "WebFetch", "WebSearch"}))
+	case AgentTargetCursor:
+		return renderMarkdownAgent(agent, agent.ReadOnly, nil)
+	case AgentTargetGemini:
+		return renderMarkdownAgent(agent, false, readOnlyTools(agent.ReadOnly, []string{"read_file", "grep_search", "glob", "list_directory", "web_fetch", "google_web_search"}))
+	case AgentTargetCodex:
+		return renderCodexAgent(agent)
+	case AgentTargetCopilot:
+		return renderMarkdownAgent(agent, false, readOnlyTools(agent.ReadOnly, []string{"read", "search"}))
+	default:
+		return "", fmt.Errorf("unknown agent target format %q", format)
+	}
+}
+
+func readOnlyTools(readOnly bool, tools []string) []string {
+	if !readOnly {
+		return nil
+	}
+	return tools
+}
+
+func renderMarkdownAgent(agent AgentSource, readOnly bool, tools []string) (string, error) {
+	frontmatter := markdownAgentFrontmatter{
+		Name:        agent.Name,
+		Description: agent.Description,
+		ReadOnly:    readOnly,
+		Tools:       tools,
+	}
+	rawFrontmatter, err := yaml.Marshal(frontmatter)
+	if err != nil {
+		slog.Warn("compilation: marshaling agent frontmatter", "agent", agent.Name, "err", err)
+		return "", fmt.Errorf("marshaling agent front matter: %w", err)
+	}
+	content := "---\n" + string(rawFrontmatter) + "---\n\n" + strings.TrimSpace(agent.Body) + "\n"
+	return injectSkillMarker(content), nil
+}
+
+func renderCodexAgent(agent AgentSource) (string, error) {
+	sandboxMode := ""
+	if agent.ReadOnly {
+		sandboxMode = "read-only"
+	}
+	payload, err := toml.Marshal(codexAgentFile{
+		Name:                  agent.Name,
+		Description:           agent.Description,
+		SandboxMode:           sandboxMode,
+		DeveloperInstructions: strings.TrimSpace(agent.Body),
+	})
+	if err != nil {
+		slog.Warn("compilation: marshaling Codex agent", "agent", agent.Name, "err", err)
+		return "", fmt.Errorf("marshaling Codex agent: %w", err)
+	}
+	return GeneratedAgentMarker + "\n\n" + string(payload), nil
+}
+
+func validateAgentName(name string) error {
+	cleanName := filepath.Clean(filepath.FromSlash(name))
+	if cleanName == "." || cleanName == ".." || filepath.IsAbs(cleanName) {
+		return fmt.Errorf("invalid agent name %q", name)
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, string(filepath.Separator)) {
+		return fmt.Errorf("invalid agent name %q", name)
+	}
+	if strings.HasPrefix(cleanName, ".."+string(os.PathSeparator)) || cleanName != name {
+		return fmt.Errorf("invalid agent name %q", name)
+	}
+	return nil
+}

--- a/dots/internal/sync/compilation/compilation.go
+++ b/dots/internal/sync/compilation/compilation.go
@@ -8,8 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
-	"sort"
 	"strings"
 	"text/template"
 
@@ -148,51 +146,6 @@ type RenderedRule struct {
 	Body  string
 }
 
-// RenderRuleFiles writes each .mdc rule file from src into dst as a marker-stamped
-// generated file with the given extension (for example ".mdc" or ".md").
-func RenderRuleFiles(src string, dst string, ext string, format RuleTargetFormat, style RuleRenderStyle) error {
-	files, err := sortedMdcFiles(src)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		return fmt.Errorf("creating directory %s: %w", dst, err)
-	}
-	activeFiles := make(map[string]struct{}, len(files))
-	for _, file := range files {
-		base := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
-		targetName := base + ext
-		activeFiles[targetName] = struct{}{}
-
-		content, readErr := os.ReadFile(file)
-		if readErr != nil {
-			slog.Warn("compilation: RenderRuleFiles read failed", "file", file, "err", readErr)
-			return fmt.Errorf("reading file %s: %w", file, readErr)
-		}
-		rule, parseErr := ParseRuleSource(string(content))
-		if parseErr != nil {
-			return fmt.Errorf("parsing rule source %s: %w", file, parseErr)
-		}
-		renderedBody, renderErr := renderRuleTemplate(strings.TrimSpace(rule.Body), style, filepath.Base(file))
-		if renderErr != nil {
-			return fmt.Errorf("rendering rule template %s: %w", file, renderErr)
-		}
-		rule.Body = renderedBody
-		rendered, renderErr := rule.RenderForTarget(format)
-		if renderErr != nil {
-			return fmt.Errorf("rendering rule %s for format %q: %w", file, format, renderErr)
-		}
-		target := filepath.Join(dst, targetName)
-		if isSymlink(target) {
-			_ = os.Remove(target)
-		}
-		if err := writeFileIfChanged(target, []byte(injectSkillMarker(rendered))); err != nil {
-			return err
-		}
-	}
-	return removeMissingManagedFiles(dst, ext, activeFiles)
-}
-
 // ruleTemplateData exposes skill reference helpers to a rule template as the
 // "{{.Skill \"name\"}}" method for the active RuleRenderStyle.
 type ruleTemplateData struct {
@@ -237,125 +190,6 @@ func renderSkillLink(style RuleRenderStyle, name string) string {
 	return fmt.Sprintf("[%s](%s)", name, skillPath)
 }
 
-// RenderRulesAsInstructionDoc concatenates .mdc rule files from src into a single markdown document at dst.
-func RenderRulesAsInstructionDoc(src string, dst string, title string, style RuleRenderStyle) error {
-	files, err := sortedMdcFiles(src)
-	if err != nil {
-		return err
-	}
-	if len(files) == 0 {
-		return nil
-	}
-
-	var builder strings.Builder
-	builder.WriteString("# ")
-	builder.WriteString(title)
-	builder.WriteString("\n\n")
-	builder.WriteString(GeneratedAgentHTMLMarker)
-	builder.WriteString("\n\n")
-
-	for index, file := range files {
-		if index > 0 {
-			builder.WriteString("\n\n")
-		}
-		baseName := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
-		builder.WriteString("## ")
-		builder.WriteString(baseName)
-		builder.WriteString("\n\n")
-
-		content, readErr := os.ReadFile(file)
-		if readErr != nil {
-			slog.Warn("compilation: RenderRulesAsInstructionDoc read failed", "file", file, "err", readErr)
-			return fmt.Errorf("reading file %s: %w", file, readErr)
-		}
-		rule, parseErr := ParseRuleSource(string(content))
-		if parseErr != nil {
-			return fmt.Errorf("parsing rule source %s: %w", file, parseErr)
-		}
-		rendered, renderErr := renderRuleTemplate(strings.TrimSpace(rule.Body), style, filepath.Base(file))
-		if renderErr != nil {
-			return fmt.Errorf("rendering rule template %s: %w", file, renderErr)
-		}
-		builder.WriteString(rendered)
-		builder.WriteString("\n")
-	}
-
-	return writeFileIfChanged(dst, []byte(builder.String()))
-}
-
-// RenderCopilotInstructionFiles renders .mdc rule files from src as .instructions.md files in dst.
-func RenderCopilotInstructionFiles(src string, dst string, style RuleRenderStyle) error {
-	files, err := sortedMdcFiles(src)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		slog.Warn("compilation: RenderCopilotInstructionFiles mkdir failed", "dst", dst, "err", err)
-		return fmt.Errorf("creating directory %s: %w", dst, err)
-	}
-
-	activeFiles := make(map[string]struct{}, len(files))
-	for _, file := range files {
-		baseName := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
-		targetName := baseName + ".instructions.md"
-		activeFiles[targetName] = struct{}{}
-
-		content, readErr := os.ReadFile(file)
-		if readErr != nil {
-			slog.Warn("compilation: RenderCopilotInstructionFiles read failed", "file", file, "err", readErr)
-			return fmt.Errorf("reading file %s: %w", file, readErr)
-		}
-		rule, parseErr := ParseRuleSource(string(content))
-		if parseErr != nil {
-			return fmt.Errorf("parsing rule source %s: %w", file, parseErr)
-		}
-		renderedBody, renderErr := renderRuleTemplate(strings.TrimSpace(rule.Body), style, filepath.Base(file))
-		if renderErr != nil {
-			return fmt.Errorf("rendering rule template %s: %w", file, renderErr)
-		}
-		rule.Body = renderedBody
-		rendered, renderErr := rule.RenderCopilot(baseName)
-		if renderErr != nil {
-			return fmt.Errorf("rendering copilot instruction %s from %s: %w", baseName, file, renderErr)
-		}
-		if err := writeFileIfChanged(filepath.Join(dst, targetName), []byte(rendered)); err != nil {
-			return err
-		}
-	}
-
-	return removeMissingManagedFiles(dst, ".instructions.md", activeFiles)
-}
-
-// RenderRulesForUpload parses corpus rules and returns title/body pairs for direct cloud upload.
-func RenderRulesForUpload(rulesDir string, style RuleRenderStyle) ([]RenderedRule, error) {
-	files, err := sortedMdcFiles(rulesDir)
-	if err != nil {
-		return nil, err
-	}
-	renderedRules := make([]RenderedRule, 0, len(files))
-	for _, file := range files {
-		content, readErr := os.ReadFile(file)
-		if readErr != nil {
-			slog.Warn("compilation: RenderRulesForUpload read failed", "file", file, "err", readErr)
-			return nil, fmt.Errorf("reading file %s: %w", file, readErr)
-		}
-		rule, parseErr := ParseRuleSource(string(content))
-		if parseErr != nil {
-			return nil, fmt.Errorf("parsing rule source %s: %w", file, parseErr)
-		}
-		renderedBody, renderErr := renderRuleTemplate(strings.TrimSpace(rule.Body), style, filepath.Base(file))
-		if renderErr != nil {
-			return nil, fmt.Errorf("rendering rule template %s: %w", file, renderErr)
-		}
-		title := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
-		renderedRules = append(renderedRules, RenderedRule{
-			Title: title,
-			Body:  strings.TrimSpace(renderedBody),
-		})
-	}
-	return renderedRules, nil
-}
-
 // SkillRefStyle describes how a provider's skill files reference rule documents.
 type SkillRefStyle struct {
 	// RulesRelDir is the relative directory from a skill directory to the rule files.
@@ -370,103 +204,6 @@ var (
 	// SkillRefMD links rule references to sibling .md rule files (Claude).
 	SkillRefMD = SkillRefStyle{RulesRelDir: "../../rules", RuleExt: ".md"}
 )
-
-// RenderSkillDirs renders skill directories from src into dst, expanding rule-reference tokens for refStyle.
-func RenderSkillDirs(src string, dst string, refStyle SkillRefStyle) error {
-	slog.Info("compilation: RenderSkillDirs")
-	if _, err := os.Stat(src); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		slog.Warn("compilation: RenderSkillDirs stat failed", "src", src, "err", err)
-		return fmt.Errorf("stat %s: %w", src, err)
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		return fmt.Errorf("creating directory %s: %w", dst, err)
-	}
-	rulesDir := filepath.Join(filepath.Dir(src), "rules")
-	ruleNames, err := ruleBaseNames(rulesDir)
-	if err != nil {
-		return err
-	}
-	entries, err := os.ReadDir(src)
-	if err != nil {
-		slog.Warn("compilation: RenderSkillDirs ReadDir failed", "src", src, "err", err)
-		return fmt.Errorf("read dir %s: %w", src, err)
-	}
-	activeSkills := make(map[string]struct{}, len(entries))
-	var conflicts []string
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		activeSkills[entry.Name()] = struct{}{}
-		source := filepath.Join(src, entry.Name())
-		target := filepath.Join(dst, entry.Name())
-		if isSymlink(target) {
-			_ = os.Remove(target)
-		}
-		if err := renderSkillDir(source, target, refStyle, rulesDir, ruleNames, &conflicts); err != nil {
-			return err
-		}
-	}
-	if err := removeMissingManagedSkillDirs(dst, activeSkills); err != nil {
-		return err
-	}
-	return skillRenderConflictsError(conflicts)
-}
-
-func renderSkillDir(src string, dst string, refStyle SkillRefStyle, rulesDir string, ruleNames []string, conflicts *[]string) error {
-	entries, err := os.ReadDir(src)
-	if err != nil {
-		slog.Warn("compilation: renderSkillDir ReadDir failed", "src", src, "err", err)
-		return fmt.Errorf("read dir %s: %w", src, err)
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		return fmt.Errorf("creating directory %s: %w", dst, err)
-	}
-	for _, entry := range entries {
-		source := filepath.Join(src, entry.Name())
-		target := filepath.Join(dst, entry.Name())
-		if entry.IsDir() {
-			if err := renderSkillDir(source, target, refStyle, rulesDir, ruleNames, conflicts); err != nil {
-				return err
-			}
-			continue
-		}
-		content, readErr := os.ReadFile(source)
-		if readErr != nil {
-			slog.Warn("compilation: renderSkillDir read failed", "path", source, "err", readErr)
-			return fmt.Errorf("reading file %s: %w", source, readErr)
-		}
-		outputName := entry.Name()
-		output := content
-		fromTemplate := false
-		if base, ok := strings.CutSuffix(entry.Name(), ".tmpl"); ok {
-			outputName = base
-			fromTemplate = true
-			rendered, tmplErr := renderSkillTemplate(string(content), refStyle, rulesDir, ruleNames, entry.Name())
-			if tmplErr != nil {
-				return tmplErr
-			}
-			output = []byte(rendered)
-		}
-		target = filepath.Join(dst, outputName)
-		if isSymlink(target) {
-			_ = os.Remove(target)
-		}
-		if fromTemplate && outputName == "SKILL.md" {
-			if conflict := skillRenderConflict(target); conflict != "" {
-				*conflicts = append(*conflicts, conflict)
-				continue
-			}
-		}
-		if err := writeFileIfChanged(target, output); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 func skillRenderConflict(target string) string {
 	existing, err := os.ReadFile(filepath.Clean(target))
@@ -525,116 +262,9 @@ func skillRenderConflictsError(conflicts []string) error {
 	return fmt.Errorf("skill render conflicts:\n- %s", strings.Join(conflicts, "\n- "))
 }
 
-// skillTemplateData exposes corpus reference helpers to a skill template as the
-// "{{.Rules}}", "{{.Rule \"name\"}}", "{{.RuleBody \"name\"}}", and "{{.Skill \"name\"}}" methods.
-type skillTemplateData struct {
-	style     SkillRefStyle
-	rulesDir  string
-	ruleNames []string
-	execErr   *error
-	expanding *map[string]struct{}
-}
-
-func (d skillTemplateData) setExecErr(err error) {
-	if d.execErr != nil && *d.execErr == nil {
-		*d.execErr = err
-	}
-}
-
-func (d skillTemplateData) validRuleBodyName(name string) error {
-	if name == "" || name == "." || name == ".." {
-		return fmt.Errorf("invalid rule body name %q", name)
-	}
-	if strings.Contains(name, "/") || strings.Contains(name, string(filepath.Separator)) {
-		return fmt.Errorf("invalid rule body name %q", name)
-	}
-	if !slices.Contains(d.ruleNames, name) {
-		return fmt.Errorf("unknown rule body %q", name)
-	}
-	return nil
-}
-
-// Rules renders the full rule list for the active style.
-func (d skillTemplateData) Rules() string { return renderRulesList(d.style, d.ruleNames) }
-
-// Rule renders a single rule link for the active style.
-func (d skillTemplateData) Rule(name string) string { return renderRuleLink(d.style, name) }
-
-// Skill renders a sibling skill link for the active style.
-func (d skillTemplateData) Skill(name string) string { return renderSkillSiblingLink(name) }
-
-// RuleBody inlines a corpus rule body, expanding any skill references inside it.
-func (d skillTemplateData) RuleBody(name string) string {
-	if err := d.validRuleBodyName(name); err != nil {
-		d.setExecErr(err)
-		return ""
-	}
-	if d.expanding != nil {
-		if _, ok := (*d.expanding)[name]; ok {
-			d.setExecErr(fmt.Errorf("cyclic rule body transclusion for %q", name))
-			return ""
-		}
-		(*d.expanding)[name] = struct{}{}
-		defer delete(*d.expanding, name)
-	}
-	path := filepath.Join(d.rulesDir, name+".mdc")
-	content, err := os.ReadFile(path)
-	if err != nil {
-		d.setExecErr(fmt.Errorf("reading rule body %q: %w", name, err))
-		return ""
-	}
-	rule, parseErr := ParseRuleSource(string(content))
-	if parseErr != nil {
-		d.setExecErr(fmt.Errorf("parsing rule body %q: %w", name, parseErr))
-		return ""
-	}
-	body := strings.TrimSpace(rule.Body)
-	if !strings.Contains(body, "{{") {
-		return body
-	}
-	parsed, parseErr := template.New(name + ".mdc").Parse(body)
-	if parseErr != nil {
-		d.setExecErr(fmt.Errorf("parsing rule body template %q: %w", name, parseErr))
-		return ""
-	}
-	buf := bytes.NewBuffer(nil)
-	if execErr := parsed.Execute(buf, d); execErr != nil {
-		d.setExecErr(fmt.Errorf("executing rule body template %q: %w", name, execErr))
-		return ""
-	}
-	return strings.TrimSpace(buf.String())
-}
-
 func renderSkillSiblingLink(name string) string {
 	skillPath := filepath.ToSlash(filepath.Join("..", name, "SKILL.md"))
 	return fmt.Sprintf("[%s](%s)", name, skillPath)
-}
-
-// renderSkillTemplate renders one skill template through text/template.
-func renderSkillTemplate(content string, refStyle SkillRefStyle, rulesDir string, ruleNames []string, name string) (string, error) {
-	parsed, err := template.New(name).Parse(content)
-	if err != nil {
-		slog.Warn("compilation: renderSkillTemplate parse failed", "name", name, "err", err)
-		return "", fmt.Errorf("parsing skill template %s: %w", name, err)
-	}
-	var execErr error
-	expanding := make(map[string]struct{})
-	buf := bytes.NewBuffer(nil)
-	data := skillTemplateData{
-		style:     refStyle,
-		rulesDir:  rulesDir,
-		ruleNames: ruleNames,
-		execErr:   &execErr,
-		expanding: &expanding,
-	}
-	if err := parsed.Execute(buf, data); err != nil {
-		slog.Warn("compilation: renderSkillTemplate execute failed", "name", name, "err", err)
-		return "", fmt.Errorf("executing skill template %s: %w", name, err)
-	}
-	if execErr != nil {
-		return "", fmt.Errorf("executing skill template %s: %w", name, execErr)
-	}
-	return injectSkillMarker(buf.String()), nil
 }
 
 func renderRuleLink(refStyle SkillRefStyle, name string) string {
@@ -667,18 +297,6 @@ func injectSkillMarker(content string) string {
 		}
 	}
 	return GeneratedAgentHTMLMarker + "\n\n" + content
-}
-
-func ruleBaseNames(rulesDir string) ([]string, error) {
-	files, err := sortedMdcFiles(rulesDir)
-	if err != nil {
-		return nil, err
-	}
-	names := make([]string, 0, len(files))
-	for _, file := range files {
-		names = append(names, strings.TrimSuffix(filepath.Base(file), filepath.Ext(file)))
-	}
-	return names, nil
 }
 
 func removeMissingManagedSkillDirs(dst string, activeSkills map[string]struct{}) error {
@@ -724,20 +342,6 @@ func isSymlink(path string) bool {
 		return false
 	}
 	return info.Mode()&os.ModeSymlink != 0
-}
-
-func sortedMdcFiles(src string) ([]string, error) {
-	const ext = ".mdc"
-	if _, err := os.Stat(src); err != nil && !os.IsNotExist(err) {
-		slog.Warn("compilation: sortedMdcFiles stat failed", "src", src, "err", err)
-		return nil, fmt.Errorf("stat %s: %w", src, err)
-	}
-	files, err := filepath.Glob(filepath.Join(src, "*"+ext))
-	if err != nil {
-		return nil, fmt.Errorf("globbing files in %s: %w", src, err)
-	}
-	sort.Strings(files)
-	return files, nil
 }
 
 func writeFileIfChanged(path string, content []byte) error {

--- a/dots/internal/sync/compilation/legacy_render_test.go
+++ b/dots/internal/sync/compilation/legacy_render_test.go
@@ -1,0 +1,110 @@
+package compilation
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func RenderRuleFiles(src string, dst string, ext string, format RuleTargetFormat, style RuleRenderStyle) error {
+	sourceSet, err := loadRuleSourceSetForTest(src)
+	if err != nil {
+		return err
+	}
+	return RenderRuleFilesFromSourceSet(sourceSet, dst, ext, format, style)
+}
+
+func RenderRulesAsInstructionDoc(src string, dst string, title string, style RuleRenderStyle) error {
+	sourceSet, err := loadRuleSourceSetForTest(src)
+	if err != nil {
+		return err
+	}
+	return RenderRulesAsInstructionDocFromSourceSet(sourceSet, dst, title, style)
+}
+
+func RenderCopilotInstructionFiles(src string, dst string, style RuleRenderStyle) error {
+	sourceSet, err := loadRuleSourceSetForTest(src)
+	if err != nil {
+		return err
+	}
+	return RenderCopilotInstructionFilesFromSourceSet(sourceSet, dst, style)
+}
+
+func RenderRulesForUpload(src string, style RuleRenderStyle) ([]RenderedRule, error) {
+	sourceSet, err := loadRuleSourceSetForTest(src)
+	if err != nil {
+		return nil, err
+	}
+	return RenderRulesForUploadFromSourceSet(sourceSet, style)
+}
+
+func RenderSkillDirs(src string, dst string, style SkillRefStyle) error {
+	sourceSet, err := loadRuleSourceSetForTest(filepath.Join(filepath.Dir(src), "rules"))
+	if err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("reading skills directory %s: %w", src, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		files := make(map[string]string)
+		if err := readSkillFilesForTest(filepath.Join(src, entry.Name()), "", files); err != nil {
+			return err
+		}
+		sourceSet.Skills[entry.Name()] = SkillSource{Name: entry.Name(), Files: files}
+	}
+	return RenderSkillDirsFromSourceSet(sourceSet, dst, style)
+}
+
+func loadRuleSourceSetForTest(rulesDir string) (CorpusSourceSet, error) {
+	sourceSet := CorpusSourceSet{
+		Rules:  make(map[string]RuleSource),
+		Skills: make(map[string]SkillSource),
+		Agents: make(map[string]AgentSource),
+	}
+	files, err := filepath.Glob(filepath.Join(rulesDir, "*.mdc"))
+	if err != nil {
+		return sourceSet, fmt.Errorf("globbing test rules: %w", err)
+	}
+	for _, path := range files {
+		content, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return sourceSet, fmt.Errorf("reading test rule %s: %w", path, err)
+		}
+		rule, err := ParseRuleSource(string(content))
+		if err != nil {
+			return sourceSet, fmt.Errorf("parsing test rule %s: %w", path, err)
+		}
+		name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		sourceSet.Rules[name] = rule
+	}
+	return sourceSet, nil
+}
+
+func readSkillFilesForTest(root string, relativeDir string, files map[string]string) error {
+	current := filepath.Join(root, relativeDir)
+	entries, err := os.ReadDir(current)
+	if err != nil {
+		return fmt.Errorf("reading test skill directory %s: %w", current, err)
+	}
+	for _, entry := range entries {
+		relativePath := filepath.Join(relativeDir, entry.Name())
+		if entry.IsDir() {
+			if err := readSkillFilesForTest(root, relativePath, files); err != nil {
+				return err
+			}
+			continue
+		}
+		content, err := os.ReadFile(filepath.Clean(filepath.Join(root, relativePath)))
+		if err != nil {
+			return fmt.Errorf("reading test skill file %s: %w", relativePath, err)
+		}
+		files[filepath.ToSlash(relativePath)] = string(content)
+	}
+	return nil
+}

--- a/dots/internal/sync/compilation/source_set.go
+++ b/dots/internal/sync/compilation/source_set.go
@@ -1,0 +1,22 @@
+package compilation
+
+// CorpusSourceSet contains normalized rules, skills, and agents from every configured corpus source.
+type CorpusSourceSet struct {
+	Rules  map[string]RuleSource
+	Skills map[string]SkillSource
+	Agents map[string]AgentSource
+}
+
+// SkillSource contains one normalized skill and its relative file contents.
+type SkillSource struct {
+	Name  string
+	Files map[string]string
+}
+
+// AgentSource contains one normalized agent contract and its permission mode.
+type AgentSource struct {
+	Name        string
+	Description string
+	Body        string
+	ReadOnly    bool
+}

--- a/dots/internal/sync/compilation/source_set_render.go
+++ b/dots/internal/sync/compilation/source_set_render.go
@@ -1,0 +1,467 @@
+package compilation
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+)
+
+type renderedSkillPlan struct {
+	name      string
+	files     map[string]string
+	conflicts []string
+}
+
+// RenderSkillDirsFromSourceSet renders normalized skills into managed provider directories.
+func RenderSkillDirsFromSourceSet(sourceSet CorpusSourceSet, dst string, refStyle SkillRefStyle) error {
+	slog.Info("compilation: rendering skill directories", "dest", dst)
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		slog.Warn("compilation: creating skill directory", "dest", dst, "err", err)
+		return fmt.Errorf("creating directory %s: %w", dst, err)
+	}
+	skillNames := sortedSkillNames(sourceSet.Skills)
+	ruleNames := sortedRuleNames(sourceSet.Rules)
+	activeSkills := make(map[string]struct{}, len(skillNames))
+	plans := make([]renderedSkillPlan, 0, len(skillNames))
+	conflicts := make([]string, 0)
+	for _, skillName := range skillNames {
+		activeSkills[skillName] = struct{}{}
+		plan, err := renderSourceSkillPlan(sourceSet.Skills[skillName], filepath.Join(dst, skillName), refStyle, sourceSet.Rules, ruleNames)
+		if err != nil {
+			return err
+		}
+		plans = append(plans, plan)
+		conflicts = append(conflicts, plan.conflicts...)
+		if err := validateSkillPlanPaths(filepath.Join(dst, skillName), plan); err != nil {
+			return err
+		}
+	}
+	if err := skillRenderConflictsError(conflicts); err != nil {
+		return err
+	}
+	if err := applyRenderedSkillPlans(plans, dst); err != nil {
+		return err
+	}
+	if err := removeMissingManagedSkillDirs(dst, activeSkills); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyRenderedSkillPlans(plans []renderedSkillPlan, dst string) error {
+	slog.Info("compilation: applying rendered skill plans", "dest", dst)
+	for _, plan := range plans {
+		targetDir := filepath.Join(dst, plan.name)
+		if isSymlink(targetDir) {
+			if err := os.Remove(targetDir); err != nil {
+				slog.Warn("compilation: removing skill directory symlink", "path", targetDir, "err", err)
+				return fmt.Errorf("removing symlink %s: %w", targetDir, err)
+			}
+		}
+		fileNames := make([]string, 0, len(plan.files))
+		for fileName := range plan.files {
+			fileNames = append(fileNames, fileName)
+		}
+		sort.Strings(fileNames)
+		for _, fileName := range fileNames {
+			target := filepath.Join(targetDir, fileName)
+			if err := validateNoNestedSymlink(targetDir, target); err != nil {
+				return err
+			}
+			if isSymlink(target) {
+				if err := os.Remove(target); err != nil {
+					return fmt.Errorf("removing symlink %s: %w", target, err)
+				}
+			}
+			if err := writeFileIfChanged(target, []byte(plan.files[fileName])); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateSkillDirsFromSourceSet validates skill rendering against the real destination without writing files.
+func ValidateSkillDirsFromSourceSet(sourceSet CorpusSourceSet, dst string, refStyle SkillRefStyle) error {
+	skillNames := sortedSkillNames(sourceSet.Skills)
+	ruleNames := sortedRuleNames(sourceSet.Rules)
+	conflicts := make([]string, 0)
+	for _, skillName := range skillNames {
+		targetDir := filepath.Join(dst, skillName)
+		plan, err := renderSourceSkillPlan(sourceSet.Skills[skillName], targetDir, refStyle, sourceSet.Rules, ruleNames)
+		if err != nil {
+			return err
+		}
+		conflicts = append(conflicts, plan.conflicts...)
+		if err := validateSkillPlanPaths(targetDir, plan); err != nil {
+			return err
+		}
+	}
+	return skillRenderConflictsError(conflicts)
+}
+
+func validateSkillPlanPaths(targetDir string, plan renderedSkillPlan) error {
+	for fileName := range plan.files {
+		if err := validateNoNestedSymlink(targetDir, filepath.Join(targetDir, fileName)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderSourceSkillPlan(skill SkillSource, dst string, style SkillRefStyle, rules map[string]RuleSource, ruleNames []string) (renderedSkillPlan, error) {
+	plan := renderedSkillPlan{
+		name:      skill.Name,
+		files:     make(map[string]string),
+		conflicts: make([]string, 0),
+	}
+	fileNames := make([]string, 0, len(skill.Files))
+	for fileName := range skill.Files {
+		fileNames = append(fileNames, fileName)
+	}
+	sort.Strings(fileNames)
+	for _, fileName := range fileNames {
+		cleanName := filepath.Clean(filepath.FromSlash(fileName))
+		if cleanName == "." || cleanName == ".." || filepath.IsAbs(cleanName) || strings.HasPrefix(cleanName, ".."+string(os.PathSeparator)) {
+			return renderedSkillPlan{}, fmt.Errorf("invalid skill file path %q for %s", fileName, skill.Name)
+		}
+		outputName := cleanName
+		output := skill.Files[fileName]
+		if base, ok := strings.CutSuffix(cleanName, ".tmpl"); ok {
+			outputName = base
+			rendered, err := renderSourceSkillTemplate(output, style, rules, ruleNames, fileName)
+			if err != nil {
+				return renderedSkillPlan{}, err
+			}
+			output = rendered
+		}
+		if filepath.ToSlash(outputName) == "SKILL.md" {
+			output = injectSkillMarker(output)
+			target := filepath.Join(dst, outputName)
+			if conflict := skillRenderConflict(target); conflict != "" {
+				plan.conflicts = append(plan.conflicts, conflict)
+				continue
+			}
+		}
+		plan.files[outputName] = output
+	}
+	return plan, nil
+}
+
+type sourceSkillTemplateData struct {
+	style     SkillRefStyle
+	rules     map[string]RuleSource
+	ruleNames []string
+	execErr   *error
+	expanding map[string]struct{}
+}
+
+func (d *sourceSkillTemplateData) Rules() string            { return renderRulesList(d.style, d.ruleNames) }
+func (d *sourceSkillTemplateData) Rule(name string) string  { return renderRuleLink(d.style, name) }
+func (d *sourceSkillTemplateData) Skill(name string) string { return renderSkillSiblingLink(name) }
+
+func (d *sourceSkillTemplateData) RuleBody(name string) string {
+	if name == "" || name == "." || name == ".." || strings.Contains(name, "/") || strings.Contains(name, string(filepath.Separator)) {
+		d.setError(fmt.Errorf("invalid rule body name %q", name))
+		return ""
+	}
+	rule, ok := d.rules[name]
+	if !ok {
+		d.setError(fmt.Errorf("unknown rule body %q", name))
+		return ""
+	}
+	if _, exists := d.expanding[name]; exists {
+		d.setError(fmt.Errorf("cyclic rule body transclusion for %q", name))
+		return ""
+	}
+	d.expanding[name] = struct{}{}
+	defer delete(d.expanding, name)
+	body := strings.TrimSpace(rule.Body)
+	if !strings.Contains(body, "{{") {
+		return body
+	}
+	parsed, err := template.New(name + ".mdc").Parse(body)
+	if err != nil {
+		d.setError(fmt.Errorf("parsing rule body template %q: %w", name, err))
+		return ""
+	}
+	var buffer bytes.Buffer
+	if err := parsed.Execute(&buffer, d); err != nil {
+		d.setError(fmt.Errorf("executing rule body template %q: %w", name, err))
+		return ""
+	}
+	return strings.TrimSpace(buffer.String())
+}
+
+func (d *sourceSkillTemplateData) setError(err error) {
+	if d.execErr != nil && *d.execErr == nil {
+		*d.execErr = err
+	}
+}
+
+func renderSourceSkillTemplate(content string, style SkillRefStyle, rules map[string]RuleSource, ruleNames []string, name string) (string, error) {
+	parsed, err := template.New(name).Parse(content)
+	if err != nil {
+		slog.Warn("compilation: parsing skill template", "name", name, "err", err)
+		return "", fmt.Errorf("parsing skill template %s: %w", name, err)
+	}
+	var execErr error
+	data := &sourceSkillTemplateData{
+		style:     style,
+		rules:     rules,
+		ruleNames: ruleNames,
+		execErr:   &execErr,
+		expanding: make(map[string]struct{}),
+	}
+	var buffer bytes.Buffer
+	if err := parsed.Execute(&buffer, data); err != nil {
+		return "", fmt.Errorf("executing skill template %s: %w", name, err)
+	}
+	if execErr != nil {
+		return "", fmt.Errorf("executing skill template %s: %w", name, execErr)
+	}
+	return buffer.String(), nil
+}
+
+// ValidateRuleFilesFromSourceSet validates rule-file rendering without writing files.
+func ValidateRuleFilesFromSourceSet(sourceSet CorpusSourceSet, dst string, ext string, format RuleTargetFormat, style RuleRenderStyle) error {
+	for _, name := range sortedRuleNames(sourceSet.Rules) {
+		rule := sourceSet.Rules[name]
+		renderedBody, err := renderRuleTemplate(strings.TrimSpace(rule.Body), style, name)
+		if err != nil {
+			slog.Warn("compilation: validating rule template", "name", name, "err", err)
+			return fmt.Errorf("rendering rule template %s: %w", name, err)
+		}
+		rule.Body = renderedBody
+		if _, err := rule.RenderForTarget(format); err != nil {
+			slog.Warn("compilation: validating rendered rule", "name", name, "err", err)
+			return fmt.Errorf("rendering rule %s for format %q: %w", name, format, err)
+		}
+		if err := validateNoNestedSymlink(dst, filepath.Join(dst, name+ext)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RenderRuleFilesFromSourceSet renders normalized rules as managed files for one provider format.
+func RenderRuleFilesFromSourceSet(sourceSet CorpusSourceSet, dst string, ext string, format RuleTargetFormat, style RuleRenderStyle) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		slog.Warn("compilation: creating rule directory", "dest", dst, "err", err)
+		return fmt.Errorf("creating directory %s: %w", dst, err)
+	}
+	names := sortedRuleNames(sourceSet.Rules)
+	activeFiles := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		targetName := name + ext
+		activeFiles[targetName] = struct{}{}
+		rule := sourceSet.Rules[name]
+		renderedBody, err := renderRuleTemplate(strings.TrimSpace(rule.Body), style, name)
+		if err != nil {
+			return fmt.Errorf("rendering rule template %s: %w", name, err)
+		}
+		rule.Body = renderedBody
+		rendered, err := rule.RenderForTarget(format)
+		if err != nil {
+			return fmt.Errorf("rendering rule %s for format %q: %w", name, format, err)
+		}
+		target := filepath.Join(dst, targetName)
+		if err := removeRenderTargetSymlink(target); err != nil {
+			return err
+		}
+		if err := writeFileIfChanged(target, []byte(injectSkillMarker(rendered))); err != nil {
+			return err
+		}
+	}
+	return removeMissingManagedFiles(dst, ext, activeFiles)
+}
+
+// ValidateRulesAsInstructionDocFromSourceSet validates instruction-document rendering without writing files.
+func ValidateRulesAsInstructionDocFromSourceSet(sourceSet CorpusSourceSet, dst string, style RuleRenderStyle) error {
+	for _, name := range sortedRuleNames(sourceSet.Rules) {
+		if _, err := renderRuleTemplate(strings.TrimSpace(sourceSet.Rules[name].Body), style, name); err != nil {
+			slog.Warn("compilation: validating instruction rule", "name", name, "err", err)
+			return fmt.Errorf("rendering rule template %s: %w", name, err)
+		}
+	}
+	return validateNoNestedSymlink(filepath.Dir(dst), dst)
+}
+
+// RenderRulesAsInstructionDocFromSourceSet renders normalized rules into one managed instruction document.
+func RenderRulesAsInstructionDocFromSourceSet(sourceSet CorpusSourceSet, dst string, title string, style RuleRenderStyle) error {
+	names := sortedRuleNames(sourceSet.Rules)
+	if len(names) == 0 {
+		return removeManagedRenderTarget(dst)
+	}
+	var builder strings.Builder
+	builder.WriteString("# ")
+	builder.WriteString(title)
+	builder.WriteString("\n\n")
+	builder.WriteString(GeneratedAgentHTMLMarker)
+	builder.WriteString("\n")
+	for _, name := range names {
+		builder.WriteString("\n## ")
+		builder.WriteString(name)
+		builder.WriteString("\n\n")
+		rendered, err := renderRuleTemplate(strings.TrimSpace(sourceSet.Rules[name].Body), style, name)
+		if err != nil {
+			slog.Warn("compilation: rendering instruction rule", "name", name, "err", err)
+			return fmt.Errorf("rendering rule template %s: %w", name, err)
+		}
+		builder.WriteString(rendered)
+		builder.WriteString("\n")
+	}
+	if err := removeRenderTargetSymlink(dst); err != nil {
+		return err
+	}
+	return writeFileIfChanged(dst, []byte(builder.String()))
+}
+
+// ValidateCopilotInstructionFilesFromSourceSet validates Copilot instruction rendering without writing files.
+func ValidateCopilotInstructionFilesFromSourceSet(sourceSet CorpusSourceSet, dst string, style RuleRenderStyle) error {
+	for _, name := range sortedRuleNames(sourceSet.Rules) {
+		rule := sourceSet.Rules[name]
+		renderedBody, err := renderRuleTemplate(strings.TrimSpace(rule.Body), style, name)
+		if err != nil {
+			slog.Warn("compilation: validating Copilot rule template", "name", name, "err", err)
+			return fmt.Errorf("rendering rule template %s: %w", name, err)
+		}
+		rule.Body = renderedBody
+		if _, err := rule.RenderCopilot(name); err != nil {
+			slog.Warn("compilation: validating Copilot instruction", "name", name, "err", err)
+			return fmt.Errorf("rendering copilot instruction %s: %w", name, err)
+		}
+		if err := validateNoNestedSymlink(dst, filepath.Join(dst, name+".instructions.md")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RenderCopilotInstructionFilesFromSourceSet renders normalized rules as managed Copilot instruction files.
+func RenderCopilotInstructionFilesFromSourceSet(sourceSet CorpusSourceSet, dst string, style RuleRenderStyle) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		slog.Warn("compilation: creating Copilot instruction directory", "dest", dst, "err", err)
+		return fmt.Errorf("creating directory %s: %w", dst, err)
+	}
+	names := sortedRuleNames(sourceSet.Rules)
+	activeFiles := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		targetName := name + ".instructions.md"
+		activeFiles[targetName] = struct{}{}
+		rule := sourceSet.Rules[name]
+		renderedBody, err := renderRuleTemplate(strings.TrimSpace(rule.Body), style, name)
+		if err != nil {
+			return fmt.Errorf("rendering rule template %s: %w", name, err)
+		}
+		rule.Body = renderedBody
+		rendered, err := rule.RenderCopilot(name)
+		if err != nil {
+			return fmt.Errorf("rendering copilot instruction %s: %w", name, err)
+		}
+		target := filepath.Join(dst, targetName)
+		if err := removeRenderTargetSymlink(target); err != nil {
+			return err
+		}
+		if err := writeFileIfChanged(target, []byte(rendered)); err != nil {
+			return err
+		}
+	}
+	return removeMissingManagedFiles(dst, ".instructions.md", activeFiles)
+}
+
+// RenderRulesForUploadFromSourceSet renders normalized rules for direct cloud upload.
+func RenderRulesForUploadFromSourceSet(sourceSet CorpusSourceSet, style RuleRenderStyle) ([]RenderedRule, error) {
+	names := sortedRuleNames(sourceSet.Rules)
+	renderedRules := make([]RenderedRule, 0, len(names))
+	for _, name := range names {
+		rendered, err := renderRuleTemplate(strings.TrimSpace(sourceSet.Rules[name].Body), style, name)
+		if err != nil {
+			slog.Warn("compilation: rendering rule for upload", "name", name, "err", err)
+			return nil, fmt.Errorf("rendering rule template %s: %w", name, err)
+		}
+		renderedRules = append(renderedRules, RenderedRule{Title: name, Body: strings.TrimSpace(rendered)})
+	}
+	return renderedRules, nil
+}
+
+func removeRenderTargetSymlink(path string) error {
+	if !isSymlink(path) {
+		return nil
+	}
+	if err := os.Remove(path); err != nil {
+		slog.Warn("compilation: removing render target symlink", "path", path, "err", err)
+		return fmt.Errorf("removing symlink %s: %w", path, err)
+	}
+	return nil
+}
+
+func removeManagedRenderTarget(path string) error {
+	content, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		slog.Warn("compilation: reading managed render target", "path", path, "err", err)
+		return fmt.Errorf("reading managed render target %s: %w", path, err)
+	}
+	if !HasGeneratedMarker(string(content)) {
+		return nil
+	}
+	if err := os.Remove(filepath.Clean(path)); err != nil {
+		slog.Warn("compilation: removing managed render target", "path", path, "err", err)
+		return fmt.Errorf("removing managed render target %s: %w", path, err)
+	}
+	return nil
+}
+
+func validateNoNestedSymlink(root string, target string) error {
+	relativePath, err := filepath.Rel(root, target)
+	if err != nil {
+		slog.Warn("compilation: resolving nested render target", "root", root, "target", target, "err", err)
+		return fmt.Errorf("resolving render target %s below %s: %w", target, root, err)
+	}
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("render target %s escapes destination %s", target, root)
+	}
+	components := strings.Split(relativePath, string(os.PathSeparator))
+	currentPath := root
+	for _, component := range components[:len(components)-1] {
+		currentPath = filepath.Join(currentPath, component)
+		info, statErr := os.Lstat(currentPath)
+		if os.IsNotExist(statErr) {
+			continue
+		}
+		if statErr != nil {
+			slog.Warn("compilation: checking nested render path", "path", currentPath, "err", statErr)
+			return fmt.Errorf("checking render path %s: %w", currentPath, statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("render path component %s is a symlink", currentPath)
+		}
+	}
+	return nil
+}
+
+func sortedRuleNames(rules map[string]RuleSource) []string {
+	names := make([]string, 0, len(rules))
+	for name := range rules {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedSkillNames(skills map[string]SkillSource) []string {
+	names := make([]string, 0, len(skills))
+	for name := range skills {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/dots/internal/sync/compilation/source_set_render_test.go
+++ b/dots/internal/sync/compilation/source_set_render_test.go
@@ -1,0 +1,504 @@
+package compilation
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestRenderSkillDirsFromSourceSetRendersTemplatesAndImportedSkills(t *testing.T) {
+	sourceSet := CorpusSourceSet{
+		Rules: map[string]RuleSource{
+			"code":    {Body: "code body"},
+			"general": {Body: "general body"},
+		},
+		Skills: map[string]SkillSource{
+			"local-skill": {
+				Name: "local-skill",
+				Files: map[string]string{
+					"SKILL.md.tmpl": strings.Join([]string{
+						"---",
+						"name: local-skill",
+						"description: local",
+						"---",
+						"",
+						"Rules:",
+						"",
+						"{{.Rules}}",
+					}, "\n") + "\n",
+				},
+			},
+			"trace-the-chain": {
+				Name: "trace-the-chain",
+				Files: map[string]string{
+					"SKILL.md": strings.Join([]string{
+						"---",
+						"name: trace-the-chain",
+						"description: imported",
+						"---",
+						"",
+						"Imported body",
+					}, "\n") + "\n",
+				},
+			},
+		},
+	}
+
+	dst := filepath.Join(t.TempDir(), "skills")
+	if err := RenderSkillDirsFromSourceSet(sourceSet, dst, SkillRefMDC); err != nil {
+		t.Fatalf("RenderSkillDirsFromSourceSet: %v", err)
+	}
+
+	localSkill, err := os.ReadFile(filepath.Join(dst, "local-skill", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading rendered local skill: %v", err)
+	}
+	if !strings.Contains(string(localSkill), "[code.mdc](../../rules/code.mdc)") {
+		t.Fatalf("rendered local skill missing rule link:\n%s", localSkill)
+	}
+	if strings.Contains(string(localSkill), "{{") {
+		t.Fatalf("rendered local skill still contains template tokens:\n%s", localSkill)
+	}
+	if !HasGeneratedMarker(string(localSkill)) {
+		t.Fatalf("rendered local skill missing generated marker:\n%s", localSkill)
+	}
+
+	importedSkill, err := os.ReadFile(filepath.Join(dst, "trace-the-chain", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading imported skill: %v", err)
+	}
+	if !strings.Contains(string(importedSkill), "Imported body") {
+		t.Fatalf("imported skill body missing:\n%s", importedSkill)
+	}
+	if !HasGeneratedMarker(string(importedSkill)) {
+		t.Fatalf("imported skill missing generated marker:\n%s", importedSkill)
+	}
+}
+
+func TestRenderAgentFilesWritesProviderSpecificFormats(t *testing.T) {
+	testCases := []struct {
+		name         string
+		format       AgentTargetFormat
+		fileName     string
+		wantContains []string
+	}{
+		{
+			name:     "claude",
+			format:   AgentTargetClaude,
+			fileName: "evidence-gatherer.md",
+			wantContains: []string{
+				"name: evidence-gatherer",
+				"description: Evidence specialist",
+				"- Read",
+				"Gather evidence",
+			},
+		},
+		{
+			name:     "cursor",
+			format:   AgentTargetCursor,
+			fileName: "evidence-gatherer.md",
+			wantContains: []string{
+				"name: evidence-gatherer",
+				"readonly: true",
+				"Gather evidence",
+			},
+		},
+		{
+			name:     "gemini",
+			format:   AgentTargetGemini,
+			fileName: "evidence-gatherer.md",
+			wantContains: []string{
+				"name: evidence-gatherer",
+				"description: Evidence specialist",
+				"- read_file",
+				"Gather evidence",
+			},
+		},
+		{
+			name:     "codex",
+			format:   AgentTargetCodex,
+			fileName: "evidence-gatherer.toml",
+			wantContains: []string{
+				"name = ",
+				"sandbox_mode = ",
+				"developer_instructions = ",
+				"Gather evidence",
+			},
+		},
+		{
+			name:     "copilot",
+			format:   AgentTargetCopilot,
+			fileName: "evidence-gatherer.agent.md",
+			wantContains: []string{
+				"name: evidence-gatherer",
+				"description: Evidence specialist",
+				"- read",
+				"Gather evidence",
+			},
+		},
+	}
+
+	agents := map[string]AgentSource{
+		"code-implementer": {
+			Name:        "code-implementer",
+			Description: "Implementation specialist",
+			Body:        "Implement precisely",
+		},
+		"evidence-gatherer": {
+			Name:        "evidence-gatherer",
+			Description: "Evidence specialist",
+			Body:        "Gather evidence",
+			ReadOnly:    true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dst := filepath.Join(t.TempDir(), "agents")
+			if err := RenderAgentFiles(agents, dst, testCase.format); err != nil {
+				t.Fatalf("RenderAgentFiles(%s): %v", testCase.format, err)
+			}
+			payload, err := os.ReadFile(filepath.Join(dst, testCase.fileName))
+			if err != nil {
+				t.Fatalf("reading rendered agent: %v", err)
+			}
+			rendered := string(payload)
+			for _, want := range testCase.wantContains {
+				if !strings.Contains(rendered, want) {
+					t.Fatalf("rendered agent missing %q:\n%s", want, rendered)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderCodexAgentProducesValidTOML(t *testing.T) {
+	agent := AgentSource{
+		Name:        "evidence-gatherer",
+		Description: "Evidence specialist",
+		Body:        "Control byte: \x01",
+		ReadOnly:    true,
+	}
+
+	rendered, err := renderAgent(agent, AgentTargetCodex)
+	if err != nil {
+		t.Fatalf("renderAgent: %v", err)
+	}
+	var decoded struct {
+		Name                  string `toml:"name"`
+		Description           string `toml:"description"`
+		SandboxMode           string `toml:"sandbox_mode"`
+		DeveloperInstructions string `toml:"developer_instructions"`
+	}
+	if err := toml.Unmarshal([]byte(rendered), &decoded); err != nil {
+		t.Fatalf("rendered Codex agent is invalid TOML: %v\n%s", err, rendered)
+	}
+	if decoded.DeveloperInstructions != agent.Body {
+		t.Fatalf("developer instructions = %q, want %q", decoded.DeveloperInstructions, agent.Body)
+	}
+}
+
+func TestRenderSkillDirsFromSourceSetDoesNotMutateOnTemplateError(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "skills")
+	if err := os.MkdirAll(filepath.Join(dst, "local-skill"), 0o755); err != nil {
+		t.Fatalf("mkdir existing skill: %v", err)
+	}
+	const existingContent = "existing content\n"
+	if err := os.WriteFile(filepath.Join(dst, "local-skill", "SKILL.md"), []byte(existingContent), 0o600); err != nil {
+		t.Fatalf("write existing skill: %v", err)
+	}
+
+	sourceSet := CorpusSourceSet{
+		Rules: map[string]RuleSource{},
+		Skills: map[string]SkillSource{
+			"broken-skill": {
+				Name: "broken-skill",
+				Files: map[string]string{
+					"SKILL.md.tmpl": "{{.RuleBody \"missing\"}}\n",
+				},
+			},
+			"local-skill": {
+				Name: "local-skill",
+				Files: map[string]string{
+					"SKILL.md": "replacement\n",
+				},
+			},
+		},
+	}
+
+	err := RenderSkillDirsFromSourceSet(sourceSet, dst, SkillRefMD)
+	if err == nil {
+		t.Fatal("RenderSkillDirsFromSourceSet() returned nil, want template error")
+	}
+	content, readErr := os.ReadFile(filepath.Join(dst, "local-skill", "SKILL.md"))
+	if readErr != nil {
+		t.Fatalf("reading existing skill: %v", readErr)
+	}
+	if string(content) != existingContent {
+		t.Fatalf("existing skill changed after template error:\n%s", string(content))
+	}
+}
+
+func TestRenderSkillDirsFromSourceSetDoesNotMutateOnConflict(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "skills")
+	conflictPath := filepath.Join(dst, "conflicting-skill", "SKILL.md")
+	const conflictContent = "invalid unmanaged skill\n"
+	if err := os.MkdirAll(filepath.Dir(conflictPath), 0o755); err != nil {
+		t.Fatalf("mkdir conflict skill: %v", err)
+	}
+	if err := os.WriteFile(conflictPath, []byte(conflictContent), 0o600); err != nil {
+		t.Fatalf("write conflict skill: %v", err)
+	}
+	existingPath := filepath.Join(dst, "local-skill", "SKILL.md")
+	const existingContent = GeneratedAgentHTMLMarker + "\nexisting managed output\n"
+	if err := os.MkdirAll(filepath.Dir(existingPath), 0o755); err != nil {
+		t.Fatalf("mkdir existing skill: %v", err)
+	}
+	if err := os.WriteFile(existingPath, []byte(existingContent), 0o600); err != nil {
+		t.Fatalf("write existing skill: %v", err)
+	}
+
+	sourceSet := CorpusSourceSet{
+		Rules: map[string]RuleSource{},
+		Skills: map[string]SkillSource{
+			"conflicting-skill": {Name: "conflicting-skill", Files: map[string]string{"SKILL.md": "replacement conflict\n"}},
+			"local-skill":       {Name: "local-skill", Files: map[string]string{"SKILL.md": "replacement managed\n"}},
+		},
+	}
+
+	err := RenderSkillDirsFromSourceSet(sourceSet, dst, SkillRefMD)
+	if err == nil {
+		t.Fatal("RenderSkillDirsFromSourceSet() returned nil, want conflict error")
+	}
+	content, readErr := os.ReadFile(existingPath)
+	if readErr != nil {
+		t.Fatalf("reading existing skill: %v", readErr)
+	}
+	if string(content) != existingContent {
+		t.Fatalf("existing skill changed after conflict:\n%s", string(content))
+	}
+}
+
+func TestRenderAgentFilesReplacesSymlinkTargetsSafely(t *testing.T) {
+	agents := map[string]AgentSource{
+		"evidence-gatherer": {
+			Name:        "evidence-gatherer",
+			Description: "Evidence specialist",
+			Body:        "Gather evidence",
+			ReadOnly:    true,
+		},
+	}
+	dst := filepath.Join(t.TempDir(), "agents")
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("mkdir agents dir: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	if err := os.WriteFile(outside, []byte("outside\n"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	linkPath := filepath.Join(dst, "evidence-gatherer.md")
+	if err := os.Symlink(outside, linkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	if err := RenderAgentFiles(agents, dst, AgentTargetClaude); err != nil {
+		t.Fatalf("RenderAgentFiles: %v", err)
+	}
+	linkInfo, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat rendered agent: %v", err)
+	}
+	if linkInfo.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("rendered agent remained symlink")
+	}
+	outsideContent, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatalf("read outside file: %v", err)
+	}
+	if string(outsideContent) != "outside\n" {
+		t.Fatalf("outside file changed:\n%s", string(outsideContent))
+	}
+}
+
+func TestRenderAgentFilesDoesNotMutateOnInvalidName(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "agents")
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("mkdir agents dir: %v", err)
+	}
+	const existingContent = "existing content\n"
+	if err := os.WriteFile(filepath.Join(dst, "code-implementer.md"), []byte(existingContent), 0o600); err != nil {
+		t.Fatalf("write existing agent: %v", err)
+	}
+
+	agents := map[string]AgentSource{
+		"code-implementer": {
+			Name:        "code-implementer",
+			Description: "Implementation specialist",
+			Body:        "Implement precisely",
+		},
+		"z/bad-agent": {
+			Name:        "z/bad-agent",
+			Description: "Bad agent",
+			Body:        "Should fail",
+		},
+	}
+
+	err := RenderAgentFiles(agents, dst, AgentTargetClaude)
+	if err == nil {
+		t.Fatal("RenderAgentFiles() returned nil, want invalid agent name error")
+	}
+	content, readErr := os.ReadFile(filepath.Join(dst, "code-implementer.md"))
+	if readErr != nil {
+		t.Fatalf("reading existing agent: %v", readErr)
+	}
+	if string(content) != existingContent {
+		t.Fatalf("existing agent changed after validation error:\n%s", string(content))
+	}
+}
+
+func TestRenderRuleFilesFromSourceSetReplacesSymlinkTargetsSafely(t *testing.T) {
+	sourceSet := CorpusSourceSet{
+		Rules: map[string]RuleSource{
+			"general": {
+				Description: "General rules",
+				AppliesTo:   []string{"**/*"},
+				Always:      true,
+				Body:        "General body",
+			},
+		},
+		Skills: map[string]SkillSource{},
+		Agents: map[string]AgentSource{},
+	}
+	dst := filepath.Join(t.TempDir(), "rules")
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("creating rules directory: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.mdc")
+	const outsideContent = "outside\n"
+	if err := os.WriteFile(outside, []byte(outsideContent), 0o600); err != nil {
+		t.Fatalf("writing outside file: %v", err)
+	}
+	target := filepath.Join(dst, "general.mdc")
+	if err := os.Symlink(outside, target); err != nil {
+		t.Fatalf("creating target symlink: %v", err)
+	}
+
+	if err := RenderRuleFilesFromSourceSet(sourceSet, dst, ".mdc", RuleTargetCursor, RuleRenderStyle{}); err != nil {
+		t.Fatalf("RenderRuleFilesFromSourceSet: %v", err)
+	}
+	outsidePayload, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatalf("reading outside file: %v", err)
+	}
+	if string(outsidePayload) != outsideContent {
+		t.Fatalf("outside file changed through symlink:\n%s", outsidePayload)
+	}
+	info, err := os.Lstat(target)
+	if err != nil {
+		t.Fatalf("lstat rendered rule: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("rendered rule remained a symlink")
+	}
+}
+
+func TestRenderSkillDirsFromSourceSetRejectsNestedSymlink(t *testing.T) {
+	sourceSet := CorpusSourceSet{
+		Rules: map[string]RuleSource{},
+		Skills: map[string]SkillSource{
+			"nested": {
+				Name: "nested",
+				Files: map[string]string{
+					"SKILL.md":            "---\nname: nested\ndescription: Nested skill.\n---\n",
+					"references/guide.md": "guide\n",
+				},
+			},
+		},
+		Agents: map[string]AgentSource{},
+	}
+	dst := filepath.Join(t.TempDir(), "skills")
+	targetDir := filepath.Join(dst, "nested")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("creating skill directory: %v", err)
+	}
+	outside := t.TempDir()
+	outsideGuide := filepath.Join(outside, "guide.md")
+	if err := os.WriteFile(outsideGuide, []byte("outside\n"), 0o600); err != nil {
+		t.Fatalf("writing outside guide: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(targetDir, "references")); err != nil {
+		t.Fatalf("creating nested symlink: %v", err)
+	}
+
+	err := RenderSkillDirsFromSourceSet(sourceSet, dst, SkillRefMD)
+	if err == nil {
+		t.Fatal("RenderSkillDirsFromSourceSet() returned nil, want nested symlink error")
+	}
+	if !strings.Contains(err.Error(), "path component") {
+		t.Fatalf("RenderSkillDirsFromSourceSet() error = %v, want nested symlink error", err)
+	}
+	content, readErr := os.ReadFile(outsideGuide)
+	if readErr != nil {
+		t.Fatalf("reading outside guide: %v", readErr)
+	}
+	if string(content) != "outside\n" {
+		t.Fatalf("outside guide changed through nested symlink: %s", content)
+	}
+}
+
+func TestRenderRulesAsInstructionDocFromSourceSetRemovesStaleManagedOutput(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "AGENTS.md")
+	content := GeneratedAgentHTMLMarker + "\nmanaged\n"
+	if err := os.WriteFile(destination, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing managed instruction document: %v", err)
+	}
+	sourceSet := CorpusSourceSet{
+		Rules:  map[string]RuleSource{},
+		Skills: map[string]SkillSource{},
+		Agents: map[string]AgentSource{},
+	}
+
+	if err := RenderRulesAsInstructionDocFromSourceSet(
+		sourceSet,
+		destination,
+		"Instructions",
+		RuleRenderStyle{},
+	); err != nil {
+		t.Fatalf("RenderRulesAsInstructionDocFromSourceSet() returned error: %v", err)
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Fatalf("managed instruction document still exists: %v", err)
+	}
+}
+
+func TestRenderRulesAsInstructionDocFromSourceSetPreservesUnmanagedOutput(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "AGENTS.md")
+	const content = "user-owned\n"
+	if err := os.WriteFile(destination, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing unmanaged instruction document: %v", err)
+	}
+	sourceSet := CorpusSourceSet{
+		Rules:  map[string]RuleSource{},
+		Skills: map[string]SkillSource{},
+		Agents: map[string]AgentSource{},
+	}
+
+	if err := RenderRulesAsInstructionDocFromSourceSet(
+		sourceSet,
+		destination,
+		"Instructions",
+		RuleRenderStyle{},
+	); err != nil {
+		t.Fatalf("RenderRulesAsInstructionDocFromSourceSet() returned error: %v", err)
+	}
+	rendered, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("reading unmanaged instruction document: %v", err)
+	}
+	if string(rendered) != content {
+		t.Fatalf("unmanaged instruction document = %q, want %q", rendered, content)
+	}
+}

--- a/dots/internal/sync/corpus/agent_fallbacks.go
+++ b/dots/internal/sync/corpus/agent_fallbacks.go
@@ -1,0 +1,63 @@
+package corpus
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"goodkind.io/.dotfiles/internal/sync/compilation"
+)
+
+const agentFallbackPrefix = "agent-"
+
+func withAgentFallbackSkills(sourceSet compilation.CorpusSourceSet) (compilation.CorpusSourceSet, error) {
+	skills := make(map[string]compilation.SkillSource, len(sourceSet.Skills)+len(sourceSet.Agents))
+	for name, skill := range sourceSet.Skills {
+		skills[name] = skill
+	}
+
+	agentNames := make([]string, 0, len(sourceSet.Agents))
+	for name := range sourceSet.Agents {
+		agentNames = append(agentNames, name)
+	}
+	sort.Strings(agentNames)
+
+	for _, agentName := range agentNames {
+		skillName := agentFallbackPrefix + agentName
+		if _, exists := skills[skillName]; exists {
+			return sourceSet, fmt.Errorf("duplicate skill %q", skillName)
+		}
+		agent := sourceSet.Agents[agentName]
+		skills[skillName] = compilation.SkillSource{
+			Name: skillName,
+			Files: map[string]string{
+				"SKILL.md": renderAgentFallbackSkill(skillName, agent),
+			},
+		}
+	}
+
+	sourceSet.Skills = skills
+	return sourceSet, nil
+}
+
+func renderAgentFallbackSkill(skillName string, agent compilation.AgentSource) string {
+	var builder strings.Builder
+	builder.WriteString("---\nname: ")
+	builder.WriteString(skillName)
+	builder.WriteString("\ndescription: Apply the ")
+	builder.WriteString(agent.Name)
+	builder.WriteString(" agent contract without subagent context isolation.\n---\n\n")
+	builder.WriteString("# ")
+	builder.WriteString(agent.Name)
+	builder.WriteString(" agent fallback\n\n")
+	builder.WriteString("This skill applies the `")
+	builder.WriteString(agent.Name)
+	builder.WriteString("` agent contract in the current conversation. This harness does not provide prompt-bearing subagent isolation, so this skill does not create a separate context.\n\n")
+	if agent.ReadOnly {
+		builder.WriteString("This fallback is read-only. Use only tools that inspect files, search content, or retrieve evidence. Do not edit files, run mutating commands, or change external state.\n\n")
+	}
+	builder.WriteString("## Prompt contract\n\n")
+	builder.WriteString(strings.TrimSpace(agent.Body))
+	builder.WriteString("\n")
+	return builder.String()
+}

--- a/dots/internal/sync/corpus/corpus.go
+++ b/dots/internal/sync/corpus/corpus.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 
@@ -24,7 +25,16 @@ const ManifestName = "targets.toml"
 // OutputKind is the artifact kind an output produces.
 type OutputKind string
 
+// SourceKind is the kind of imported corpus source to load before rendering.
+type SourceKind string
+
+// ProviderName identifies one corpus output provider.
+type ProviderName string
+
 const (
+	// KindSubmoduleImport loads selected artifacts from a checked-out submodule.
+	KindSubmoduleImport SourceKind = "submodule-import"
+
 	// KindSkills renders skill directories from corpus/skills.
 	KindSkills OutputKind = "skills"
 	// KindRuleFiles writes each rule as a marker-stamped file.
@@ -33,6 +43,17 @@ const (
 	KindInstructionDoc OutputKind = "instruction-doc"
 	// KindPerFileInstructions renders each rule as a .instructions.md file.
 	KindPerFileInstructions OutputKind = "per-file-instructions"
+	// KindAgents renders native agent definitions for one provider.
+	KindAgents OutputKind = "agents"
+)
+
+const (
+	providerAgents  ProviderName = "agents"
+	providerClaude  ProviderName = "claude"
+	providerCursor  ProviderName = "cursor"
+	providerGemini  ProviderName = "gemini"
+	providerCodex   ProviderName = "codex"
+	providerCopilot ProviderName = "copilot"
 )
 
 // RefStyleName names a skill rule-reference style.
@@ -47,7 +68,7 @@ const (
 
 // Output is one declarative fan-out artifact.
 type Output struct {
-	Provider  string       `toml:"provider"`
+	Provider  ProviderName `toml:"provider"`
 	Kind      OutputKind   `toml:"kind"`
 	Dest      string       `toml:"dest"`
 	RefStyle  RefStyleName `toml:"ref_style"`
@@ -57,8 +78,22 @@ type Output struct {
 	OS        string       `toml:"os"`
 }
 
+// Source is one imported source declaration in the corpus manifest.
+type Source struct {
+	Name             string     `toml:"name"`
+	Kind             SourceKind `toml:"kind"`
+	Root             string     `toml:"root"`
+	SourceURL        string     `toml:"source_url"`
+	SourceBranch     string     `toml:"source_branch"`
+	WorkingAgreement string     `toml:"working_agreement"`
+	Skills           []string   `toml:"skills"`
+	Agents           []string   `toml:"agents"`
+	ReadOnlyAgents   []string   `toml:"read_only_agents"`
+}
+
 // Manifest is the parsed targets.toml.
 type Manifest struct {
+	Sources []Source `toml:"source"`
 	Outputs []Output `toml:"output"`
 }
 
@@ -77,6 +112,16 @@ func LoadManifest(path string) (Manifest, error) {
 	return manifest, nil
 }
 
+// LoadSourceSet loads local and imported corpus artifacts into one normalized set.
+func LoadSourceSet(dotfiles string) (compilation.CorpusSourceSet, error) {
+	corpusPaths := compilation.ResolveCorpusSource(dotfiles)
+	manifest, err := LoadManifest(filepath.Join(corpusPaths.Root, ManifestName))
+	if err != nil {
+		return compilation.CorpusSourceSet{}, err
+	}
+	return loadSourceSet(dotfiles, manifest)
+}
+
 // Sync renders every manifest output that applies to the running OS.
 func Sync(ctx context.Context, dotfiles string, logger *telemetry.Logger) error {
 	_ = logger
@@ -87,25 +132,52 @@ func Sync(ctx context.Context, dotfiles string, logger *telemetry.Logger) error 
 		return fmt.Errorf("resolving home directory: %w", err)
 	}
 
-	source := compilation.ResolveCorpusSource(dotfiles)
-	manifest, err := LoadManifest(filepath.Join(source.Root, ManifestName))
+	corpusPaths := compilation.ResolveCorpusSource(dotfiles)
+	manifest, err := LoadManifest(filepath.Join(corpusPaths.Root, ManifestName))
+	if err != nil {
+		return err
+	}
+	sourceSet, err := loadSourceSet(dotfiles, manifest)
 	if err != nil {
 		return err
 	}
 
+	if err := preflightOutputPlans(sourceSet, manifest.Outputs, home); err != nil {
+		return err
+	}
 	for _, output := range manifest.Outputs {
 		if output.OS != "" && output.OS != runtime.GOOS {
 			continue
 		}
-		dest := filepath.Join(home, output.Dest)
-		if err := renderOutput(source, output, home, dest); err != nil {
+		dest, err := resolveOutputDest(home, output.Dest)
+		if err != nil {
+			return err
+		}
+		if err := renderOutput(sourceSet, output, home, dest); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func renderOutput(source compilation.CorpusPaths, output Output, home string, dest string) error {
+func preflightOutputPlans(sourceSet compilation.CorpusSourceSet, outputs []Output, home string) error {
+	for _, output := range outputs {
+		if output.OS != "" && output.OS != runtime.GOOS {
+			continue
+		}
+		dest, err := resolveOutputDest(home, output.Dest)
+		if err != nil {
+			return err
+		}
+		if err := validateOutput(sourceSet, output, home, dest); err != nil {
+			slog.Warn("corpus: preflighting output", "provider", output.Provider, "kind", output.Kind, "err", err)
+			return fmt.Errorf("preflighting %s output for %s: %w", output.Kind, output.Provider, err)
+		}
+	}
+	return nil
+}
+
+func validateOutput(sourceSet compilation.CorpusSourceSet, output Output, home string, dest string) error {
 	var err error
 	switch output.Kind {
 	case KindSkills:
@@ -113,7 +185,134 @@ func renderOutput(source compilation.CorpusPaths, output Output, home string, de
 		if styleErr != nil {
 			return styleErr
 		}
-		err = compilation.RenderSkillDirs(source.Skills, dest, style)
+		renderSourceSet := sourceSet
+		if output.Provider == providerAgents {
+			renderSourceSet, err = withAgentFallbackSkills(sourceSet)
+			if err != nil {
+				return err
+			}
+		}
+		if err := compilation.ValidateSkillDirsFromSourceSet(renderSourceSet, dest, style); err != nil {
+			slog.Warn("corpus: validating skill output", "provider", output.Provider, "err", err)
+			return fmt.Errorf("validating skill output: %w", err)
+		}
+		return nil
+	case KindRuleFiles:
+		return validateRuleFileOutput(sourceSet, output, home, dest)
+	case KindInstructionDoc:
+		if output.Title == "" {
+			return fmt.Errorf("instruction-doc output for %s requires title", output.Provider)
+		}
+		ruleStyle, styleErr := resolveRuleRenderStyle(output, home, dest)
+		if styleErr != nil {
+			return styleErr
+		}
+		if err := compilation.ValidateRulesAsInstructionDocFromSourceSet(sourceSet, dest, ruleStyle); err != nil {
+			slog.Warn("corpus: validating instruction document", "provider", output.Provider, "err", err)
+			return fmt.Errorf("validating instruction document: %w", err)
+		}
+		return nil
+	case KindPerFileInstructions:
+		ruleStyle, styleErr := resolveRuleRenderStyle(output, home, dest)
+		if styleErr != nil {
+			return styleErr
+		}
+		if err := compilation.ValidateCopilotInstructionFilesFromSourceSet(sourceSet, dest, ruleStyle); err != nil {
+			slog.Warn("corpus: validating Copilot instructions", "provider", output.Provider, "err", err)
+			return fmt.Errorf("validating Copilot instructions: %w", err)
+		}
+		return nil
+	case KindAgents:
+		format, formatErr := resolveAgentFormat(output.Provider)
+		if formatErr != nil {
+			return formatErr
+		}
+		if err := compilation.ValidateAgentFiles(sourceSet.Agents, dest, format); err != nil {
+			slog.Warn("corpus: validating agent output", "provider", output.Provider, "err", err)
+			return fmt.Errorf("validating agent output: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown output kind %q for %s", output.Kind, output.Provider)
+	}
+}
+
+func validateRuleFileOutput(sourceSet compilation.CorpusSourceSet, output Output, home string, dest string) error {
+	if output.RuleExt == "" {
+		return fmt.Errorf("rule-files output for %s requires rule_ext", output.Provider)
+	}
+	ruleStyle, err := resolveRuleRenderStyle(output, home, dest)
+	if err != nil {
+		return err
+	}
+	format, err := compilation.RuleTargetFormatFromExt(output.RuleExt)
+	if err != nil {
+		slog.Warn("corpus: resolving rule format", "provider", output.Provider, "err", err)
+		return fmt.Errorf("unsupported rule_ext %q for %s: %w", output.RuleExt, output.Provider, err)
+	}
+	if err := compilation.ValidateRuleFilesFromSourceSet(sourceSet, dest, output.RuleExt, format, ruleStyle); err != nil {
+		slog.Warn("corpus: validating rule output", "provider", output.Provider, "err", err)
+		return fmt.Errorf("validating rule output: %w", err)
+	}
+	return nil
+}
+
+func resolveOutputDest(home string, relativeDest string) (string, error) {
+	cleanHome := filepath.Clean(home)
+	cleanDest := filepath.Clean(relativeDest)
+
+	if filepath.IsAbs(cleanDest) {
+		return "", fmt.Errorf("output destination %q escapes home directory %s", relativeDest, cleanHome)
+	}
+	if cleanDest == "." {
+		return "", fmt.Errorf("output destination %q must name a path below %s", relativeDest, cleanHome)
+	}
+	joined := filepath.Clean(filepath.Join(cleanHome, cleanDest))
+	if !strings.HasPrefix(joined, cleanHome+string(os.PathSeparator)) {
+		return "", fmt.Errorf("output destination %q escapes home directory %s", relativeDest, cleanHome)
+	}
+	resolvedHome, err := filepath.EvalSymlinks(cleanHome)
+	if err != nil {
+		slog.Warn("corpus: resolving home directory", "home", cleanHome, "err", err)
+		return "", fmt.Errorf("resolving home directory %s: %w", cleanHome, err)
+	}
+	existingPath := joined
+	for {
+		resolvedParent, resolveErr := filepath.EvalSymlinks(existingPath)
+		if resolveErr == nil {
+			if resolvedParent != resolvedHome && !strings.HasPrefix(resolvedParent, resolvedHome+string(os.PathSeparator)) {
+				return "", fmt.Errorf("output destination %q resolves outside home directory %s", relativeDest, cleanHome)
+			}
+			break
+		}
+		if !os.IsNotExist(resolveErr) {
+			return "", fmt.Errorf("resolving output destination path %s: %w", existingPath, resolveErr)
+		}
+		nextPath := filepath.Dir(existingPath)
+		if nextPath == existingPath {
+			return "", fmt.Errorf("resolving output destination path %s: %w", existingPath, resolveErr)
+		}
+		existingPath = nextPath
+	}
+	return joined, nil
+}
+
+func renderOutput(sourceSet compilation.CorpusSourceSet, output Output, home string, dest string) error {
+	var err error
+	switch output.Kind {
+	case KindSkills:
+		style, styleErr := resolveRefStyle(output.RefStyle)
+		if styleErr != nil {
+			return styleErr
+		}
+		renderSourceSet := sourceSet
+		if output.Provider == providerAgents {
+			renderSourceSet, err = withAgentFallbackSkills(sourceSet)
+			if err != nil {
+				return err
+			}
+		}
+		err = compilation.RenderSkillDirsFromSourceSet(renderSourceSet, dest, style)
 	case KindRuleFiles:
 		if output.RuleExt == "" {
 			return fmt.Errorf("rule-files output for %s requires rule_ext", output.Provider)
@@ -127,7 +326,7 @@ func renderOutput(source compilation.CorpusPaths, output Output, home string, de
 			slog.Error("corpus: unsupported rule_ext", "provider", output.Provider, "rule_ext", output.RuleExt, "err", formatErr)
 			return fmt.Errorf("unsupported rule_ext %q for %s: %w", output.RuleExt, output.Provider, formatErr)
 		}
-		err = compilation.RenderRuleFiles(source.Rules, dest, output.RuleExt, format, ruleStyle)
+		err = compilation.RenderRuleFilesFromSourceSet(sourceSet, dest, output.RuleExt, format, ruleStyle)
 	case KindInstructionDoc:
 		if output.Title == "" {
 			return fmt.Errorf("instruction-doc output for %s requires title", output.Provider)
@@ -136,13 +335,19 @@ func renderOutput(source compilation.CorpusPaths, output Output, home string, de
 		if ruleStyleErr != nil {
 			return ruleStyleErr
 		}
-		err = compilation.RenderRulesAsInstructionDoc(source.Rules, dest, output.Title, ruleStyle)
+		err = compilation.RenderRulesAsInstructionDocFromSourceSet(sourceSet, dest, output.Title, ruleStyle)
 	case KindPerFileInstructions:
 		ruleStyle, ruleStyleErr := resolveRuleRenderStyle(output, home, dest)
 		if ruleStyleErr != nil {
 			return ruleStyleErr
 		}
-		err = compilation.RenderCopilotInstructionFiles(source.Rules, dest, ruleStyle)
+		err = compilation.RenderCopilotInstructionFilesFromSourceSet(sourceSet, dest, ruleStyle)
+	case KindAgents:
+		format, formatErr := resolveAgentFormat(output.Provider)
+		if formatErr != nil {
+			return formatErr
+		}
+		err = compilation.RenderAgentFiles(sourceSet.Agents, dest, format)
 	default:
 		return fmt.Errorf("unknown output kind %q for %s", output.Kind, output.Provider)
 	}
@@ -153,6 +358,25 @@ func renderOutput(source compilation.CorpusPaths, output Output, home string, de
 	return nil
 }
 
+func resolveAgentFormat(provider ProviderName) (compilation.AgentTargetFormat, error) {
+	switch provider {
+	case providerClaude:
+		return compilation.AgentTargetClaude, nil
+	case providerCursor:
+		return compilation.AgentTargetCursor, nil
+	case providerGemini:
+		return compilation.AgentTargetGemini, nil
+	case providerCodex:
+		return compilation.AgentTargetCodex, nil
+	case providerCopilot:
+		return compilation.AgentTargetCopilot, nil
+	case providerAgents:
+		return "", fmt.Errorf("unsupported agent provider %q", provider)
+	default:
+		return "", fmt.Errorf("unsupported agent provider %q", provider)
+	}
+}
+
 func resolveRuleRenderStyle(output Output, home string, dest string) (compilation.RuleRenderStyle, error) {
 	emptyStyle := compilation.RuleRenderStyle{SkillsRelDir: ""}
 	if output.SkillDest == "" {
@@ -160,7 +384,7 @@ func resolveRuleRenderStyle(output Output, home string, dest string) (compilatio
 	}
 	var linkBase string
 	switch output.Kind {
-	case KindSkills:
+	case KindSkills, KindAgents:
 		return emptyStyle, nil
 	case KindRuleFiles, KindPerFileInstructions:
 		linkBase = dest

--- a/dots/internal/sync/corpus/corpus_test.go
+++ b/dots/internal/sync/corpus/corpus_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -187,5 +188,244 @@ func TestSyncRendersProviderFrontmatter(t *testing.T) {
 	}
 	if frontmatterStringField(t, string(copilotRule), "applyTo") != "*.md" {
 		t.Errorf("copilot applyTo mismatch:\n%s", string(copilotRule))
+	}
+}
+
+func TestSyncRendersImportedAgentsAndFallbackSkills(t *testing.T) {
+	dotfiles := t.TempDir()
+	importedRoot := filepath.Join(dotfiles, "lib", "reliability")
+	writeFile(t, filepath.Join(importedRoot, "working-agreements.md"), "# Agreements\n\n```text\nVerify the premise.\n```\n")
+	writeFile(t, filepath.Join(importedRoot, "skills", "trace", "SKILL.md"), "---\nname: trace-the-chain\ndescription: Trace evidence.\n---\n\nTrace body.\n")
+	writeFile(t, filepath.Join(importedRoot, "agents", "code.md"), "---\nname: code-implementer\ndescription: Implement settled designs.\n---\n\nImplement body.\n")
+	writeFile(t, filepath.Join(importedRoot, "agents", "evidence.md"), "---\nname: evidence-gatherer\ndescription: Gather cited evidence.\n---\n\nGather body.\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", ManifestName), `[[source]]
+name = "reliability"
+kind = "submodule-import"
+root = "lib/reliability"
+working_agreement = "working-agreements.md"
+skills = ["skills/trace/SKILL.md"]
+agents = ["agents/code.md", "agents/evidence.md"]
+read_only_agents = ["evidence-gatherer"]
+
+[[output]]
+provider = "agents"
+kind = "skills"
+dest = ".agents/skills"
+ref_style = "md"
+
+[[output]]
+provider = "claude"
+kind = "agents"
+dest = ".claude/agents"
+
+[[output]]
+provider = "cursor"
+kind = "agents"
+dest = ".cursor/agents"
+
+[[output]]
+provider = "gemini"
+kind = "agents"
+dest = ".gemini/agents"
+
+[[output]]
+provider = "codex"
+kind = "agents"
+dest = ".codex/agents"
+
+[[output]]
+provider = "copilot"
+kind = "agents"
+dest = ".copilot/agents"
+`)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := Sync(context.Background(), dotfiles, nil); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	assertions := map[string]string{
+		filepath.Join(home, ".agents", "skills", "trace-the-chain", "SKILL.md"):         "Trace body.",
+		filepath.Join(home, ".agents", "skills", "agent-code-implementer", "SKILL.md"):  "does not provide prompt-bearing subagent isolation",
+		filepath.Join(home, ".agents", "skills", "agent-evidence-gatherer", "SKILL.md"): "This fallback is read-only.",
+		filepath.Join(home, ".claude", "agents", "code-implementer.md"):                 "Implement body.",
+		filepath.Join(home, ".cursor", "agents", "evidence-gatherer.md"):                "readonly: true",
+		filepath.Join(home, ".gemini", "agents", "code-implementer.md"):                 "Implement body.",
+		filepath.Join(home, ".codex", "agents", "evidence-gatherer.toml"):               "Gather body.",
+		filepath.Join(home, ".copilot", "agents", "code-implementer.agent.md"):          "Implement body.",
+	}
+	for path, expected := range assertions {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		if !strings.Contains(string(content), expected) {
+			t.Errorf("%s missing %q:\n%s", path, expected, string(content))
+		}
+	}
+	codexPath := filepath.Join(home, ".codex", "agents", "evidence-gatherer.toml")
+	codexContent, err := os.ReadFile(codexPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", codexPath, err)
+	}
+	var codexAgent struct {
+		SandboxMode string `toml:"sandbox_mode"`
+	}
+	if err := toml.Unmarshal(codexContent, &codexAgent); err != nil {
+		t.Fatalf("decoding %s: %v", codexPath, err)
+	}
+	if codexAgent.SandboxMode != "read-only" {
+		t.Fatalf("Codex sandbox_mode = %q, want read-only", codexAgent.SandboxMode)
+	}
+}
+
+func TestSyncValidationFailurePreservesExistingOutputs(t *testing.T) {
+	dotfiles := t.TempDir()
+	importedRoot := filepath.Join(dotfiles, "lib", "reliability")
+	writeFile(t, filepath.Join(importedRoot, "agents", "broken.md"), "missing front matter\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", ManifestName), `[[source]]
+name = "reliability"
+kind = "submodule-import"
+root = "lib/reliability"
+agents = ["agents/broken.md"]
+
+[[output]]
+provider = "claude"
+kind = "agents"
+dest = ".claude/agents"
+`)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	existingPath := filepath.Join(home, ".claude", "agents", "code-implementer.md")
+	const existingContent = "existing managed output\n"
+	writeFile(t, existingPath, existingContent)
+
+	if err := Sync(context.Background(), dotfiles, nil); err == nil {
+		t.Fatal("Sync expected validation error, got nil")
+	}
+	content, err := os.ReadFile(existingPath)
+	if err != nil {
+		t.Fatalf("reading existing output: %v", err)
+	}
+	if string(content) != existingContent {
+		t.Errorf("existing output changed after validation failure:\n%s", string(content))
+	}
+}
+
+func TestSyncPreflightUsesExistingDestinations(t *testing.T) {
+	dotfiles := t.TempDir()
+	importedRoot := filepath.Join(dotfiles, "lib", "reliability")
+	writeFile(t, filepath.Join(importedRoot, "agents", "code.md"), "---\nname: code-implementer\ndescription: Implement code.\n---\n\nImplement.\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", "skills", "conflict", "SKILL.md"), "---\nname: conflict\ndescription: Conflict.\n---\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", ManifestName), `[[source]]
+name = "reliability"
+kind = "submodule-import"
+root = "lib/reliability"
+agents = ["agents/code.md"]
+
+[[output]]
+provider = "claude"
+kind = "agents"
+dest = ".claude/agents"
+
+[[output]]
+provider = "claude"
+kind = "skills"
+dest = ".claude/skills"
+ref_style = "md"
+`)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	agentPath := filepath.Join(home, ".claude", "agents", "code-implementer.md")
+	const existingAgent = "existing agent\n"
+	writeFile(t, agentPath, existingAgent)
+	conflictPath := filepath.Join(home, ".claude", "skills", "conflict", "SKILL.md")
+	writeFile(t, conflictPath, "user-owned skill\n")
+
+	err := Sync(context.Background(), dotfiles, nil)
+	if err == nil {
+		t.Fatal("Sync() returned nil, want existing destination conflict")
+	}
+	if !strings.Contains(err.Error(), "conflict") {
+		t.Fatalf("Sync() error = %v, want conflict", err)
+	}
+	content, readErr := os.ReadFile(agentPath)
+	if readErr != nil {
+		t.Fatalf("reading existing agent: %v", readErr)
+	}
+	if string(content) != existingAgent {
+		t.Fatalf("earlier output changed before conflict: %s", content)
+	}
+}
+
+func TestSyncRejectsEscapingOutputDestination(t *testing.T) {
+	dotfiles := t.TempDir()
+	writeFile(t, filepath.Join(dotfiles, "corpus", ManifestName), "[[output]]\nprovider=\"claude\"\nkind=\"agents\"\ndest=\"../outside\"\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", "rules", "general.mdc"), "---\ndescription: General\napplies_to:\n  - \"**/*\"\nalways: true\n---\nGeneral body\n")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	err := Sync(context.Background(), dotfiles, nil)
+	if err == nil {
+		t.Fatal("Sync() returned nil, want output destination error")
+	}
+	if !strings.Contains(err.Error(), "escapes home directory") {
+		t.Fatalf("Sync() error = %v, want destination containment failure", err)
+	}
+}
+
+func TestResolveOutputDestRejectsHomeDirectory(t *testing.T) {
+	home := t.TempDir()
+	for _, destination := range []string{"", "."} {
+		t.Run(destination, func(t *testing.T) {
+			_, err := resolveOutputDest(home, destination)
+			if err == nil {
+				t.Fatalf("resolveOutputDest(%q) returned nil, want strict descendant error", destination)
+			}
+			if !strings.Contains(err.Error(), "must name a path below") {
+				t.Fatalf("resolveOutputDest(%q) error = %v, want strict descendant failure", destination, err)
+			}
+		})
+	}
+}
+
+func TestResolveOutputDestRejectsSymlinkEscape(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir()
+	linkPath := filepath.Join(home, "linked")
+	if err := os.Symlink(outside, linkPath); err != nil {
+		t.Fatalf("creating destination symlink: %v", err)
+	}
+
+	_, err := resolveOutputDest(home, filepath.Join("linked", "agents"))
+	if err == nil {
+		t.Fatal("resolveOutputDest() returned nil, want symlink containment error")
+	}
+	if !strings.Contains(err.Error(), "resolves outside home directory") {
+		t.Fatalf("resolveOutputDest() error = %v, want resolved containment failure", err)
+	}
+}
+
+func TestResolveOutputDestRejectsDestinationSymlinkEscape(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatalf("creating provider directory: %v", err)
+	}
+	destination := filepath.Join(home, ".codex", "agents")
+	if err := os.Symlink(outside, destination); err != nil {
+		t.Fatalf("creating destination symlink: %v", err)
+	}
+
+	_, err := resolveOutputDest(home, filepath.Join(".codex", "agents"))
+	if err == nil {
+		t.Fatal("resolveOutputDest() returned nil, want destination symlink error")
+	}
+	if !strings.Contains(err.Error(), "resolves outside home directory") {
+		t.Fatalf("resolveOutputDest() error = %v, want destination symlink failure", err)
 	}
 }

--- a/dots/internal/sync/corpus/source_set.go
+++ b/dots/internal/sync/corpus/source_set.go
@@ -1,0 +1,338 @@
+package corpus
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"goodkind.io/.dotfiles/internal/sync/compilation"
+)
+
+type promptFrontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+func loadSourceSet(dotfiles string, manifest Manifest) (compilation.CorpusSourceSet, error) {
+	source := compilation.ResolveCorpusSource(dotfiles)
+	sourceSet := compilation.CorpusSourceSet{
+		Rules:  make(map[string]compilation.RuleSource),
+		Skills: make(map[string]compilation.SkillSource),
+		Agents: make(map[string]compilation.AgentSource),
+	}
+	if err := loadLocalRules(source.Rules, &sourceSet); err != nil {
+		return sourceSet, err
+	}
+	if err := loadLocalSkills(source.Skills, &sourceSet); err != nil {
+		return sourceSet, err
+	}
+	for _, importedSource := range manifest.Sources {
+		switch importedSource.Kind {
+		case KindSubmoduleImport:
+			if err := loadSubmoduleImport(dotfiles, importedSource, &sourceSet); err != nil {
+				return sourceSet, err
+			}
+		default:
+			return sourceSet, fmt.Errorf("unknown source kind %q for %s", importedSource.Kind, importedSource.Name)
+		}
+	}
+	return sourceSet, nil
+}
+
+func loadLocalRules(rulesDir string, sourceSet *compilation.CorpusSourceSet) error {
+	files, err := filepath.Glob(filepath.Join(rulesDir, "*.mdc"))
+	if err != nil {
+		slog.Warn("corpus: globbing local rules", "directory", rulesDir, "err", err)
+		return fmt.Errorf("globbing corpus rules: %w", err)
+	}
+	sort.Strings(files)
+	for _, file := range files {
+		content, err := os.ReadFile(filepath.Clean(file))
+		if err != nil {
+			return fmt.Errorf("reading rule %s: %w", file, err)
+		}
+		rule, err := compilation.ParseRuleSource(string(content))
+		if err != nil {
+			return fmt.Errorf("parsing rule %s: %w", file, err)
+		}
+		name := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
+		if err := addRule(sourceSet, name, rule); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadLocalSkills(skillsDir string, sourceSet *compilation.CorpusSourceSet) error {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		slog.Warn("corpus: reading local skills", "directory", skillsDir, "err", err)
+		return fmt.Errorf("reading corpus skills: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillDir := filepath.Join(skillsDir, entry.Name())
+		files, err := readSkillFiles(skillDir)
+		if err != nil {
+			return err
+		}
+		if err := addSkill(sourceSet, compilation.SkillSource{Name: entry.Name(), Files: files}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readSkillFiles(skillDir string) (map[string]string, error) {
+	files := make(map[string]string)
+	if err := readSkillFilesInDir(skillDir, "", files); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func readSkillFilesInDir(skillDir string, relativeDir string, files map[string]string) error {
+	currentDir := filepath.Join(skillDir, relativeDir)
+	entries, err := os.ReadDir(currentDir)
+	if err != nil {
+		slog.Warn("corpus: reading skill directory", "directory", currentDir, "err", err)
+		return fmt.Errorf("reading skill directory %s: %w", currentDir, err)
+	}
+	for _, entry := range entries {
+		relativePath := filepath.Join(relativeDir, entry.Name())
+		if entry.IsDir() {
+			if err := readSkillFilesInDir(skillDir, relativePath, files); err != nil {
+				return err
+			}
+			continue
+		}
+		path := filepath.Join(skillDir, relativePath)
+		content, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return fmt.Errorf("reading skill file %s: %w", path, err)
+		}
+		files[filepath.ToSlash(relativePath)] = string(content)
+	}
+	return nil
+}
+
+func loadSubmoduleImport(dotfiles string, importedSource Source, sourceSet *compilation.CorpusSourceSet) error {
+	root, err := resolveImportedRoot(dotfiles, importedSource.Root)
+	if err != nil {
+		return err
+	}
+	if importedSource.WorkingAgreement != "" {
+		ruleName := strings.TrimSuffix(filepath.Base(importedSource.WorkingAgreement), filepath.Ext(importedSource.WorkingAgreement))
+		rule, err := loadWorkingAgreementRule(root, importedSource.WorkingAgreement)
+		if err != nil {
+			return err
+		}
+		if err := addRule(sourceSet, ruleName, rule); err != nil {
+			return err
+		}
+	}
+	for _, skillPath := range importedSource.Skills {
+		content, err := readImportedFile(root, skillPath)
+		if err != nil {
+			return err
+		}
+		name, _, _, err := parsePromptMarkdown(string(content))
+		if err != nil {
+			return err
+		}
+		if err := addSkill(sourceSet, compilation.SkillSource{Name: name, Files: map[string]string{"SKILL.md": string(content)}}); err != nil {
+			return err
+		}
+	}
+	readOnlyAgents := make(map[string]struct{}, len(importedSource.ReadOnlyAgents))
+	for _, name := range importedSource.ReadOnlyAgents {
+		readOnlyAgents[name] = struct{}{}
+	}
+	for _, agentPath := range importedSource.Agents {
+		content, err := readImportedFile(root, agentPath)
+		if err != nil {
+			return err
+		}
+		name, description, body, err := parsePromptMarkdown(string(content))
+		if err != nil {
+			return err
+		}
+		_, readOnly := readOnlyAgents[name]
+		if readOnly {
+			delete(readOnlyAgents, name)
+		}
+		if err := addAgent(sourceSet, compilation.AgentSource{
+			Name:        name,
+			Description: description,
+			Body:        body,
+			ReadOnly:    readOnly,
+		}); err != nil {
+			return err
+		}
+	}
+	if len(readOnlyAgents) > 0 {
+		unmatchedNames := make([]string, 0, len(readOnlyAgents))
+		for name := range readOnlyAgents {
+			unmatchedNames = append(unmatchedNames, name)
+		}
+		sort.Strings(unmatchedNames)
+		return fmt.Errorf("read-only agent metadata did not match imported agents: %s", strings.Join(unmatchedNames, ", "))
+	}
+	return nil
+}
+
+func resolveImportedRoot(dotfiles string, relativeRoot string) (string, error) {
+	return resolveContainedPath(dotfiles, relativeRoot, "dotfiles root", "source root")
+}
+
+func readImportedFile(root string, relativePath string) ([]byte, error) {
+	resolvedPath, err := resolveImportedPath(root, relativePath)
+	if err != nil {
+		return nil, err
+	}
+	content, err := os.ReadFile(filepath.Clean(resolvedPath))
+	if err != nil {
+		slog.Warn("corpus: reading imported file", "path", relativePath, "err", err)
+		return nil, fmt.Errorf("reading imported file %s: %w", relativePath, err)
+	}
+	return content, nil
+}
+
+func resolveImportedPath(root string, relativePath string) (string, error) {
+	return resolveContainedPath(root, relativePath, "source root", "import path")
+}
+
+func resolveContainedPath(base string, relative string, baseLabel string, pathLabel string) (string, error) {
+	cleanBase := filepath.Clean(base)
+	candidatePath := filepath.Clean(filepath.Join(cleanBase, relative))
+	if candidatePath != cleanBase && !strings.HasPrefix(candidatePath, cleanBase+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%s %q escapes %s %s", pathLabel, relative, baseLabel, cleanBase)
+	}
+	resolvedBase, err := filepath.EvalSymlinks(cleanBase)
+	if err != nil {
+		slog.Warn("corpus: resolving contained path base", "label", baseLabel, "root", cleanBase, "err", err)
+		return "", fmt.Errorf("resolving %s %s: %w", baseLabel, cleanBase, err)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(candidatePath)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s %s: %w", pathLabel, relative, err)
+	}
+	if resolvedPath != resolvedBase && !strings.HasPrefix(resolvedPath, resolvedBase+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%s %q resolves outside %s %s", pathLabel, relative, baseLabel, cleanBase)
+	}
+	return resolvedPath, nil
+}
+
+func loadWorkingAgreementRule(root string, relativePath string) (compilation.RuleSource, error) {
+	content, err := readImportedFile(root, relativePath)
+	if err != nil {
+		return compilation.RuleSource{}, err
+	}
+	body, err := extractFirstFencedBlock(string(content))
+	if err != nil {
+		slog.Warn("corpus: extracting working agreement", "path", relativePath, "err", err)
+		return compilation.RuleSource{}, fmt.Errorf("extracting working agreement body from %s: %w", relativePath, err)
+	}
+	return compilation.RuleSource{
+		Description: "Imported working agreements",
+		AppliesTo:   []string{"**/*"},
+		Always:      true,
+		Body:        body,
+	}, nil
+}
+
+func extractFirstFencedBlock(content string) (string, error) {
+	openFence := strings.Index(content, "```")
+	if openFence == -1 {
+		return "", fmt.Errorf("missing opening fenced block")
+	}
+	afterFence := content[openFence+3:]
+	newlineIndex := strings.Index(afterFence, "\n")
+	if newlineIndex == -1 {
+		return "", fmt.Errorf("missing fenced block body")
+	}
+	bodyStart := openFence + 3 + newlineIndex + 1
+	closeFence := strings.Index(content[bodyStart:], "\n```")
+	if closeFence == -1 {
+		return "", fmt.Errorf("missing closing fenced block")
+	}
+	return strings.TrimSpace(content[bodyStart : bodyStart+closeFence]), nil
+}
+
+func parsePromptMarkdown(content string) (string, string, string, error) {
+	if !strings.HasPrefix(content, "---\n") {
+		return "", "", "", fmt.Errorf("missing opening frontmatter delimiter")
+	}
+	endMarker := "\n---\n"
+	frontmatterEnd := strings.Index(content[4:], endMarker)
+	if frontmatterEnd == -1 {
+		return "", "", "", fmt.Errorf("missing closing frontmatter delimiter")
+	}
+	rawFrontmatter := content[4 : 4+frontmatterEnd]
+	var frontmatter promptFrontmatter
+	if err := yaml.Unmarshal([]byte(rawFrontmatter), &frontmatter); err != nil {
+		slog.Warn("corpus: parsing prompt frontmatter", "err", err)
+		return "", "", "", fmt.Errorf("parsing prompt front matter: %w", err)
+	}
+	promptName := strings.TrimSpace(frontmatter.Name)
+	if promptName == "" {
+		return "", "", "", fmt.Errorf("missing prompt name")
+	}
+	if err := validatePromptName(promptName); err != nil {
+		return "", "", "", err
+	}
+	if strings.TrimSpace(frontmatter.Description) == "" {
+		return "", "", "", fmt.Errorf("missing prompt description")
+	}
+	bodyStart := 4 + frontmatterEnd + len(endMarker)
+	body := strings.TrimSpace(content[bodyStart:])
+	return promptName, strings.TrimSpace(frontmatter.Description), body, nil
+}
+
+func validatePromptName(name string) error {
+	cleanName := filepath.Clean(filepath.FromSlash(name))
+	if cleanName == "." || cleanName == ".." || filepath.IsAbs(cleanName) {
+		return fmt.Errorf("invalid prompt name %q", name)
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, string(filepath.Separator)) {
+		return fmt.Errorf("invalid prompt name %q", name)
+	}
+	if strings.HasPrefix(cleanName, ".."+string(os.PathSeparator)) || cleanName != name {
+		return fmt.Errorf("invalid prompt name %q", name)
+	}
+	return nil
+}
+
+func addRule(sourceSet *compilation.CorpusSourceSet, name string, rule compilation.RuleSource) error {
+	if _, exists := sourceSet.Rules[name]; exists {
+		return fmt.Errorf("duplicate rule %q", name)
+	}
+	sourceSet.Rules[name] = rule
+	return nil
+}
+
+func addSkill(sourceSet *compilation.CorpusSourceSet, skill compilation.SkillSource) error {
+	if _, exists := sourceSet.Skills[skill.Name]; exists {
+		return fmt.Errorf("duplicate skill %q", skill.Name)
+	}
+	sourceSet.Skills[skill.Name] = skill
+	return nil
+}
+
+func addAgent(sourceSet *compilation.CorpusSourceSet, agent compilation.AgentSource) error {
+	if _, exists := sourceSet.Agents[agent.Name]; exists {
+		return fmt.Errorf("duplicate agent %q", agent.Name)
+	}
+	sourceSet.Agents[agent.Name] = agent
+	return nil
+}

--- a/dots/internal/sync/corpus/source_set_test.go
+++ b/dots/internal/sync/corpus/source_set_test.go
@@ -1,0 +1,263 @@
+package corpus
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadManifestParsesImportedSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ManifestName)
+	writeFile(t, path, strings.Join([]string{
+		"[[source]]",
+		"name = \"reliability\"",
+		"kind = \"submodule-import\"",
+		"root = \"lib/Claude-Opus-5-tools\"",
+		"source_url = \"https://github.com/Lunarsong/Claude-Opus-5-tools.git\"",
+		"source_branch = \"main\"",
+		"working_agreement = \"working-agreements.md\"",
+		"skills = [\".claude/skills/trace-the-chain/SKILL.md\"]",
+		"agents = [\".claude/agents/code-implementer.md\"]",
+		"read_only_agents = [\"code-implementer\"]",
+	}, "\n")+"\n")
+
+	manifest, err := LoadManifest(path)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if len(manifest.Sources) != 1 {
+		t.Fatalf("expected 1 source, got %d", len(manifest.Sources))
+	}
+	source := manifest.Sources[0]
+	if source.Name != "reliability" || source.Kind != KindSubmoduleImport {
+		t.Fatalf("unexpected source parsed: %+v", source)
+	}
+	if source.Root != "lib/Claude-Opus-5-tools" || source.WorkingAgreement != "working-agreements.md" {
+		t.Fatalf("unexpected source paths: %+v", source)
+	}
+	if len(source.Skills) != 1 || source.Skills[0] != ".claude/skills/trace-the-chain/SKILL.md" {
+		t.Fatalf("unexpected source skills: %+v", source.Skills)
+	}
+	if len(source.Agents) != 1 || source.Agents[0] != ".claude/agents/code-implementer.md" {
+		t.Fatalf("unexpected source agents: %+v", source.Agents)
+	}
+	if len(source.ReadOnlyAgents) != 1 || source.ReadOnlyAgents[0] != "code-implementer" {
+		t.Fatalf("unexpected read-only agents: %+v", source.ReadOnlyAgents)
+	}
+}
+
+func TestLoadSourceSetIncludesImportedArtifacts(t *testing.T) {
+	dotfiles := t.TempDir()
+	writeFile(t, filepath.Join(dotfiles, "corpus", "rules", "general.mdc"), strings.Join([]string{
+		"---",
+		"description: General rules",
+		"applies_to:",
+		"  - \"**/*\"",
+		"always: true",
+		"---",
+		"General body",
+	}, "\n")+"\n")
+	writeFile(t, filepath.Join(dotfiles, "corpus", "skills", "local-skill", "SKILL.md.tmpl"), strings.Join([]string{
+		"---",
+		"name: local-skill",
+		"description: local",
+		"---",
+		"",
+		"Local body",
+	}, "\n")+"\n")
+	writeFile(t, filepath.Join(dotfiles, "lib", "Claude-Opus-5-tools", "working-agreements.md"), strings.Join([]string{
+		"# Working agreements",
+		"",
+		"```markdown",
+		"## Subagent Working Agreements",
+		"",
+		"- Verify the brief first.",
+		"```",
+	}, "\n")+"\n")
+	writeFile(t, filepath.Join(dotfiles, "lib", "Claude-Opus-5-tools", ".claude", "skills", "trace-the-chain", "SKILL.md"), strings.Join([]string{
+		"---",
+		"name: trace-the-chain",
+		"description: imported skill",
+		"---",
+		"",
+		"Trace body",
+	}, "\n")+"\n")
+	writeFile(t, filepath.Join(dotfiles, "lib", "Claude-Opus-5-tools", ".claude", "agents", "code-implementer.md"), strings.Join([]string{
+		"---",
+		"name: code-implementer",
+		"description: imported agent",
+		"---",
+		"",
+		"Implement body",
+	}, "\n")+"\n")
+	manifest := Manifest{
+		Sources: []Source{{
+			Name:             "reliability",
+			Kind:             KindSubmoduleImport,
+			Root:             "lib/Claude-Opus-5-tools",
+			WorkingAgreement: "working-agreements.md",
+			Skills:           []string{".claude/skills/trace-the-chain/SKILL.md"},
+			Agents:           []string{".claude/agents/code-implementer.md"},
+			ReadOnlyAgents:   []string{"code-implementer"},
+		}},
+	}
+
+	sourceSet, err := loadSourceSet(dotfiles, manifest)
+	if err != nil {
+		t.Fatalf("loadSourceSet() returned error: %v", err)
+	}
+	if _, ok := sourceSet.Rules["general"]; !ok {
+		t.Fatalf("local rules missing from source set: %#v", sourceSet.Rules)
+	}
+	workingAgreements, ok := sourceSet.Rules["working-agreements"]
+	if !ok {
+		t.Fatalf("imported working agreement rule missing: %#v", sourceSet.Rules)
+	}
+	if !workingAgreements.Always {
+		t.Fatalf("working agreements rule should always apply: %+v", workingAgreements)
+	}
+	if !strings.Contains(workingAgreements.Body, "## Subagent Working Agreements") {
+		t.Fatalf("working agreements body was not extracted from fenced block: %q", workingAgreements.Body)
+	}
+	traceSkill, ok := sourceSet.Skills["trace-the-chain"]
+	if !ok {
+		t.Fatalf("imported skill missing from source set: %#v", sourceSet.Skills)
+	}
+	if traceSkill.Files["SKILL.md"] == "" {
+		t.Fatalf("imported skill files missing SKILL.md: %#v", traceSkill.Files)
+	}
+	codeImplementer, ok := sourceSet.Agents["code-implementer"]
+	if !ok {
+		t.Fatalf("imported agent missing from source set: %#v", sourceSet.Agents)
+	}
+	if codeImplementer.Description != "imported agent" || !strings.Contains(codeImplementer.Body, "Implement body") {
+		t.Fatalf("unexpected imported agent content: %+v", codeImplementer)
+	}
+	if !codeImplementer.ReadOnly {
+		t.Fatal("imported agent did not preserve manifest read-only metadata")
+	}
+}
+
+func TestLoadSourceSetRejectsDuplicateSkillNames(t *testing.T) {
+	dotfiles := t.TempDir()
+	writeFile(t, filepath.Join(dotfiles, "corpus", "skills", "trace-the-chain", "SKILL.md.tmpl"), strings.Join([]string{
+		"---",
+		"name: trace-the-chain",
+		"description: local duplicate",
+		"---",
+		"",
+		"Local duplicate",
+	}, "\n")+"\n")
+	writeFile(t, filepath.Join(dotfiles, "lib", "Claude-Opus-5-tools", ".claude", "skills", "trace-the-chain", "SKILL.md"), strings.Join([]string{
+		"---",
+		"name: trace-the-chain",
+		"description: imported duplicate",
+		"---",
+		"",
+		"Imported duplicate",
+	}, "\n")+"\n")
+	manifest := Manifest{
+		Sources: []Source{{
+			Name:   "reliability",
+			Kind:   KindSubmoduleImport,
+			Root:   "lib/Claude-Opus-5-tools",
+			Skills: []string{".claude/skills/trace-the-chain/SKILL.md"},
+		}},
+	}
+
+	_, err := loadSourceSet(dotfiles, manifest)
+	if err == nil {
+		t.Fatal("loadSourceSet() returned nil, want duplicate skill error")
+	}
+	if !strings.Contains(err.Error(), "duplicate skill") || !strings.Contains(err.Error(), "trace-the-chain") {
+		t.Fatalf("duplicate skill error = %v, want trace-the-chain duplicate", err)
+	}
+}
+
+func TestLoadSourceSetRejectsEscapedImportedRoot(t *testing.T) {
+	dotfiles := t.TempDir()
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, ".claude", "agents", "code-implementer.md"), strings.Join([]string{
+		"---",
+		"name: code-implementer",
+		"description: imported agent",
+		"---",
+		"",
+		"Implement body",
+	}, "\n")+"\n")
+	manifest := Manifest{
+		Sources: []Source{{
+			Name:   "reliability",
+			Kind:   KindSubmoduleImport,
+			Root:   filepath.Join("..", filepath.Base(outside)),
+			Agents: []string{".claude/agents/code-implementer.md"},
+		}},
+	}
+
+	_, err := loadSourceSet(dotfiles, manifest)
+	if err == nil {
+		t.Fatal("loadSourceSet() returned nil, want escaped root error")
+	}
+	if !strings.Contains(err.Error(), "escapes dotfiles root") {
+		t.Fatalf("escaped root error = %v, want containment failure", err)
+	}
+}
+
+func TestLoadSourceSetRejectsImportedPromptNameTraversal(t *testing.T) {
+	dotfiles := t.TempDir()
+	writeFile(t, filepath.Join(dotfiles, "lib", "Claude-Opus-5-tools", ".claude", "agents", "code-implementer.md"), strings.Join([]string{
+		"---",
+		"name: ../../outside",
+		"description: imported agent",
+		"---",
+		"",
+		"Implement body",
+	}, "\n")+"\n")
+	manifest := Manifest{
+		Sources: []Source{{
+			Name:   "reliability",
+			Kind:   KindSubmoduleImport,
+			Root:   "lib/Claude-Opus-5-tools",
+			Agents: []string{".claude/agents/code-implementer.md"},
+		}},
+	}
+
+	_, err := loadSourceSet(dotfiles, manifest)
+	if err == nil {
+		t.Fatal("loadSourceSet() returned nil, want invalid prompt name error")
+	}
+	if !strings.Contains(err.Error(), "invalid prompt name") {
+		t.Fatalf("invalid prompt name error = %v, want prompt name validation", err)
+	}
+}
+
+func TestLoadSourceSetRejectsUnmatchedReadOnlyAgent(t *testing.T) {
+	dotfiles := t.TempDir()
+	agentPath := filepath.Join(dotfiles, "lib", "reliability", "agents", "evidence.md")
+	writeFile(t, agentPath, strings.Join([]string{
+		"---",
+		"name: renamed-evidence-gatherer",
+		"description: imported agent",
+		"---",
+		"",
+		"Gather evidence",
+	}, "\n")+"\n")
+	manifest := Manifest{
+		Sources: []Source{{
+			Name:           "reliability",
+			Kind:           KindSubmoduleImport,
+			Root:           "lib/reliability",
+			Agents:         []string{"agents/evidence.md"},
+			ReadOnlyAgents: []string{"evidence-gatherer"},
+		}},
+	}
+
+	_, err := loadSourceSet(dotfiles, manifest)
+	if err == nil {
+		t.Fatal("loadSourceSet() returned nil, want unmatched read-only agent error")
+	}
+	if !strings.Contains(err.Error(), "read-only agent") || !strings.Contains(err.Error(), "evidence-gatherer") {
+		t.Fatalf("loadSourceSet() error = %v, want unmatched read-only agent", err)
+	}
+}

--- a/dots/internal/sync/workspace/workspace.go
+++ b/dots/internal/sync/workspace/workspace.go
@@ -22,6 +22,7 @@ import (
 	"goodkind.io/.dotfiles/internal/runner"
 	"goodkind.io/.dotfiles/internal/sync/common"
 	"goodkind.io/.dotfiles/internal/sync/compilation"
+	"goodkind.io/.dotfiles/internal/sync/corpus"
 	"goodkind.io/.dotfiles/internal/telemetry"
 )
 
@@ -242,9 +243,13 @@ func SyncCursorUserRules(ctx context.Context, dotfiles string, logger *telemetry
 		return fmt.Errorf("checking cursor state.vscdb: %w", err)
 	}
 	logging.ConfigureWithLogger(logger)
-	source := compilation.ResolveCorpusSource(dotfiles)
+	sourceSet, err := corpus.LoadSourceSet(dotfiles)
+	if err != nil {
+		slog.WarnContext(ctx, "workspace: loading corpus for cursor upload", "err", err)
+		return fmt.Errorf("loading corpus for cursor upload: %w", err)
+	}
 	style := compilation.RuleRenderStyle{SkillsRelDir: "../skills"}
-	rules, err := compilation.RenderRulesForUpload(source.Rules, style)
+	rules, err := compilation.RenderRulesForUploadFromSourceSet(sourceSet, style)
 	if err != nil {
 		slog.WarnContext(ctx, "workspace: rendering corpus rules for cursor upload", "err", err)
 		return fmt.Errorf("rendering corpus rules for cursor upload: %w", err)


### PR DESCRIPTION
### Summary

Corpus sync now loads local and imported rules, skills, and agents into one validated source set before writing managed outputs.

Stacked on: https://github.com/agoodkind/.dotfiles/pull/125

## Change

The renderer preflights output conflicts and path containment, preserves unmanaged files, and produces provider-specific rules, skills, and agent definitions. Cursor uploads use the same normalized source set as file-based outputs.

## Testing

- `go test -count=1 ./cmd/dots ./internal/sync/corpus ./internal/sync/compilation ./internal/sync/workspace`
- `make check`
