### PR TITLE
Import reliability agents across providers (PR 3/3)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 [submodule "lib/zsh-defer"]
 	path = lib/zsh-defer
 	url = https://github.com/romkatv/zsh-defer.git
+[submodule "lib/Claude-Opus-5-tools"]
+	path = lib/Claude-Opus-5-tools
+	url = https://github.com/Lunarsong/Claude-Opus-5-tools.git
+	branch = main

--- a/corpus/targets.toml
+++ b/corpus/targets.toml
@@ -9,6 +9,7 @@
 #   rule-files            each rule written as a marker-stamped file (needs rule_ext)
 #   instruction-doc       all rules concatenated into one document (needs title)
 #   per-file-instructions each rule rendered as a .instructions.md file
+#   agents               native provider agent definitions
 #
 # ref_style values (skills only): mdc | md
 #
@@ -18,6 +19,28 @@
 # VSCode also reads ~/.copilot/instructions, ~/.claude/rules, and ~/.agents/skills.
 # Claude Desktop shares ~/.claude with Claude Code.
 # Cursor global user rules are uploaded to the cloud API during dots sync (not from ~/.cursor/rules).
+
+# Imported reliability methods from the branch-tracking submodule.
+[[source]]
+name              = "reliability"
+kind              = "submodule-import"
+root              = "lib/Claude-Opus-5-tools"
+source_url        = "https://github.com/Lunarsong/Claude-Opus-5-tools.git"
+source_branch     = "main"
+working_agreement = "working-agreements.md"
+skills = [
+  ".claude/skills/trace-the-chain/SKILL.md",
+  ".claude/skills/adversarial-review/SKILL.md",
+  ".claude/skills/root-cause-debugging/SKILL.md",
+  ".claude/skills/empirical-validation/SKILL.md",
+]
+agents = [
+  ".claude/agents/code-implementer.md",
+  ".claude/agents/evidence-gatherer.md",
+]
+read_only_agents = [
+  "evidence-gatherer",
+]
 
 # Claude Code (and Claude Desktop)
 [[output]]
@@ -33,6 +56,11 @@ dest       = ".claude/rules"
 rule_ext   = ".md"
 skill_dest = ".claude/skills"
 
+[[output]]
+provider = "claude"
+kind     = "agents"
+dest     = ".claude/agents"
+
 # Shared cross-agent directory (read by Zed, VSCode, and Codex)
 [[output]]
 provider  = "agents"
@@ -47,6 +75,12 @@ dest       = ".agents/rules"
 rule_ext   = ".mdc"
 skill_dest = ".agents/skills"
 
+# Cursor
+[[output]]
+provider = "cursor"
+kind     = "agents"
+dest     = ".cursor/agents"
+
 # Codex
 [[output]]
 provider   = "codex"
@@ -55,6 +89,11 @@ dest       = ".codex/AGENTS.md"
 title      = "Codex Instructions"
 skill_dest = ".agents/skills"
 
+[[output]]
+provider = "codex"
+kind     = "agents"
+dest     = ".codex/agents"
+
 # Gemini
 [[output]]
 provider   = "gemini"
@@ -62,6 +101,11 @@ kind       = "instruction-doc"
 dest       = ".gemini/GEMINI.md"
 title      = "Gemini Instructions"
 skill_dest = ".agents/skills"
+
+[[output]]
+provider = "gemini"
+kind     = "agents"
+dest     = ".gemini/agents"
 
 # GitHub Copilot
 [[output]]
@@ -76,6 +120,11 @@ provider   = "copilot"
 kind       = "per-file-instructions"
 dest       = ".copilot/instructions"
 skill_dest = ".agents/skills"
+
+[[output]]
+provider = "copilot"
+kind     = "agents"
+dest     = ".copilot/agents"
 
 # Zed (first-party agent reads user-global rules from this doc)
 [[output]]

--- a/dots/internal/freshsmoke/freshsmoke.go
+++ b/dots/internal/freshsmoke/freshsmoke.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-var requiredSmokeSubmodules = []string{"lib/zinit", "lib/zsh-defer"}
+var requiredSmokeSubmodules = []string{"lib/zinit", "lib/zsh-defer", "lib/Claude-Opus-5-tools"}
 
 // HasCommand reports whether command is findable via [exec.LookPath].
 func HasCommand(command string) bool {

--- a/dots/internal/freshsmoke/freshsmoke_test.go
+++ b/dots/internal/freshsmoke/freshsmoke_test.go
@@ -16,6 +16,12 @@ func TestInstallArgsIncludesSkipGitBeforeExtraArgs(t *testing.T) {
 	}
 }
 
+func TestRequiredSmokeSubmodulesIncludesReliabilityToolkit(t *testing.T) {
+	if !slices.Contains(requiredSmokeSubmodules, "lib/Claude-Opus-5-tools") {
+		t.Fatalf("requiredSmokeSubmodules = %v, want lib/Claude-Opus-5-tools", requiredSmokeSubmodules)
+	}
+}
+
 func TestAssertSmokeSubmodulesPresentAcceptsCheckedOutSubmodules(t *testing.T) {
 	repoRoot := t.TempDir()
 	for _, submodule := range requiredSmokeSubmodules {


### PR DESCRIPTION
### Summary

The corpus now imports the selected Claude Opus 5 reliability agreement, four skills, and two agents from a branch-tracking submodule.

Stacked on: https://github.com/agoodkind/.dotfiles/pull/128

## Change

Sync renders native agent definitions for Claude, Cursor, Gemini, Codex, and GitHub Copilot. Shared consumers receive fallback skills that preserve each prompt contract without subagent context isolation.

Fresh-host checks require the imported corpus source.

## Testing

- `go test -count=1 ./internal/freshsmoke ./internal/sync/corpus ./internal/sync/compilation`
- `make check`
- `./sync.sh --quick --skip-git --skip-cursor-sync` with a temporary home
- Gemini discovered all imported and fallback skills.
- Claude listed both generated custom agents before authentication.
