### PR TITLE
Update zsh startup test for Right Arrow acceptance

### DIFF
--- a/dots/internal/zshstartup/zshstartup_test.go
+++ b/dots/internal/zshstartup/zshstartup_test.go
@@ -132,12 +132,12 @@ source "$DOTDOTFILES/zshrc/core/plugins.zsh"
 
 _load_tier1
 _require_function _zsh_autosuggest_start
-if [[ -n ${ZSH_AUTOSUGGEST_ACCEPT_WIDGETS[(r)forward-char]} ]]; then
-    print -r -- "forward-char stayed in ZSH_AUTOSUGGEST_ACCEPT_WIDGETS"
+if [[ -z ${ZSH_AUTOSUGGEST_ACCEPT_WIDGETS[(r)forward-char]} ]]; then
+    print -r -- "forward-char is missing from ZSH_AUTOSUGGEST_ACCEPT_WIDGETS"
     exit 1
 fi
-if [[ -n ${ZSH_AUTOSUGGEST_ACCEPT_WIDGETS[(r)vi-forward-char]} ]]; then
-    print -r -- "vi-forward-char stayed in ZSH_AUTOSUGGEST_ACCEPT_WIDGETS"
+if [[ -z ${ZSH_AUTOSUGGEST_ACCEPT_WIDGETS[(r)vi-forward-char]} ]]; then
+    print -r -- "vi-forward-char is missing from ZSH_AUTOSUGGEST_ACCEPT_WIDGETS"
     exit 1
 fi
 


### PR DESCRIPTION
### Summary

The zsh startup regression now verifies that Right Arrow remains an autosuggestion acceptance widget.

## Change

The test now requires `forward-char` and `vi-forward-char` after tier 1 loads. This matches the behavior merged in PR #122 and protects the current Right Arrow contract.
