### PR TITLE
Protect GPT subagents and default branches

### DIFF
--- a/corpus/skills/gpt-subagent/SKILL.md.tmpl
+++ b/corpus/skills/gpt-subagent/SKILL.md.tmpl
@@ -1,11 +1,11 @@
 ---
 name: gpt-subagent
-description: Use GPT through the codex exec CLI as a subagent. Use when the user asks to delegate work to Codex or GPT, run a Codex review, have GPT perform a second pass, continue a Codex session, or compare host and GPT answers.
+description: Use GPT through the codex exec CLI as a subagent. Use when the user asks to delegate work to Codex or GPT, run a Codex review, have GPT perform a second pass, or compare host and GPT answers.
 ---
 
 # GPT Subagent
 
-Use `codex exec` when the user asks to delegate work to GPT through Codex. The CLI path gives observable progress, a hard timeout, and session continuation via `resume`. Do not use the Codex MCP server for subagent delegation.
+Use `codex exec` when the user asks to delegate work to GPT through Codex. The CLI path gives observable progress and a hard timeout. Do not use the Codex MCP server for subagent delegation.
 
 Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 
@@ -13,9 +13,11 @@ Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 
 Every `codex exec` dispatch uses these flags unless the user overrides them:
 
+- **Ephemeral session:** `--ephemeral`. This prevents Codex from persisting session files. Do not use `codex exec resume` or `--last`, because ephemeral runs cannot be resumed.
 - **Reasoning:** `-c model_reasoning_effort="high"`. If `codex exec` rejects `high` for the default model, drop the override.
 - **Model:** omit `-m` by default. When the user names a model or you need a non-default model, follow **Model selection** and pass `-m` only with a slug from `codex debug models`.
-- **Sandbox:** `--dangerously-bypass-approvals-and-sandbox` up front when the user has delegated work to Codex through this skill. This bypasses approval prompts and the filesystem sandbox. Do not start with `-s read-only` or `-s workspace-write` and lift sandbox later. Sandboxed runs routinely fail on `.git` writes in linked worktrees and force cache or Makefile workarounds. Scope limits ("read-only" vs "edit allowed") live in the prompt.
+- **Review sandbox:** use `-s read-only` for review, analysis, and search.
+- **Edit sandbox:** use `--dangerously-bypass-approvals-and-sandbox` only for user-authorized edit tasks. This bypasses approval prompts and the filesystem sandbox.
 
 ## Model selection
 
@@ -39,13 +41,14 @@ codex debug models >"$models_file"
 
 ## Run codex exec
 
-Start a new task with the prompt on stdin and the final answer written to a file:
+For review, analysis, and search, start a new read-only task with the prompt on stdin and the final answer written to a file:
 
 ```bash
 result_file="$(mktemp)"
 stderr_file="$(mktemp)"
 timeout 1500 codex exec \
-  --dangerously-bypass-approvals-and-sandbox \
+  --ephemeral \
+  -s read-only \
   -c model_reasoning_effort="high" \
   -o "$result_file" 2>"$stderr_file" - <<'PROMPT'
 <bounded prompt>
@@ -54,26 +57,21 @@ PROMPT
 
 GNU `timeout` is required. On macOS, use `gtimeout` from coreutils when `timeout` is not on PATH.
 
-Permissions:
-
-- Read-only analysis, review, and search: state "read-only" in the prompt and do not edit files.
-- Implementation: state "edit allowed" in the prompt when the user grants edit permission for that work.
-- The bypass flag removes approval prompts and the filesystem sandbox, so scope discipline lives in the prompt. Polling and timeout remain mandatory.
-
-Continue a prior session with `codex exec resume`:
+For user-authorized edits, use the bypass flag instead:
 
 ```bash
 result_file="$(mktemp)"
 stderr_file="$(mktemp)"
-timeout 1500 codex exec resume <session-id> \
+timeout 1500 codex exec \
+  --ephemeral \
   --dangerously-bypass-approvals-and-sandbox \
   -c model_reasoning_effort="high" \
   -o "$result_file" 2>"$stderr_file" - <<'PROMPT'
-<follow-up prompt>
+<bounded prompt>
 PROMPT
 ```
 
-Use `codex exec resume --last` when the session id is unknown and the most recent session is the right one.
+State "read-only" in review prompts, and state "edit allowed" only when the user authorized the implementation. The bypass flag removes approval prompts and the filesystem sandbox, so scope discipline lives in the prompt. Polling and timeout remain mandatory.
 
 Set `-C <dir>` when the task is scoped to a specific repository or directory.
 
@@ -113,8 +111,8 @@ After launching the background job, arm a periodic check-in loop that fires on a
 1. Read the streaming stdout from the background shell.
 2. Read `$result_file` and `$stderr_file` if they exist.
 3. Compare each snapshot to the previous one to detect no progress.
-4. Treat exit code 124 from `timeout` as a time-limit breach. That may mean the session is still healthy but needs more time, or that progress has stalled. Read stdout and `$result_file` before restarting or resuming.
-5. Steer with `codex exec resume <session-id>` or restart the run the moment progress stops.
+4. Treat exit code 124 from `timeout` as a time-limit breach. That may mean the run needs more time, or that progress has stalled. Read stdout and `$result_file` before restarting.
+5. Restart the run with a new ephemeral invocation when progress stops.
 
 Add `--json` when JSONL event streaming makes progress easier to parse.
 
@@ -126,7 +124,7 @@ The host agent stays the owner. It must still consume the final result and repor
 
 - Ask GPT for independent analysis when the user wants a second pass, adversarial review, broad code search, or a cheaper subagent.
 - Ask GPT for implementation only when the user has granted edit permission for that work.
-- Keep the host agent responsible for the final answer. Summarize what GPT returned, cite the session id, and separate GPT's result from the host agent's own observations.
+- Keep the host agent responsible for the final answer. Summarize what GPT returned and separate GPT's result from the host agent's own observations.
 - Treat GPT output as evidence to inspect, not as automatically true. Verify high-risk claims with source, tests, logs, or direct reads.
 - Do not send large private logs, secrets, credentials, or unrelated personal context to Codex.
 - If GPT edits files through `codex exec`, inspect the resulting diff before reporting success.
@@ -136,9 +134,9 @@ The host agent stays the owner. It must still consume the final result and repor
 Report the result in this order:
 
 1. State whether the host agent successfully ran `codex exec`.
-2. Include the Codex session id and exit code (0 for clean completion, 124 for timeout).
+2. Include the exit code (0 for clean completion, 124 for timeout).
 3. Quote or summarize the GPT response from `$result_file`, depending on what the user asked for.
 4. Name any verification performed by the host agent after the GPT response.
 5. State exact errors if the `codex exec` run failed.
 
-For failures, preserve exact CLI stderr from `$stderr_file` and the exit code. Retry only for pre-execution parameter failures (for example rejected `model_reasoning_effort` or an unknown model slug). After execution may have started, inspect the workspace and diff before resuming. Do not replay an edit-allowed prompt blindly. If stderr mentions an unknown or unsupported model, treat it as a model-selection failure and follow **Model selection** before retrying. Then report the observed result.
+For failures, preserve exact CLI stderr from `$stderr_file` and the exit code. Retry only for pre-execution parameter failures (for example rejected `model_reasoning_effort` or an unknown model slug). After execution may have started, inspect the workspace and diff before starting another ephemeral run. Do not replay an edit-allowed prompt blindly. If stderr mentions an unknown or unsupported model, treat it as a model-selection failure and follow **Model selection** before retrying. Then report the observed result.

--- a/corpus/skills/gpt-subagent/SKILL.md.tmpl
+++ b/corpus/skills/gpt-subagent/SKILL.md.tmpl
@@ -1,19 +1,19 @@
 ---
 name: gpt-subagent
-description: Use GPT through the codex exec CLI as a subagent. Use when the user asks to delegate work to Codex or GPT, run a Codex review, have GPT perform a second pass, or compare host and GPT answers.
+description: Use GPT through the codex exec CLI as a subagent. Use when the user asks to delegate work to Codex or GPT, run a Codex review, have GPT perform a second pass, continue an existing Codex edit session, or compare host and GPT answers.
 ---
 
 # GPT Subagent
 
-Use `codex exec` when the user asks to delegate work to GPT through Codex. The CLI path gives observable progress and a hard timeout. Do not use the Codex MCP server for subagent delegation.
+Use `codex exec` when the user asks to delegate work to GPT through Codex. The CLI path gives observable progress, a hard timeout, and ephemeral continuation of an existing edit session. Do not use the Codex MCP server for subagent delegation.
 
 Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 
 ## Defaults
 
-Every `codex exec` dispatch must include `--ephemeral`. All other defaults apply unless the user overrides them:
+Every `codex exec` dispatch, including `codex exec resume`, must include `--ephemeral`. All other defaults apply unless the user overrides them:
 
-- **Ephemeral session:** `--ephemeral`. This prevents Codex from persisting session files. Do not use `codex exec resume` or `--last`, because ephemeral runs cannot be resumed.
+- **Ephemeral session:** `--ephemeral`. This prevents Codex from persisting session files. A session created with `--ephemeral` is unavailable to resume. A resumed recorded session must still include `--ephemeral` so the continuation is not persisted.
 - **Reasoning:** `-c model_reasoning_effort="high"`. If `codex exec` rejects `high` for the default model, drop the override.
 - **Model:** omit `-m` by default. When the user names a model or you need a non-default model, follow **Model selection** and pass `-m` only with a slug from `codex debug models`.
 - **Review sandbox:** use `-s read-only` for review, analysis, and search.
@@ -71,9 +71,28 @@ timeout 1500 codex exec \
 PROMPT
 ```
 
+Continue an existing recorded edit session with the resume subcommand:
+
+```bash
+result_file="$(mktemp)"
+stderr_file="$(mktemp)"
+timeout 1500 codex exec resume \
+  --ephemeral \
+  --dangerously-bypass-approvals-and-sandbox \
+  -c model_reasoning_effort="high" \
+  --json \
+  -o "$result_file" <session-id> - 2>"$stderr_file" <<'PROMPT'
+<follow-up prompt>
+PROMPT
+```
+
+Use `--last` only when the user identifies the most recent recorded session as the intended edit session.
+
 State "read-only" in review prompts, and state "edit allowed" only when the user authorized the implementation. The bypass flag removes approval prompts and the filesystem sandbox, so scope discipline lives in the prompt. Polling and timeout remain mandatory.
 
-Set `-C <dir>` when the task is scoped to a specific repository or directory.
+Start reviews as new tasks because `codex exec resume` does not accept `-s read-only`.
+
+Set `-C <dir>` only on new tasks. The resume subcommand does not accept `-C`, so run it from the intended working directory.
 
 ## Run in the background
 

--- a/corpus/skills/gpt-subagent/SKILL.md.tmpl
+++ b/corpus/skills/gpt-subagent/SKILL.md.tmpl
@@ -11,7 +11,7 @@ Assume `codex` is on PATH. This skill gives only CLI invocation instructions.
 
 ## Defaults
 
-Every `codex exec` dispatch uses these flags unless the user overrides them:
+Every `codex exec` dispatch must include `--ephemeral`. All other defaults apply unless the user overrides them:
 
 - **Ephemeral session:** `--ephemeral`. This prevents Codex from persisting session files. Do not use `codex exec resume` or `--last`, because ephemeral runs cannot be resumed.
 - **Reasoning:** `-c model_reasoning_effort="high"`. If `codex exec` rejects `high` for the default model, drop the override.
@@ -112,7 +112,7 @@ After launching the background job, arm a periodic check-in loop that fires on a
 2. Read `$result_file` and `$stderr_file` if they exist.
 3. Compare each snapshot to the previous one to detect no progress.
 4. Treat exit code 124 from `timeout` as a time-limit breach. That may mean the run needs more time, or that progress has stalled. Read stdout and `$result_file` before restarting.
-5. Restart the run with a new ephemeral invocation when progress stops.
+5. Restart read-only tasks with a new ephemeral invocation when progress stops. For edit-allowed tasks, inspect the workspace and diff before deciding whether another invocation is safe.
 
 Add `--json` when JSONL event streaming makes progress easier to parse.
 

--- a/git-global-hooks/pre-commit
+++ b/git-global-hooks/pre-commit
@@ -2,6 +2,43 @@
 source "$(dirname "$0")/email-guard.sh"
 source "$(dirname "$0")/chain-hook.sh"
 
+protected_branch_names() {
+    printf '%s\n' main
+
+    local remote_name remote_head configured_default
+    while IFS= read -r remote_name; do
+        remote_head="$(git symbolic-ref --quiet "refs/remotes/$remote_name/HEAD" 2>/dev/null || true)"
+        if [[ "$remote_head" == "refs/remotes/$remote_name/"* ]]; then
+            printf '%s\n' "${remote_head#"refs/remotes/$remote_name/"}"
+        fi
+    done < <(git remote)
+
+    configured_default="$(git config --get init.defaultBranch 2>/dev/null || true)"
+    if [[ -n "$configured_default" ]]; then
+        printf '%s\n' "$configured_default"
+    fi
+}
+
+is_protected_branch() {
+    local branch_name="$1"
+    local protected_branch
+
+    while IFS= read -r protected_branch; do
+        if [[ "$branch_name" == "$protected_branch" ]]; then
+            return 0
+        fi
+    done < <(protected_branch_names)
+
+    return 1
+}
+
+current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+if [[ -n "$current_branch" ]] && is_protected_branch "$current_branch"; then
+    printf 'error: commit blocked on protected branch %q\n' "$current_branch"
+    printf '%s\n' '  make all changes in a worktree and merge via GitHub.'
+    exit 1
+fi
+
 if resolve_allowed_identity_fields; then
     allowed_email="$RESOLVED_ALLOWED_EMAIL"
     allowed_name="$RESOLVED_ALLOWED_NAME"

--- a/git-global-hooks/pre-commit-test.sh
+++ b/git-global-hooks/pre-commit-test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GLOBAL_HOOKS="$ROOT_DIR/git-global-hooks"
+TEMP_DIR="$(mktemp -d)"
+TEST_HOME="$TEMP_DIR/home"
+EMPTY_HOOKS="$TEMP_DIR/empty-hooks"
+MISSING_EMAIL_RULES="$TEMP_DIR/missing-email-rules"
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+create_repository() {
+    local repository_path="$1"
+    local branch_name="$2"
+
+    git init --quiet --initial-branch="$branch_name" "$repository_path"
+    git -C "$repository_path" config core.hooksPath "$GLOBAL_HOOKS"
+    git -C "$repository_path" config init.defaultBranch main
+    git -C "$repository_path" config user.name "Test User"
+    git -C "$repository_path" config user.email "test@example.invalid"
+    git -C "$repository_path" config commit.gpgsign false
+}
+
+stage_change() {
+    local repository_path="$1"
+    local scenario_name="$2"
+
+    printf '%s\n' "$scenario_name" >>"$repository_path/change.txt"
+    git -C "$repository_path" add change.txt
+}
+
+assert_blocked() {
+    local scenario_name="$1"
+    local repository_path="$2"
+    local output
+
+    stage_change "$repository_path" "$scenario_name"
+    if output="$(HOME="$TEST_HOME" GIT_EMAIL_RULES="$MISSING_EMAIL_RULES" git -C "$repository_path" commit --quiet -m "$scenario_name" 2>&1)"; then
+        fail "$scenario_name: hook allowed a protected-branch commit"
+    fi
+    if [[ "$output" != *"make all changes in a worktree and merge via GitHub"* ]]; then
+        fail "$scenario_name: hook did not provide the recovery instruction"
+    fi
+}
+
+assert_allowed() {
+    local scenario_name="$1"
+    local repository_path="$2"
+    local output
+
+    stage_change "$repository_path" "$scenario_name"
+    if ! output="$(HOME="$TEST_HOME" GIT_EMAIL_RULES="$MISSING_EMAIL_RULES" git -C "$repository_path" commit --quiet -m "$scenario_name" 2>&1)"; then
+        fail "$scenario_name: hook rejected an allowed commit: $output"
+    fi
+}
+
+mkdir -p "$TEST_HOME" "$EMPTY_HOOKS"
+
+main_repository="$TEMP_DIR/main"
+create_repository "$main_repository" main
+assert_blocked "main branch" "$main_repository"
+
+remote_default_repository="$TEMP_DIR/release"
+create_repository "$remote_default_repository" release
+git -C "$remote_default_repository" remote add origin "$TEMP_DIR/remote.git"
+git -C "$remote_default_repository" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/release
+assert_blocked "remote default branch" "$remote_default_repository"
+
+configured_default_repository="$TEMP_DIR/trunk"
+create_repository "$configured_default_repository" trunk
+git -C "$configured_default_repository" config init.defaultBranch trunk
+assert_blocked "configured default branch" "$configured_default_repository"
+
+feature_repository="$TEMP_DIR/feature"
+create_repository "$feature_repository" feature/protected-branches
+assert_allowed "feature branch" "$feature_repository"
+
+detached_repository="$TEMP_DIR/detached"
+create_repository "$detached_repository" main
+git -C "$detached_repository" config core.hooksPath "$EMPTY_HOOKS"
+git -C "$detached_repository" commit --allow-empty --quiet -m "Create detached test state"
+git -C "$detached_repository" config core.hooksPath "$GLOBAL_HOOKS"
+git -C "$detached_repository" checkout --quiet --detach
+assert_allowed "detached HEAD" "$detached_repository"
+
+printf 'PASS: protected branch commit hook behavior\n'


### PR DESCRIPTION
### Summary

GPT subagent runs now use ephemeral sessions. Review work runs in read-only mode, and user-authorized edits run without the filesystem sandbox.

## Change

The global pre-commit hook now blocks commits on `main`, the remote default branch, and `init.defaultBranch`. The message directs contributors to use a worktree and merge through GitHub.

The hook test creates temporary repositories and verifies the policy through real `git commit` calls.

## Testing

- `bash git-global-hooks/pre-commit-test.sh`
- `go test ./...`

Made with [Cursor](https://cursor.com)