### PR TITLE
Add the brevity headline to the responses and general rules

### DIFF
--- a/corpus/rules/general.mdc
+++ b/corpus/rules/general.mdc
@@ -7,6 +7,10 @@ always: true
 
 # General
 
+HEADLINE, MUST DO: RESPOND/WRITE IN AS FEW WORDS AS POSSIBLE. THIS IS NON-NEGOTIABLE
+
+in as few words as possible
+
 This is a mandatory process, not a set of guidelines. Run every step on every task.
 
 ## Process

--- a/corpus/rules/responses.mdc
+++ b/corpus/rules/responses.mdc
@@ -7,6 +7,10 @@ always: true
 
 # Responses
 
+HEADLINE, MUST DO: RESPOND/WRITE IN AS FEW WORDS AS POSSIBLE. THIS IS NON-NEGOTIABLE
+
+in as few words as possible
+
 This is a mandatory process, not a set of guidelines. Run every step on every response. Readability for a person with dyslexia is a hard access requirement.
 
 ## Process


### PR DESCRIPTION
Both rule files now open with a non-negotiable brevity headline, so the shortest-possible-response requirement is the first thing an agent reads.

## Change

`corpus/rules/responses.mdc` and `corpus/rules/general.mdc` carry the headline and its short form above the existing mandatory-process line. The rest of each rule is unchanged.