### PR TITLE
Reword the brevity short form to respond in as few words as possible

### DIFF
--- a/corpus/rules/general.mdc
+++ b/corpus/rules/general.mdc
@@ -9,7 +9,7 @@ always: true
 
 HEADLINE, MUST DO: RESPOND/WRITE IN AS FEW WORDS AS POSSIBLE. THIS IS NON-NEGOTIABLE
 
-in as few words as possible
+respond in as few words as possible
 
 This is a mandatory process, not a set of guidelines. Run every step on every task.
 

--- a/corpus/rules/responses.mdc
+++ b/corpus/rules/responses.mdc
@@ -9,7 +9,7 @@ always: true
 
 HEADLINE, MUST DO: RESPOND/WRITE IN AS FEW WORDS AS POSSIBLE. THIS IS NON-NEGOTIABLE
 
-in as few words as possible
+respond in as few words as possible
 
 This is a mandatory process, not a set of guidelines. Run every step on every response. Readability for a person with dyslexia is a hard access requirement.
 


### PR DESCRIPTION
The brevity short form in both rule files now reads as an instruction rather than a fragment.

## Change

`corpus/rules/responses.mdc` and `corpus/rules/general.mdc` change the line under the headline from `in as few words as possible` to `respond in as few words as possible`.