### PR TITLE
Compress the general rule to load-bearing imperatives

### DIFF
--- a/corpus/rules/general.mdc
+++ b/corpus/rules/general.mdc
@@ -11,36 +11,34 @@ HEADLINE, MUST DO: RESPOND/WRITE IN AS FEW WORDS AS POSSIBLE. THIS IS NON-NEGOTI
 
 respond in as few words as possible
 
-This is a mandatory process, not a set of guidelines. Run every step on every task.
+Every rule below is mandatory. Run all of them on every task.
 
 ## Process
 
-Run these steps in order.
-
-1. Check whether a skill applies before you respond, before you ask a clarifying question, and before you read any file.
+1. Check for an applicable skill before you respond, ask, or read a file.
 2. Invoke every skill that applies.
-3. Identify every consequential decision, assumption, and classification the task requires.
-4. Route each one: state it on its own line before acting, or ask the user through the structured-question tool when only the user can settle it.
+3. Identify every consequential decision, assumption, and classification.
+4. Route each one: state it before acting, or ask when only the user can settle it.
 5. Do the work.
 6. Report findings and let the user decide what to act on.
 
 ## MUST
 
-1. Invoke a skill when there is even a 1% chance it applies. You do not have a choice, and you may not rationalize your way out of it.
+1. Invoke a skill at even a 1% chance it applies. You have no choice and may not rationalize your way out.
 2. Check for a skill before any response, including a clarifying question.
-3. Ask a blocking question before you act, and only when the task needs user input, needs a user decision, or carries a caveat only the user can settle.
-4. Call the structured-question tool for the current harness when the task needs a user decision, needs user input, or carries an unresolved caveat only the user can settle. Use `AskUserQuestion` in Claude Code, `request_user_input` in Codex, and `AskQuestion` in Cursor.
-5. Present the same structured options in plain text and wait for the user to choose when no structured-question tool is available.
-6. State every consequential decision, assumption, and classification on its own line before you act on it.
-7. Label each one `Decision`, `Assumption`, `Classification`, or `Out of scope`. These four labels are required, and they are the only labels you may use without defining what the label means.
-8. Apply the same treatment to any claim that changes what happens next, including `preexisting`, `not mine`, `out of scope`, `already handled`, `safe to ignore`, and `not part of this workstream`.
-9. Present findings and let the user decide what to act on.
+3. Ask a blocking question before you act, and only when the task needs user input, a user decision, or a caveat only the user can settle.
+4. Ask through the harness tool: `AskUserQuestion` in Claude Code, `request_user_input` in Codex, `AskQuestion` in Cursor.
+5. Offer the same structured options in plain text when no such tool exists, then wait.
+6. State every consequential decision, assumption, and classification on its own line before acting on it.
+7. Label each one `Decision`, `Assumption`, `Classification`, or `Out of scope`. These four are the only labels usable without defining them.
+8. Treat any claim that changes what happens next the same way, including `preexisting`, `not mine`, `out of scope`, `already handled`, `safe to ignore`, and `not part of this workstream`.
+9. Report findings and let the user decide what to act on.
 
 ## MUST NOT
 
-1. Do not skip a skill because the task looks simple, because you need context first, because you remember the skill, or because it feels like overkill.
-2. Do not bury a consequential decision, assumption, or classification inside prose and then act on it as if the user approved it. That is deceptive.
-3. Do not ask a blocking question after you act.
-4. Do not guess a decision that only the user can settle.
-5. Do not ask in prose when a structured-question tool is available.
-6. Do not surface an issue unrelated to the task you were asked to do.
+1. Never skip a skill because the task looks simple, you need context first, you remember the skill, or it feels like overkill.
+2. Never bury a consequential decision, assumption, or classification in prose and act on it as if approved. That is deceptive.
+3. Never ask a blocking question after you act.
+4. Never guess a decision only the user can settle.
+5. Never ask in prose when the harness tool exists.
+6. Never surface an issue unrelated to the task you were asked to do.


### PR DESCRIPTION
The general rule keeps every rule and drops the words that were not carrying one.

## Change

`corpus/rules/general.mdc` keeps all 9 MUST and all 6 MUST NOT items plus the process. Each line is now a bare imperative. MUST NOT items read `Never` rather than `Do not`, and the harness tool names stay exact.

The rule body drops from 2450 to 2153 bytes.