### PR TITLE
Add gitdir package for git dir and linked worktree resolution

### DIFF
--- a/dots/internal/gitdir/gitdir.go
+++ b/dots/internal/gitdir/gitdir.go
@@ -1,0 +1,112 @@
+// Package gitdir resolves the git layout of a working tree so callers can tell
+// a canonical checkout from a linked worktree, and can find the shared git
+// directory instead of assuming that <root>/.git is one.
+package gitdir
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"goodkind.io/.dotfiles/internal/cmdexec"
+	"goodkind.io/.dotfiles/internal/telemetry"
+)
+
+// Info describes the git layout of a working tree.
+type Info struct {
+	// Root is the working tree the caller asked about.
+	Root string
+	// GitDir is the absolute per-worktree git directory. Per-worktree state
+	// such as an in-progress rebase lives here.
+	GitDir string
+	// CommonDir is the absolute git directory shared by every worktree.
+	// Hooks, the object store, and submodule git directories live here.
+	CommonDir string
+	// IsWorktree reports whether Root is a linked worktree rather than the
+	// canonical checkout. It is true exactly when GitDir differs from
+	// CommonDir.
+	IsWorktree bool
+}
+
+// MainWorktree returns the canonical working tree, which is the directory
+// holding CommonDir. It returns an empty string when CommonDir is unset.
+func (i Info) MainWorktree() string {
+	if i.CommonDir == "" {
+		return ""
+	}
+	return filepath.Dir(i.CommonDir)
+}
+
+// ModulesDir returns the directory holding submodule git directories. Git
+// keeps these under the common directory, so every worktree shares them.
+func (i Info) ModulesDir() string {
+	if i.CommonDir == "" {
+		return ""
+	}
+	return filepath.Join(i.CommonDir, "modules")
+}
+
+// Resolve reports the git layout of root. It returns an error when root is not
+// inside a git working tree. Callers should read that error as "not a git
+// checkout" and carry on, since an archive install has no git at all.
+func Resolve(ctx context.Context, root string, logger *telemetry.Logger) (Info, error) {
+	gitDir, err := revParsePath(ctx, root, "--git-dir", logger)
+	if err != nil {
+		return Info{Root: root, GitDir: "", CommonDir: "", IsWorktree: false}, err
+	}
+	commonDir, err := revParsePath(ctx, root, "--git-common-dir", logger)
+	if err != nil {
+		return Info{Root: root, GitDir: "", CommonDir: "", IsWorktree: false}, err
+	}
+	return Info{
+		Root:       root,
+		GitDir:     gitDir,
+		CommonDir:  commonDir,
+		IsWorktree: gitDir != commonDir,
+	}, nil
+}
+
+// LinkedWorktree reports whether root is a linked worktree, along with the
+// layout that decided it. A root that is not a git checkout is not a linked
+// worktree, so the answer is false and the returned Info is zero.
+func LinkedWorktree(ctx context.Context, root string, logger *telemetry.Logger) (Info, bool) {
+	layout, err := Resolve(ctx, root, logger)
+	if err != nil {
+		return Info{Root: root, GitDir: "", CommonDir: "", IsWorktree: false}, false
+	}
+	return layout, layout.IsWorktree
+}
+
+// revParsePath runs one git rev-parse flag and returns its answer as an
+// absolute path. Git answers relative to root when it is run from the working
+// tree root and absolute when it is run from a linked worktree, so the value
+// must be joined against root before two answers can be compared.
+func revParsePath(ctx context.Context, root string, flag string, logger *telemetry.Logger) (string, error) {
+	output, err := cmdexec.OutputWithLoggerAndEnv(ctx, logger, nil, "git", "-C", root, "rev-parse", flag)
+	if err != nil {
+		slog.WarnContext(ctx, "gitdir: revParsePath: git rev-parse failed", "flag", flag, "root", root, "err", err)
+		return "", fmt.Errorf("running git rev-parse %s: %w", flag, err)
+	}
+	path := strings.TrimSpace(output)
+	if path == "" {
+		return "", fmt.Errorf("git rev-parse %s returned no path", flag)
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(root, path)
+	}
+	return canonicalPath(path), nil
+}
+
+// canonicalPath resolves symlinks so two spellings of one directory compare
+// equal. On macOS a home directory is reachable through /System/Volumes/Data,
+// so comparing git's answer against a caller-supplied path can otherwise
+// differ for paths naming the same inode.
+func canonicalPath(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return resolved
+}

--- a/dots/internal/gitdir/gitdir_test.go
+++ b/dots/internal/gitdir/gitdir_test.go
@@ -1,0 +1,115 @@
+package gitdir
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveDistinguishesWorktreeFromCanonicalCheckout builds a real
+// repository with a linked worktree and asserts that each is classified
+// correctly. This is the classification a sync run depends on before it
+// rewrites the home directory.
+func TestResolveDistinguishesWorktreeFromCanonicalCheckout(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	canonicalRoot := newTestRepo(t)
+	worktreeRoot := filepath.Join(t.TempDir(), "linked")
+	runGit(t, canonicalRoot, "worktree", "add", "-b", "feature", worktreeRoot)
+
+	canonical, err := Resolve(context.Background(), canonicalRoot, nil)
+	if err != nil {
+		t.Fatalf("Resolve(canonical) returned error: %v", err)
+	}
+	if canonical.IsWorktree {
+		t.Fatalf("Resolve(canonical).IsWorktree = true, want false (gitDir=%s commonDir=%s)", canonical.GitDir, canonical.CommonDir)
+	}
+
+	linked, err := Resolve(context.Background(), worktreeRoot, nil)
+	if err != nil {
+		t.Fatalf("Resolve(worktree) returned error: %v", err)
+	}
+	if !linked.IsWorktree {
+		t.Fatalf("Resolve(worktree).IsWorktree = false, want true (gitDir=%s commonDir=%s)", linked.GitDir, linked.CommonDir)
+	}
+	if linked.CommonDir != canonical.CommonDir {
+		t.Fatalf("worktree common dir = %s, want %s", linked.CommonDir, canonical.CommonDir)
+	}
+
+	wantMain := canonicalPath(canonicalRoot)
+	if linked.MainWorktree() != wantMain {
+		t.Fatalf("MainWorktree() = %s, want %s", linked.MainWorktree(), wantMain)
+	}
+}
+
+// TestLinkedWorktreeReportsFalseOutsideGit confirms a directory with no git at
+// all is not treated as a worktree, so an archive install still syncs.
+func TestLinkedWorktreeReportsFalseOutsideGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	// A temp dir can sit inside an unrelated repository, so point git at a
+	// directory it must refuse to walk out of.
+	plainDir := t.TempDir()
+	t.Setenv("GIT_CEILING_DIRECTORIES", plainDir)
+
+	if _, isWorktree := LinkedWorktree(context.Background(), plainDir, nil); isWorktree {
+		t.Fatal("LinkedWorktree(non-git dir) = true, want false")
+	}
+}
+
+// TestModulesDirPointsAtSharedGitDir confirms submodule git directories are
+// looked for under the shared directory, which is where git puts them for
+// every worktree.
+func TestModulesDirPointsAtSharedGitDir(t *testing.T) {
+	t.Parallel()
+
+	layout := Info{Root: "/repo", GitDir: "/repo/.git/worktrees/x", CommonDir: "/repo/.git", IsWorktree: true}
+	if got, want := layout.ModulesDir(), filepath.Join("/repo/.git", "modules"); got != want {
+		t.Fatalf("ModulesDir() = %s, want %s", got, want)
+	}
+
+	empty := Info{Root: "/repo", GitDir: "", CommonDir: "", IsWorktree: false}
+	if got := empty.ModulesDir(); got != "" {
+		t.Fatalf("ModulesDir() on zero Info = %s, want empty", got)
+	}
+	if got := empty.MainWorktree(); got != "" {
+		t.Fatalf("MainWorktree() on zero Info = %s, want empty", got)
+	}
+}
+
+func newTestRepo(t *testing.T) string {
+	t.Helper()
+	repoRoot := t.TempDir()
+	runGit(t, repoRoot, "init")
+	// The machine's global hooks refuse commits on a protected branch name, so
+	// point this fixture at a hooks directory of its own.
+	hooksDirectory := filepath.Join(repoRoot, ".git", "hooks-disabled")
+	if err := os.MkdirAll(hooksDirectory, 0o755); err != nil {
+		t.Fatalf("creating hooks directory: %v", err)
+	}
+	runGit(t, repoRoot, "config", "core.hooksPath", hooksDirectory)
+	runGit(t, repoRoot, "config", "user.name", "Test")
+	runGit(t, repoRoot, "config", "user.email", "test@example.invalid")
+	runGit(t, repoRoot, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("test\n"), 0o600); err != nil {
+		t.Fatalf("writing README.md: %v", err)
+	}
+	runGit(t, repoRoot, "add", "README.md")
+	runGit(t, repoRoot, "commit", "-m", "Initial commit")
+	return repoRoot
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, output)
+	}
+}


### PR DESCRIPTION
### Summary

Adds a package that resolves a git working tree's git directory and reports whether it is a linked worktree rather than the canonical checkout.

## Why

Several fixes stacked on top of this need to distinguish a linked worktree from the canonical checkout, and need the shared git directory rather than assuming `<root>/.git` is one. No existing code in this repository could answer either question.

## Change

`gitdir.Resolve` runs `git rev-parse --git-dir` and `--git-common-dir` and reports `IsWorktree` when they differ. `Info.MainWorktree` and `Info.ModulesDir` derive the canonical checkout path and the submodule git directory root from the result.