### PR TITLE
Clear stale git locks in submodule git dirs during repository sync

### DIFF
--- a/dots/internal/sync/repository/repository.go
+++ b/dots/internal/sync/repository/repository.go
@@ -11,8 +11,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"goodkind.io/.dotfiles/internal/clock"
 	"goodkind.io/.dotfiles/internal/cmdexec"
+	"goodkind.io/.dotfiles/internal/gitdir"
 	"goodkind.io/.dotfiles/internal/telemetry"
 )
 
@@ -70,11 +73,14 @@ func UpdateGitRepoSync(ctx context.Context, skipGit bool, logger *telemetry.Logg
 }
 
 func runDotfilesUpdate(ctx context.Context, dotfiles string, logger *telemetry.Logger) (string, error) {
-	reason := checkDotfilesGitHealth(ctx, dotfiles, logger)
+	layout, layoutErr := gitdir.Resolve(ctx, dotfiles, logger)
+	reason := checkDotfilesGitHealth(ctx, dotfiles, layout, logger)
 	if reason != "" {
 		return "", fmt.Errorf("skip: %s", reason)
 	}
-	clearGitLocks(dotfiles)
+	if layoutErr == nil {
+		clearStaleGitLocks(ctx, layout, logger)
+	}
 
 	if err := cmdexec.RunWithLoggerAndEnv(ctx, logger, nil, "git", "-C", dotfiles, "fetch", "origin", "--prune"); err != nil {
 		return "fetch failed", fmt.Errorf("running git fetch: %w", err)
@@ -177,7 +183,7 @@ func firstError(current error, candidate error) error {
 	return candidate
 }
 
-func checkDotfilesGitHealth(ctx context.Context, dotfiles string, logger *telemetry.Logger) string {
+func checkDotfilesGitHealth(ctx context.Context, dotfiles string, layout gitdir.Info, logger *telemetry.Logger) string {
 	branch, err := cmdexec.OutputWithLoggerAndEnv(ctx, logger, nil, "git", "-C", dotfiles, "symbolic-ref", "-q", "HEAD")
 	if err != nil || strings.TrimSpace(branch) == "" {
 		return "detached HEAD"
@@ -185,10 +191,16 @@ func checkDotfilesGitHealth(ctx context.Context, dotfiles string, logger *teleme
 	if gitCommandSucceeds(ctx, dotfiles, "rev-parse", "-q", "--verify", "MERGE_HEAD") {
 		return "merge in progress"
 	}
-	if _, err := os.Stat(filepath.Clean(filepath.Join(dotfiles, ".git", "rebase-merge"))); err == nil {
+	// Rebase state is per-worktree, so it lives in the worktree git directory
+	// rather than the shared one.
+	gitDirPath := layout.GitDir
+	if gitDirPath == "" {
+		gitDirPath = filepath.Join(dotfiles, ".git")
+	}
+	if _, err := os.Stat(filepath.Clean(filepath.Join(gitDirPath, "rebase-merge"))); err == nil {
 		return "rebase in progress"
 	}
-	if _, err := os.Stat(filepath.Clean(filepath.Join(dotfiles, ".git", "rebase-apply"))); err == nil {
+	if _, err := os.Stat(filepath.Clean(filepath.Join(gitDirPath, "rebase-apply"))); err == nil {
 		return "rebase in progress"
 	}
 	if output, err := cmdexec.OutputWithLoggerAndEnv(ctx, logger, nil, "git", "-C", dotfiles, "ls-files", "-u"); err == nil && strings.TrimSpace(output) != "" {
@@ -197,15 +209,91 @@ func checkDotfilesGitHealth(ctx context.Context, dotfiles string, logger *teleme
 	return ""
 }
 
-func clearGitLocks(dotfiles string) {
-	slog.Info("repository: clearGitLocks")
-	paths := []string{
-		filepath.Join(dotfiles, ".git", "index.lock"),
-		filepath.Join(dotfiles, ".git", "objects", "info", "commit-graph-chain.lock"),
+// staleLockAge is how old a git lock file must be before it is treated as
+// abandoned. No real git operation holds a lock for anything close to this, so
+// a lock older than this belongs to a process that died without cleaning up.
+const staleLockAge = time.Hour
+
+// gitLockNames are the lock files git creates inside a git directory. Any one
+// of them left behind by a crashed process blocks later operations.
+var gitLockNames = []string{
+	"index.lock",
+	"HEAD.lock",
+	"config.lock",
+	"shallow.lock",
+	"packed-refs.lock",
+	filepath.Join("objects", "info", "commit-graph-chain.lock"),
+}
+
+// clearStaleGitLocks removes abandoned lock files from the shared git
+// directory and from every submodule git directory beneath it.
+//
+// Submodule git directories live under <common dir>/modules, so a lock left
+// there fails `git checkout` inside the submodule while the parent repository
+// looks healthy. Locks are removed only once they are older than
+// [staleLockAge], since removing a lock a live git still holds would corrupt
+// that operation.
+func clearStaleGitLocks(ctx context.Context, layout gitdir.Info, logger *telemetry.Logger) {
+	removed := make([]string, 0)
+	for _, gitDir := range gitDirsToScan(layout) {
+		for _, lockName := range gitLockNames {
+			lockPath := filepath.Clean(filepath.Join(gitDir, lockName))
+			lockInfo, err := os.Stat(lockPath)
+			if err != nil {
+				continue
+			}
+			age := clock.Now().Sub(lockInfo.ModTime())
+			if age < staleLockAge {
+				continue
+			}
+			if err := os.Remove(lockPath); err != nil {
+				slog.WarnContext(ctx, "repository: clearStaleGitLocks: removing stale lock", "path", lockPath, "err", err)
+				continue
+			}
+			removed = append(removed, fmt.Sprintf("%s (age %s)", lockPath, age.Round(time.Minute)))
+		}
 	}
-	for _, path := range paths {
-		_ = os.Remove(filepath.Clean(path))
+	if len(removed) > 0 && logger != nil {
+		logger.InfoContext(ctx, "  cleared stale git locks: "+strings.Join(removed, ", "))
 	}
+}
+
+// gitDirsToScan returns the shared git directory plus every submodule git
+// directory under it.
+//
+// Git nests a submodule's git directory by the submodule's path, so `lib/zinit`
+// lands at <modules>/lib/zinit. The depth therefore varies with the submodule
+// path and the tree must be walked rather than listed.
+func gitDirsToScan(layout gitdir.Info) []string {
+	gitDirs := make([]string, 0, 1)
+	if layout.CommonDir != "" {
+		gitDirs = append(gitDirs, layout.CommonDir)
+	}
+	modules := layout.ModulesDir()
+	if modules == "" {
+		return gitDirs
+	}
+	return append(gitDirs, subdirectories(filepath.Clean(modules))...)
+}
+
+// subdirectories returns every directory beneath root, at any depth. An
+// unreadable directory contributes nothing rather than failing the caller,
+// since a lock sweep is best effort.
+func subdirectories(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	found := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		child := filepath.Join(root, entry.Name())
+		found = append(found, child)
+		found = append(found, subdirectories(child)...)
+	}
+	return found
 }
 
 func getRemoteStatus(ctx context.Context, dotfiles string, remoteRef string, logger *telemetry.Logger) string {
@@ -297,6 +385,11 @@ func syncDotfilesSubmodules(ctx context.Context, dotfiles string, logger *teleme
 	}
 	if len(subs) == 0 {
 		return nil
+	}
+	// A lock abandoned in a submodule git directory fails every later checkout
+	// there, and nothing else in this flow would ever clear it.
+	if layout, layoutErr := gitdir.Resolve(ctx, dotfiles, logger); layoutErr == nil {
+		clearStaleGitLocks(ctx, layout, logger)
 	}
 	if err := cmdexec.RunWithLoggerAndEnv(ctx, logger, nil, "git", "-C", dotfiles, "submodule", "update", "--init", "--recursive"); err != nil {
 		slog.WarnContext(ctx, "repository: initializing submodules", "err", err)

--- a/dots/internal/sync/repository/stalelocks_test.go
+++ b/dots/internal/sync/repository/stalelocks_test.go
@@ -1,0 +1,91 @@
+package repository
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"goodkind.io/.dotfiles/internal/gitdir"
+)
+
+// TestClearStaleGitLocksRemovesAbandonedSubmoduleLock reproduces the failure
+// that blocked the updater on every login: a lock left behind in a submodule
+// git directory, which lives under the shared directory rather than under the
+// repository root.
+func TestClearStaleGitLocksRemovesAbandonedSubmoduleLock(t *testing.T) {
+	commonDir := t.TempDir()
+	submoduleGitDir := filepath.Join(commonDir, "modules", "lib", "zinit")
+	if err := os.MkdirAll(submoduleGitDir, 0o755); err != nil {
+		t.Fatalf("creating submodule git dir: %v", err)
+	}
+
+	// The real lock was zero bytes and about two months old.
+	staleLock := filepath.Join(submoduleGitDir, "index.lock")
+	writeLock(t, staleLock, time.Now().Add(-48*time.Hour))
+
+	layout := gitdir.Info{Root: t.TempDir(), GitDir: commonDir, CommonDir: commonDir, IsWorktree: false}
+	clearStaleGitLocks(context.Background(), layout, nil)
+
+	if _, err := os.Stat(staleLock); !os.IsNotExist(err) {
+		t.Fatalf("stale submodule lock still present at %s (stat err = %v)", staleLock, err)
+	}
+}
+
+// TestClearStaleGitLocksLeavesFreshLocks confirms a lock a live git still
+// holds is not removed. Removing one would corrupt that operation.
+func TestClearStaleGitLocksLeavesFreshLocks(t *testing.T) {
+	commonDir := t.TempDir()
+	freshLock := filepath.Join(commonDir, "index.lock")
+	writeLock(t, freshLock, time.Now())
+
+	layout := gitdir.Info{Root: t.TempDir(), GitDir: commonDir, CommonDir: commonDir, IsWorktree: false}
+	clearStaleGitLocks(context.Background(), layout, nil)
+
+	if _, err := os.Stat(freshLock); err != nil {
+		t.Fatalf("fresh lock was removed from %s: %v", freshLock, err)
+	}
+}
+
+// TestClearStaleGitLocksCoversEveryLockName confirms each lock git can leave
+// behind is cleared, in the shared directory and in a submodule alike.
+func TestClearStaleGitLocksCoversEveryLockName(t *testing.T) {
+	commonDir := t.TempDir()
+	submoduleGitDir := filepath.Join(commonDir, "modules", "lib", "zsh-defer")
+	if err := os.MkdirAll(submoduleGitDir, 0o755); err != nil {
+		t.Fatalf("creating submodule git dir: %v", err)
+	}
+
+	old := time.Now().Add(-24 * time.Hour)
+	created := make([]string, 0, len(gitLockNames)*2)
+	for _, dir := range []string{commonDir, submoduleGitDir} {
+		for _, lockName := range gitLockNames {
+			lockPath := filepath.Join(dir, lockName)
+			if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+				t.Fatalf("creating lock parent: %v", err)
+			}
+			writeLock(t, lockPath, old)
+			created = append(created, lockPath)
+		}
+	}
+
+	layout := gitdir.Info{Root: t.TempDir(), GitDir: commonDir, CommonDir: commonDir, IsWorktree: false}
+	clearStaleGitLocks(context.Background(), layout, nil)
+
+	for _, lockPath := range created {
+		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+			t.Fatalf("lock still present at %s (stat err = %v)", lockPath, err)
+		}
+	}
+}
+
+func writeLock(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("writing lock %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("setting lock mod time %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Stacked on: https://github.com/agoodkind/.dotfiles/pull/142

### Summary

The background updater now clears abandoned git lock files from submodule git directories, not only from the top-level one.

## Why

A lock file left behind by a crashed git process blocked the updater from ever syncing again. The existing cleanup only checked `<root>/.git`, removed unconditionally with no age check, and never looked inside `.git/modules/<submodule>`, which is where a submodule checkout actually fails.

## Change

Lock clearing now walks the shared git directory and every submodule git directory beneath it, and only removes a lock older than one hour. That age check is what keeps this from ever touching a lock a live git process still holds.