### PR TITLE
Refuse dots sync from a linked worktree and clear stale git locks

### DIFF
--- a/dots/cmd/dots/main.go
+++ b/dots/cmd/dots/main.go
@@ -99,7 +99,7 @@ func runSync(args []string) int {
 	for _, arg := range args {
 		if arg == "-h" || arg == "--help" {
 			logInfo("Usage:")
-			logInfo("  dots sync [--repair] [--quick] [--skip-git] [--skip-network] [--skip-cursor-sync] [--dry-run] [--use-defaults] [--strict]")
+			logInfo("  dots sync [--repair] [--quick] [--skip-git] [--skip-network] [--skip-cursor-sync] [--dry-run] [--use-defaults] [--strict] [--allow-worktree]")
 			return 0
 		}
 	}
@@ -113,6 +113,7 @@ func runSync(args []string) int {
 	dryRun := fs.Bool("dry-run", false, "run through sync steps without applying changes")
 	useDefaults := fs.Bool("use-defaults", false, "use non-interactive installer defaults")
 	strictMode := fs.Bool("strict", false, "fail on non-critical sync step failures")
+	allowWorktree := fs.Bool("allow-worktree", false, "allow syncing from a linked git worktree")
 	if err := fs.Parse(args); err != nil {
 		logWarn(err.Error())
 		printUsage()
@@ -129,6 +130,7 @@ func runSync(args []string) int {
 		DryRun:         *dryRun,
 		UseDefaults:    *useDefaults,
 		StrictMode:     *strictMode,
+		AllowWorktree:  *allowWorktree,
 	}); err != nil {
 		logError("sync failed", err)
 		return 1

--- a/dots/internal/dispatch/updater/updater.go
+++ b/dots/internal/dispatch/updater/updater.go
@@ -104,6 +104,7 @@ func runSyncOnly(ctx context.Context, dotfiles string, dispatchLogger *telemetry
 		DryRun:         false,
 		UseDefaults:    true,
 		StrictMode:     false,
+		AllowWorktree:  false,
 	})
 	if runErr != nil {
 		dispatchLogger.WarnContextWithErr(ctx, "updater: sync exited with non-zero status", runErr)
@@ -128,6 +129,7 @@ func doWeeklyUpdate(ctx context.Context, dotfiles, weeklyMarkerPath string, disp
 		DryRun:         false,
 		UseDefaults:    true,
 		StrictMode:     false,
+		AllowWorktree:  false,
 	})
 	if runErr != nil {
 		dispatchLogger.WarnContextWithErr(ctx, "updater: weekly sync exited with non-zero status", runErr)

--- a/dots/internal/gitdir/gitdir.go
+++ b/dots/internal/gitdir/gitdir.go
@@ -1,0 +1,112 @@
+// Package gitdir resolves the git layout of a working tree so callers can tell
+// a canonical checkout from a linked worktree, and can find the shared git
+// directory instead of assuming that <root>/.git is one.
+package gitdir
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"goodkind.io/.dotfiles/internal/cmdexec"
+	"goodkind.io/.dotfiles/internal/telemetry"
+)
+
+// Info describes the git layout of a working tree.
+type Info struct {
+	// Root is the working tree the caller asked about.
+	Root string
+	// GitDir is the absolute per-worktree git directory. Per-worktree state
+	// such as an in-progress rebase lives here.
+	GitDir string
+	// CommonDir is the absolute git directory shared by every worktree.
+	// Hooks, the object store, and submodule git directories live here.
+	CommonDir string
+	// IsWorktree reports whether Root is a linked worktree rather than the
+	// canonical checkout. It is true exactly when GitDir differs from
+	// CommonDir.
+	IsWorktree bool
+}
+
+// MainWorktree returns the canonical working tree, which is the directory
+// holding CommonDir. It returns an empty string when CommonDir is unset.
+func (i Info) MainWorktree() string {
+	if i.CommonDir == "" {
+		return ""
+	}
+	return filepath.Dir(i.CommonDir)
+}
+
+// ModulesDir returns the directory holding submodule git directories. Git
+// keeps these under the common directory, so every worktree shares them.
+func (i Info) ModulesDir() string {
+	if i.CommonDir == "" {
+		return ""
+	}
+	return filepath.Join(i.CommonDir, "modules")
+}
+
+// Resolve reports the git layout of root. It returns an error when root is not
+// inside a git working tree. Callers should read that error as "not a git
+// checkout" and carry on, since an archive install has no git at all.
+func Resolve(ctx context.Context, root string, logger *telemetry.Logger) (Info, error) {
+	gitDir, err := revParsePath(ctx, root, "--git-dir", logger)
+	if err != nil {
+		return Info{Root: root, GitDir: "", CommonDir: "", IsWorktree: false}, err
+	}
+	commonDir, err := revParsePath(ctx, root, "--git-common-dir", logger)
+	if err != nil {
+		return Info{Root: root, GitDir: "", CommonDir: "", IsWorktree: false}, err
+	}
+	return Info{
+		Root:       root,
+		GitDir:     gitDir,
+		CommonDir:  commonDir,
+		IsWorktree: gitDir != commonDir,
+	}, nil
+}
+
+// LinkedWorktree reports whether root is a linked worktree, along with the
+// layout that decided it. A root that is not a git checkout is not a linked
+// worktree, so the answer is false and the returned Info is zero.
+func LinkedWorktree(ctx context.Context, root string, logger *telemetry.Logger) (Info, bool) {
+	layout, err := Resolve(ctx, root, logger)
+	if err != nil {
+		return Info{Root: root, GitDir: "", CommonDir: "", IsWorktree: false}, false
+	}
+	return layout, layout.IsWorktree
+}
+
+// revParsePath runs one git rev-parse flag and returns its answer as an
+// absolute path. Git answers relative to root when it is run from the working
+// tree root and absolute when it is run from a linked worktree, so the value
+// must be joined against root before two answers can be compared.
+func revParsePath(ctx context.Context, root string, flag string, logger *telemetry.Logger) (string, error) {
+	output, err := cmdexec.OutputWithLoggerAndEnv(ctx, logger, nil, "git", "-C", root, "rev-parse", flag)
+	if err != nil {
+		slog.WarnContext(ctx, "gitdir: revParsePath: git rev-parse failed", "flag", flag, "root", root, "err", err)
+		return "", fmt.Errorf("running git rev-parse %s: %w", flag, err)
+	}
+	path := strings.TrimSpace(output)
+	if path == "" {
+		return "", fmt.Errorf("git rev-parse %s returned no path", flag)
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(root, path)
+	}
+	return canonicalPath(path), nil
+}
+
+// canonicalPath resolves symlinks so two spellings of one directory compare
+// equal. On macOS a home directory is reachable through /System/Volumes/Data,
+// so comparing git's answer against a caller-supplied path can otherwise
+// differ for paths naming the same inode.
+func canonicalPath(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return resolved
+}

--- a/dots/internal/gitdir/gitdir_test.go
+++ b/dots/internal/gitdir/gitdir_test.go
@@ -1,0 +1,115 @@
+package gitdir
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveDistinguishesWorktreeFromCanonicalCheckout builds a real
+// repository with a linked worktree and asserts that each is classified
+// correctly. This is the classification a sync run depends on before it
+// rewrites the home directory.
+func TestResolveDistinguishesWorktreeFromCanonicalCheckout(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	canonicalRoot := newTestRepo(t)
+	worktreeRoot := filepath.Join(t.TempDir(), "linked")
+	runGit(t, canonicalRoot, "worktree", "add", "-b", "feature", worktreeRoot)
+
+	canonical, err := Resolve(context.Background(), canonicalRoot, nil)
+	if err != nil {
+		t.Fatalf("Resolve(canonical) returned error: %v", err)
+	}
+	if canonical.IsWorktree {
+		t.Fatalf("Resolve(canonical).IsWorktree = true, want false (gitDir=%s commonDir=%s)", canonical.GitDir, canonical.CommonDir)
+	}
+
+	linked, err := Resolve(context.Background(), worktreeRoot, nil)
+	if err != nil {
+		t.Fatalf("Resolve(worktree) returned error: %v", err)
+	}
+	if !linked.IsWorktree {
+		t.Fatalf("Resolve(worktree).IsWorktree = false, want true (gitDir=%s commonDir=%s)", linked.GitDir, linked.CommonDir)
+	}
+	if linked.CommonDir != canonical.CommonDir {
+		t.Fatalf("worktree common dir = %s, want %s", linked.CommonDir, canonical.CommonDir)
+	}
+
+	wantMain := canonicalPath(canonicalRoot)
+	if linked.MainWorktree() != wantMain {
+		t.Fatalf("MainWorktree() = %s, want %s", linked.MainWorktree(), wantMain)
+	}
+}
+
+// TestLinkedWorktreeReportsFalseOutsideGit confirms a directory with no git at
+// all is not treated as a worktree, so an archive install still syncs.
+func TestLinkedWorktreeReportsFalseOutsideGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	// A temp dir can sit inside an unrelated repository, so point git at a
+	// directory it must refuse to walk out of.
+	plainDir := t.TempDir()
+	t.Setenv("GIT_CEILING_DIRECTORIES", plainDir)
+
+	if _, isWorktree := LinkedWorktree(context.Background(), plainDir, nil); isWorktree {
+		t.Fatal("LinkedWorktree(non-git dir) = true, want false")
+	}
+}
+
+// TestModulesDirPointsAtSharedGitDir confirms submodule git directories are
+// looked for under the shared directory, which is where git puts them for
+// every worktree.
+func TestModulesDirPointsAtSharedGitDir(t *testing.T) {
+	t.Parallel()
+
+	layout := Info{Root: "/repo", GitDir: "/repo/.git/worktrees/x", CommonDir: "/repo/.git", IsWorktree: true}
+	if got, want := layout.ModulesDir(), filepath.Join("/repo/.git", "modules"); got != want {
+		t.Fatalf("ModulesDir() = %s, want %s", got, want)
+	}
+
+	empty := Info{Root: "/repo", GitDir: "", CommonDir: "", IsWorktree: false}
+	if got := empty.ModulesDir(); got != "" {
+		t.Fatalf("ModulesDir() on zero Info = %s, want empty", got)
+	}
+	if got := empty.MainWorktree(); got != "" {
+		t.Fatalf("MainWorktree() on zero Info = %s, want empty", got)
+	}
+}
+
+func newTestRepo(t *testing.T) string {
+	t.Helper()
+	repoRoot := t.TempDir()
+	runGit(t, repoRoot, "init")
+	// The machine's global hooks refuse commits on a protected branch name, so
+	// point this fixture at a hooks directory of its own.
+	hooksDirectory := filepath.Join(repoRoot, ".git", "hooks-disabled")
+	if err := os.MkdirAll(hooksDirectory, 0o755); err != nil {
+		t.Fatalf("creating hooks directory: %v", err)
+	}
+	runGit(t, repoRoot, "config", "core.hooksPath", hooksDirectory)
+	runGit(t, repoRoot, "config", "user.name", "Test")
+	runGit(t, repoRoot, "config", "user.email", "test@example.invalid")
+	runGit(t, repoRoot, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("test\n"), 0o600); err != nil {
+		t.Fatalf("writing README.md: %v", err)
+	}
+	runGit(t, repoRoot, "add", "README.md")
+	runGit(t, repoRoot, "commit", "-m", "Initial commit")
+	return repoRoot
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, output)
+	}
+}

--- a/dots/internal/install/install.go
+++ b/dots/internal/install/install.go
@@ -184,6 +184,7 @@ func parseInstallArgs(args []string) (bool, sync.Options, bool, error) {
 		DryRun:         false,
 		UseDefaults:    false,
 		StrictMode:     false,
+		AllowWorktree:  false,
 	}
 
 	for _, arg := range args {

--- a/dots/internal/sync/repository/repository.go
+++ b/dots/internal/sync/repository/repository.go
@@ -11,8 +11,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"goodkind.io/.dotfiles/internal/clock"
 	"goodkind.io/.dotfiles/internal/cmdexec"
+	"goodkind.io/.dotfiles/internal/gitdir"
 	"goodkind.io/.dotfiles/internal/telemetry"
 )
 
@@ -70,11 +73,14 @@ func UpdateGitRepoSync(ctx context.Context, skipGit bool, logger *telemetry.Logg
 }
 
 func runDotfilesUpdate(ctx context.Context, dotfiles string, logger *telemetry.Logger) (string, error) {
-	reason := checkDotfilesGitHealth(ctx, dotfiles, logger)
+	layout, layoutErr := gitdir.Resolve(ctx, dotfiles, logger)
+	reason := checkDotfilesGitHealth(ctx, dotfiles, layout, logger)
 	if reason != "" {
 		return "", fmt.Errorf("skip: %s", reason)
 	}
-	clearGitLocks(dotfiles)
+	if layoutErr == nil {
+		clearStaleGitLocks(ctx, layout, logger)
+	}
 
 	if err := cmdexec.RunWithLoggerAndEnv(ctx, logger, nil, "git", "-C", dotfiles, "fetch", "origin", "--prune"); err != nil {
 		return "fetch failed", fmt.Errorf("running git fetch: %w", err)
@@ -177,7 +183,7 @@ func firstError(current error, candidate error) error {
 	return candidate
 }
 
-func checkDotfilesGitHealth(ctx context.Context, dotfiles string, logger *telemetry.Logger) string {
+func checkDotfilesGitHealth(ctx context.Context, dotfiles string, layout gitdir.Info, logger *telemetry.Logger) string {
 	branch, err := cmdexec.OutputWithLoggerAndEnv(ctx, logger, nil, "git", "-C", dotfiles, "symbolic-ref", "-q", "HEAD")
 	if err != nil || strings.TrimSpace(branch) == "" {
 		return "detached HEAD"
@@ -185,10 +191,16 @@ func checkDotfilesGitHealth(ctx context.Context, dotfiles string, logger *teleme
 	if gitCommandSucceeds(ctx, dotfiles, "rev-parse", "-q", "--verify", "MERGE_HEAD") {
 		return "merge in progress"
 	}
-	if _, err := os.Stat(filepath.Clean(filepath.Join(dotfiles, ".git", "rebase-merge"))); err == nil {
+	// Rebase state is per-worktree, so it lives in the worktree git directory
+	// rather than the shared one.
+	gitDirPath := layout.GitDir
+	if gitDirPath == "" {
+		gitDirPath = filepath.Join(dotfiles, ".git")
+	}
+	if _, err := os.Stat(filepath.Clean(filepath.Join(gitDirPath, "rebase-merge"))); err == nil {
 		return "rebase in progress"
 	}
-	if _, err := os.Stat(filepath.Clean(filepath.Join(dotfiles, ".git", "rebase-apply"))); err == nil {
+	if _, err := os.Stat(filepath.Clean(filepath.Join(gitDirPath, "rebase-apply"))); err == nil {
 		return "rebase in progress"
 	}
 	if output, err := cmdexec.OutputWithLoggerAndEnv(ctx, logger, nil, "git", "-C", dotfiles, "ls-files", "-u"); err == nil && strings.TrimSpace(output) != "" {
@@ -197,15 +209,91 @@ func checkDotfilesGitHealth(ctx context.Context, dotfiles string, logger *teleme
 	return ""
 }
 
-func clearGitLocks(dotfiles string) {
-	slog.Info("repository: clearGitLocks")
-	paths := []string{
-		filepath.Join(dotfiles, ".git", "index.lock"),
-		filepath.Join(dotfiles, ".git", "objects", "info", "commit-graph-chain.lock"),
+// staleLockAge is how old a git lock file must be before it is treated as
+// abandoned. No real git operation holds a lock for anything close to this, so
+// a lock older than this belongs to a process that died without cleaning up.
+const staleLockAge = time.Hour
+
+// gitLockNames are the lock files git creates inside a git directory. Any one
+// of them left behind by a crashed process blocks later operations.
+var gitLockNames = []string{
+	"index.lock",
+	"HEAD.lock",
+	"config.lock",
+	"shallow.lock",
+	"packed-refs.lock",
+	filepath.Join("objects", "info", "commit-graph-chain.lock"),
+}
+
+// clearStaleGitLocks removes abandoned lock files from the shared git
+// directory and from every submodule git directory beneath it.
+//
+// Submodule git directories live under <common dir>/modules, so a lock left
+// there fails `git checkout` inside the submodule while the parent repository
+// looks healthy. Locks are removed only once they are older than
+// [staleLockAge], since removing a lock a live git still holds would corrupt
+// that operation.
+func clearStaleGitLocks(ctx context.Context, layout gitdir.Info, logger *telemetry.Logger) {
+	removed := make([]string, 0)
+	for _, gitDir := range gitDirsToScan(layout) {
+		for _, lockName := range gitLockNames {
+			lockPath := filepath.Clean(filepath.Join(gitDir, lockName))
+			lockInfo, err := os.Stat(lockPath)
+			if err != nil {
+				continue
+			}
+			age := clock.Now().Sub(lockInfo.ModTime())
+			if age < staleLockAge {
+				continue
+			}
+			if err := os.Remove(lockPath); err != nil {
+				slog.WarnContext(ctx, "repository: clearStaleGitLocks: removing stale lock", "path", lockPath, "err", err)
+				continue
+			}
+			removed = append(removed, fmt.Sprintf("%s (age %s)", lockPath, age.Round(time.Minute)))
+		}
 	}
-	for _, path := range paths {
-		_ = os.Remove(filepath.Clean(path))
+	if len(removed) > 0 && logger != nil {
+		logger.InfoContext(ctx, "  cleared stale git locks: "+strings.Join(removed, ", "))
 	}
+}
+
+// gitDirsToScan returns the shared git directory plus every submodule git
+// directory under it.
+//
+// Git nests a submodule's git directory by the submodule's path, so `lib/zinit`
+// lands at <modules>/lib/zinit. The depth therefore varies with the submodule
+// path and the tree must be walked rather than listed.
+func gitDirsToScan(layout gitdir.Info) []string {
+	gitDirs := make([]string, 0, 1)
+	if layout.CommonDir != "" {
+		gitDirs = append(gitDirs, layout.CommonDir)
+	}
+	modules := layout.ModulesDir()
+	if modules == "" {
+		return gitDirs
+	}
+	return append(gitDirs, subdirectories(filepath.Clean(modules))...)
+}
+
+// subdirectories returns every directory beneath root, at any depth. An
+// unreadable directory contributes nothing rather than failing the caller,
+// since a lock sweep is best effort.
+func subdirectories(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	found := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		child := filepath.Join(root, entry.Name())
+		found = append(found, child)
+		found = append(found, subdirectories(child)...)
+	}
+	return found
 }
 
 func getRemoteStatus(ctx context.Context, dotfiles string, remoteRef string, logger *telemetry.Logger) string {
@@ -297,6 +385,11 @@ func syncDotfilesSubmodules(ctx context.Context, dotfiles string, logger *teleme
 	}
 	if len(subs) == 0 {
 		return nil
+	}
+	// A lock abandoned in a submodule git directory fails every later checkout
+	// there, and nothing else in this flow would ever clear it.
+	if layout, layoutErr := gitdir.Resolve(ctx, dotfiles, logger); layoutErr == nil {
+		clearStaleGitLocks(ctx, layout, logger)
 	}
 	if err := cmdexec.RunWithLoggerAndEnv(ctx, logger, nil, "git", "-C", dotfiles, "submodule", "update", "--init", "--recursive"); err != nil {
 		slog.WarnContext(ctx, "repository: initializing submodules", "err", err)

--- a/dots/internal/sync/repository/stalelocks_test.go
+++ b/dots/internal/sync/repository/stalelocks_test.go
@@ -1,0 +1,91 @@
+package repository
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"goodkind.io/.dotfiles/internal/gitdir"
+)
+
+// TestClearStaleGitLocksRemovesAbandonedSubmoduleLock reproduces the failure
+// that blocked the updater on every login: a lock left behind in a submodule
+// git directory, which lives under the shared directory rather than under the
+// repository root.
+func TestClearStaleGitLocksRemovesAbandonedSubmoduleLock(t *testing.T) {
+	commonDir := t.TempDir()
+	submoduleGitDir := filepath.Join(commonDir, "modules", "lib", "zinit")
+	if err := os.MkdirAll(submoduleGitDir, 0o755); err != nil {
+		t.Fatalf("creating submodule git dir: %v", err)
+	}
+
+	// The real lock was zero bytes and about two months old.
+	staleLock := filepath.Join(submoduleGitDir, "index.lock")
+	writeLock(t, staleLock, time.Now().Add(-48*time.Hour))
+
+	layout := gitdir.Info{Root: t.TempDir(), GitDir: commonDir, CommonDir: commonDir, IsWorktree: false}
+	clearStaleGitLocks(context.Background(), layout, nil)
+
+	if _, err := os.Stat(staleLock); !os.IsNotExist(err) {
+		t.Fatalf("stale submodule lock still present at %s (stat err = %v)", staleLock, err)
+	}
+}
+
+// TestClearStaleGitLocksLeavesFreshLocks confirms a lock a live git still
+// holds is not removed. Removing one would corrupt that operation.
+func TestClearStaleGitLocksLeavesFreshLocks(t *testing.T) {
+	commonDir := t.TempDir()
+	freshLock := filepath.Join(commonDir, "index.lock")
+	writeLock(t, freshLock, time.Now())
+
+	layout := gitdir.Info{Root: t.TempDir(), GitDir: commonDir, CommonDir: commonDir, IsWorktree: false}
+	clearStaleGitLocks(context.Background(), layout, nil)
+
+	if _, err := os.Stat(freshLock); err != nil {
+		t.Fatalf("fresh lock was removed from %s: %v", freshLock, err)
+	}
+}
+
+// TestClearStaleGitLocksCoversEveryLockName confirms each lock git can leave
+// behind is cleared, in the shared directory and in a submodule alike.
+func TestClearStaleGitLocksCoversEveryLockName(t *testing.T) {
+	commonDir := t.TempDir()
+	submoduleGitDir := filepath.Join(commonDir, "modules", "lib", "zsh-defer")
+	if err := os.MkdirAll(submoduleGitDir, 0o755); err != nil {
+		t.Fatalf("creating submodule git dir: %v", err)
+	}
+
+	old := time.Now().Add(-24 * time.Hour)
+	created := make([]string, 0, len(gitLockNames)*2)
+	for _, dir := range []string{commonDir, submoduleGitDir} {
+		for _, lockName := range gitLockNames {
+			lockPath := filepath.Join(dir, lockName)
+			if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+				t.Fatalf("creating lock parent: %v", err)
+			}
+			writeLock(t, lockPath, old)
+			created = append(created, lockPath)
+		}
+	}
+
+	layout := gitdir.Info{Root: t.TempDir(), GitDir: commonDir, CommonDir: commonDir, IsWorktree: false}
+	clearStaleGitLocks(context.Background(), layout, nil)
+
+	for _, lockPath := range created {
+		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+			t.Fatalf("lock still present at %s (stat err = %v)", lockPath, err)
+		}
+	}
+}
+
+func writeLock(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("writing lock %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("setting lock mod time %s: %v", path, err)
+	}
+}

--- a/dots/internal/sync/sync.go
+++ b/dots/internal/sync/sync.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"goodkind.io/.dotfiles/internal/gitdir"
 	"goodkind.io/.dotfiles/internal/runner"
 	"goodkind.io/.dotfiles/internal/sync/compilation"
 	"goodkind.io/.dotfiles/internal/sync/corpus"
@@ -35,6 +36,7 @@ type Options struct {
 	DryRun         bool
 	UseDefaults    bool
 	StrictMode     bool
+	AllowWorktree  bool
 }
 
 var commandLogger *telemetry.Logger
@@ -57,13 +59,10 @@ func Run(ctx context.Context, options Options) error {
 	runner.SetLogger(commandLogger)
 	_ = os.Setenv("DOTFILES_LOG", logPath)
 
-	notify := func(level string, message string) {
-		if err := telemetry.Notify(level, message, logPath, telemetry.RunID(ctx)); err != nil {
-			logger.WarnContextWithErr(ctx, "notification write failed", err)
-		}
-		if level == "warn" || level == "error" {
-			logger.WarnContext(ctx, message)
-		}
+	notify := newNotifier(ctx, logger, logPath)
+
+	if err := refuseLinkedWorktree(ctx, dotfiles, options, logger, notify); err != nil {
+		return err
 	}
 
 	lockFile, flockFdInt, alreadyRunning, err := acquireSyncLock(ctx, logger)
@@ -125,6 +124,44 @@ func Run(ctx context.Context, options Options) error {
 
 	logger.SuccessContext(ctx, "Dotfiles synced")
 	return nil
+}
+
+// newNotifier returns the function sync steps use to queue a notification for
+// the next interactive login, mirroring warnings and errors into the log.
+func newNotifier(ctx context.Context, logger *telemetry.Logger, logPath string) func(string, string) {
+	return func(level string, message string) {
+		if err := telemetry.Notify(level, message, logPath, telemetry.RunID(ctx)); err != nil {
+			logger.WarnContextWithErr(ctx, "notification write failed", err)
+		}
+		if level == "warn" || level == "error" {
+			logger.WarnContext(ctx, message)
+		}
+	}
+}
+
+// refuseLinkedWorktree stops a sync whose resolved root is a linked git
+// worktree rather than the canonical checkout.
+//
+// Sync rewrites the user's home directory from <root>/home, so running it from
+// a worktree repoints every managed dotfile at that worktree's branch. Every
+// step that does so is non-critical, so such a run otherwise reports success.
+// A root that is not a git checkout at all is left alone, since an archive
+// install has no git.
+func refuseLinkedWorktree(ctx context.Context, dotfiles string, options Options, logger *telemetry.Logger, notify func(string, string)) error {
+	if options.AllowWorktree {
+		return nil
+	}
+	layout, isWorktree := gitdir.LinkedWorktree(ctx, dotfiles, logger)
+	if !isWorktree {
+		return nil
+	}
+	refusal := fmt.Errorf("refusing to sync from linked worktree %s (canonical: %s); pass --allow-worktree to override", layout.Root, layout.MainWorktree())
+	logger.ErrorContextWithErr(ctx, "FATAL: refusing to sync from a linked worktree", refusal)
+	logger.InfoContext(ctx, "  root:       "+layout.Root)
+	logger.InfoContext(ctx, "  common dir: "+layout.CommonDir)
+	logger.InfoContext(ctx, "  canonical:  "+layout.MainWorktree())
+	notify("error", "sync refused: run from a linked worktree, not the canonical checkout")
+	return refusal
 }
 
 func resolveDotfilesEnv() string {

--- a/dots/internal/sync/workspace/backup_test.go
+++ b/dots/internal/sync/workspace/backup_test.go
@@ -1,0 +1,80 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"goodkind.io/.dotfiles/internal/telemetry"
+)
+
+// TestIsWithinDirRejectsSiblingWithSharedPrefix covers the containment bypass
+// a plain strings.HasPrefix check misses: a sibling directory whose name
+// starts with the same characters as root, but is not inside it.
+func TestIsWithinDirRejectsSiblingWithSharedPrefix(t *testing.T) {
+	if isWithinDir("/tmp/backup", "/tmp/backup-evil/x.bak") {
+		t.Fatal("isWithinDir(/tmp/backup, /tmp/backup-evil/x.bak) = true, want false")
+	}
+}
+
+// TestIsWithinDirAcceptsDescendantsAndSelf covers the positive cases: a
+// nested descendant, and the root path itself.
+func TestIsWithinDirAcceptsDescendantsAndSelf(t *testing.T) {
+	if !isWithinDir("/tmp/backup", "/tmp/backup/rel/x.bak") {
+		t.Fatal("isWithinDir(/tmp/backup, /tmp/backup/rel/x.bak) = false, want true")
+	}
+	if !isWithinDir("/tmp/backup", "/tmp/backup") {
+		t.Fatal("isWithinDir(/tmp/backup, /tmp/backup) = false, want true")
+	}
+}
+
+// TestClearExistingHomeFileBacksUpAndFreesThePath confirms the normal path:
+// an existing real file is backed up, then removed so the caller can place a
+// symlink there.
+func TestClearExistingHomeFileBacksUpAndFreesThePath(t *testing.T) {
+	if _, err := os.Stat("/usr/bin/cp"); err != nil {
+		t.Skip("cp is not available")
+	}
+
+	root := t.TempDir()
+	homeFile := filepath.Join(root, "home", ".zshrc")
+	backupPath := filepath.Join(root, "backup")
+	if err := os.MkdirAll(filepath.Dir(homeFile), 0o755); err != nil {
+		t.Fatalf("creating home dir: %v", err)
+	}
+	if err := os.WriteFile(homeFile, []byte("existing content\n"), 0o600); err != nil {
+		t.Fatalf("writing existing file: %v", err)
+	}
+
+	logger, _ := newBackupTestLogger(t)
+	backedUp, pathIsFree := clearExistingHomeFile(context.Background(), homeFile, backupPath, ".zshrc", logger)
+
+	if !backedUp {
+		t.Fatal("clearExistingHomeFile did not back up an existing real file")
+	}
+	if !pathIsFree {
+		t.Fatal("clearExistingHomeFile left the path occupied after a successful backup")
+	}
+	if _, err := os.Stat(homeFile); !os.IsNotExist(err) {
+		t.Fatalf("homeFile still present after backup, stat err = %v", err)
+	}
+	backupContent, err := os.ReadFile(filepath.Join(backupPath, ".zshrc.bak"))
+	if err != nil {
+		t.Fatalf("reading backup: %v", err)
+	}
+	if string(backupContent) != "existing content\n" {
+		t.Fatalf("backup content = %q, want %q", backupContent, "existing content\n")
+	}
+}
+
+func newBackupTestLogger(t *testing.T) (*telemetry.Logger, string) {
+	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "test.log")
+	logger, err := telemetry.NewLogger(logPath)
+	if err != nil {
+		t.Fatalf("creating logger: %v", err)
+	}
+	t.Cleanup(func() { _ = logger.Close() })
+	return logger, logPath
+}

--- a/dots/internal/sync/workspace/workspace.go
+++ b/dots/internal/sync/workspace/workspace.go
@@ -19,6 +19,7 @@ import (
 	"goodkind.io/.dotfiles/internal/cmdexec"
 	"goodkind.io/.dotfiles/internal/cursor/logging"
 	"goodkind.io/.dotfiles/internal/cursor/syncer"
+	"goodkind.io/.dotfiles/internal/gitdir"
 	"goodkind.io/.dotfiles/internal/runner"
 	"goodkind.io/.dotfiles/internal/sync/common"
 	"goodkind.io/.dotfiles/internal/sync/compilation"
@@ -96,16 +97,12 @@ func LinkDotfiles(ctx context.Context, dotfiles string, logger *telemetry.Logger
 			return nil
 		}
 
-		if _, err := os.Lstat(filepath.Clean(homeFile)); err == nil {
-			backupDest := filepath.Join(backupPath, rel+".bak")
-			if !strings.HasPrefix(filepath.Clean(backupDest), filepath.Clean(backupPath)) {
-				slog.WarnContext(ctx, "workspace: skipping backup, path traversal detected", "rel", rel)
-			} else if mkErr := os.MkdirAll(filepath.Dir(backupDest), 0o755); mkErr != nil {
-				slog.WarnContext(ctx, "workspace: creating backup directory, skipping backup", "err", mkErr)
-			} else if err := cmdexec.RunWithLogger(ctx, logger, "cp", "-HpR", homeFile, backupDest); err == nil {
-				backed++
-			}
-			_ = os.RemoveAll(filepath.Clean(homeFile))
+		backedUp, pathIsFree := clearExistingHomeFile(ctx, homeFile, backupPath, rel, logger)
+		if backedUp {
+			backed++
+		}
+		if !pathIsFree {
+			return nil
 		}
 
 		if err := os.MkdirAll(filepath.Dir(filepath.Clean(homeFile)), 0o755); err != nil {
@@ -126,6 +123,55 @@ func LinkDotfiles(ctx context.Context, dotfiles string, logger *telemetry.Logger
 	}
 	common.InfoContextf(ctx, logger, "  Linked: %s Skipped: %s Backed up: %s", strconv.Itoa(linked), strconv.Itoa(skipped), strconv.Itoa(backed))
 	return nil
+}
+
+// isWithinDir reports whether target is root itself or a descendant of root.
+//
+// A plain [strings.HasPrefix] on the cleaned paths is not enough: it treats
+// /tmp/backup-evil as contained within /tmp/backup, since the check compares
+// raw characters rather than path segments.
+func isWithinDir(root string, target string) bool {
+	cleanRoot := filepath.Clean(root)
+	cleanTarget := filepath.Clean(target)
+	if cleanTarget == cleanRoot {
+		return true
+	}
+	return strings.HasPrefix(cleanTarget, cleanRoot+string(filepath.Separator))
+}
+
+// clearExistingHomeFile backs up whatever already occupies homeFile and then
+// removes it, so the caller can put a symlink there.
+//
+// It reports whether a backup was taken, and whether the path is now free. A
+// real file whose backup failed is left in place and reported as not free,
+// since removing it would destroy the only copy. A symlink carries no content
+// of its own, so it is always safe to replace.
+func clearExistingHomeFile(ctx context.Context, homeFile string, backupPath string, rel string, logger *telemetry.Logger) (bool, bool) {
+	existing, err := os.Lstat(filepath.Clean(homeFile))
+	if err != nil {
+		return false, true
+	}
+
+	backedUp := false
+	backupDest := filepath.Join(backupPath, rel+".bak")
+	switch {
+	case !isWithinDir(backupPath, backupDest):
+		slog.WarnContext(ctx, "workspace: skipping backup, path traversal detected", "rel", rel)
+	default:
+		if mkErr := os.MkdirAll(filepath.Dir(backupDest), 0o755); mkErr != nil {
+			slog.WarnContext(ctx, "workspace: creating backup directory, skipping backup", "err", mkErr)
+		} else if cpErr := cmdexec.RunWithLogger(ctx, logger, "cp", "-HpR", homeFile, backupDest); cpErr == nil {
+			backedUp = true
+		}
+	}
+
+	isSymlink := existing.Mode()&os.ModeSymlink != 0
+	if !backedUp && !isSymlink {
+		slog.WarnContext(ctx, "workspace: backup failed, leaving existing file in place", "path", homeFile)
+		return false, false
+	}
+	_ = os.RemoveAll(filepath.Clean(homeFile))
+	return backedUp, true
 }
 
 // SyncSSHConfig installs the SSH config symlink into ~/.ssh/config.
@@ -265,7 +311,6 @@ func SyncCursorUserRules(ctx context.Context, dotfiles string, logger *telemetry
 func SyncGitHooks(ctx context.Context, dotfiles string, logger *telemetry.Logger) error {
 	slog.InfoContext(ctx, "workspace: SyncGitHooks")
 	hooksPath := filepath.Join(dotfiles, ".githooks")
-	destination := filepath.Join(dotfiles, ".git", "hooks")
 	if _, err := os.Stat(hooksPath); err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -273,6 +318,13 @@ func SyncGitHooks(ctx context.Context, dotfiles string, logger *telemetry.Logger
 		slog.WarnContext(ctx, "workspace: checking git hooks dir", "err", err)
 		return fmt.Errorf("checking git hooks dir: %w", err)
 	}
+	// Hooks live in the shared git directory, which every worktree uses. In a
+	// linked worktree <root>/.git is a file, so joining onto it fails.
+	gitCommonDir := filepath.Join(dotfiles, ".git")
+	if layout, err := gitdir.Resolve(ctx, dotfiles, logger); err == nil {
+		gitCommonDir = layout.CommonDir
+	}
+	destination := filepath.Join(gitCommonDir, "hooks")
 	if err := os.MkdirAll(destination, 0o755); err != nil {
 		slog.WarnContext(ctx, "workspace: creating git hooks destination", "err", err)
 		return fmt.Errorf("creating git hooks destination: %w", err)
@@ -288,7 +340,9 @@ func SyncGitHooks(ctx context.Context, dotfiles string, logger *telemetry.Logger
 		}
 		target := filepath.Join(destination, entry.Name())
 		_ = os.Remove(target)
-		if err := os.Symlink(filepath.Join("..", "..", ".githooks", entry.Name()), target); err != nil {
+		// An absolute link target stays correct wherever the shared git
+		// directory sits relative to the working tree.
+		if err := os.Symlink(filepath.Join(hooksPath, entry.Name()), target); err != nil {
 			slog.WarnContext(ctx, "workspace: creating hook symlink", "err", err)
 			return fmt.Errorf("creating hook symlink %s: %w", target, err)
 		}

--- a/dots/internal/sync/worktree_test.go
+++ b/dots/internal/sync/worktree_test.go
@@ -1,0 +1,127 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunRefusesLinkedWorktree covers the failure that repointed this
+// machine's home directory: a sync run from a linked worktree relinked every
+// managed dotfile at that worktree and still exited zero.
+//
+// The refusal must also come before the sync lock is taken, so a refused run
+// cannot block a real one.
+func TestRunRefusesLinkedWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := filepath.Join(home, ".cache", "dotfiles", "sync.log")
+	t.Setenv("DOTFILES_LOG", logPath)
+
+	canonicalRoot := newSyncTestRepo(t)
+	worktreeRoot := filepath.Join(t.TempDir(), "linked")
+	runSyncTestGit(t, canonicalRoot, "worktree", "add", "-b", "feature", worktreeRoot)
+	t.Setenv("DOTDOTFILES", worktreeRoot)
+
+	err := Run(context.Background(), syncOptionsForTest(false))
+	if err == nil {
+		t.Fatal("Run from a linked worktree returned nil, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "linked worktree") {
+		t.Fatalf("Run error = %v, want it to name the linked worktree", err)
+	}
+	if !strings.Contains(err.Error(), canonicalRoot) && !strings.Contains(err.Error(), filepath.Base(canonicalRoot)) {
+		t.Fatalf("Run error = %v, want it to name the canonical checkout %s", err, canonicalRoot)
+	}
+
+	// The refusal happens before the lock is acquired, so no lock file exists.
+	if _, statErr := os.Stat(filepath.Join(home, ".cache", "dotfiles_sync.flock")); statErr == nil {
+		t.Fatal("a refused run left a sync lock behind")
+	}
+
+	// The refusal is queued for the next login rather than only logged.
+	notifications, readErr := os.ReadFile(filepath.Join(home, ".cache", "dotfiles", "notifications"))
+	if readErr != nil {
+		t.Fatalf("reading notifications: %v", readErr)
+	}
+	if !strings.Contains(string(notifications), "sync refused") {
+		t.Fatalf("notifications = %q, want a refusal entry", notifications)
+	}
+}
+
+// TestRunAcceptsLinkedWorktreeWithOverride confirms the escape hatch works, so
+// the guard is a default rather than a wall.
+func TestRunAcceptsLinkedWorktreeWithOverride(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOTFILES_LOG", filepath.Join(home, ".cache", "dotfiles", "sync.log"))
+
+	canonicalRoot := newSyncTestRepo(t)
+	worktreeRoot := filepath.Join(t.TempDir(), "linked")
+	runSyncTestGit(t, canonicalRoot, "worktree", "add", "-b", "feature", worktreeRoot)
+	t.Setenv("DOTDOTFILES", worktreeRoot)
+
+	// Dry run keeps this from touching the real machine while still proving
+	// the guard let the pipeline start.
+	err := Run(context.Background(), syncOptionsForTest(true))
+	if err != nil {
+		t.Fatalf("Run with AllowWorktree returned error: %v", err)
+	}
+}
+
+func syncOptionsForTest(allowWorktree bool) Options {
+	return Options{
+		RepairMode:     false,
+		QuickMode:      true,
+		SkipGit:        true,
+		SkipNetwork:    true,
+		SkipCorpusSync: true,
+		SkipCursorSync: true,
+		DryRun:         true,
+		UseDefaults:    true,
+		StrictMode:     false,
+		AllowWorktree:  allowWorktree,
+	}
+}
+
+func newSyncTestRepo(t *testing.T) string {
+	t.Helper()
+	repoRoot := t.TempDir()
+	runSyncTestGit(t, repoRoot, "init")
+	// The machine's global hooks refuse commits on a protected branch name, so
+	// point this fixture at a hooks directory of its own.
+	hooksDirectory := filepath.Join(repoRoot, ".git", "hooks-disabled")
+	if err := os.MkdirAll(hooksDirectory, 0o755); err != nil {
+		t.Fatalf("creating hooks directory: %v", err)
+	}
+	runSyncTestGit(t, repoRoot, "config", "core.hooksPath", hooksDirectory)
+	runSyncTestGit(t, repoRoot, "config", "user.name", "Test")
+	runSyncTestGit(t, repoRoot, "config", "user.email", "test@example.invalid")
+	runSyncTestGit(t, repoRoot, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("test\n"), 0o600); err != nil {
+		t.Fatalf("writing README.md: %v", err)
+	}
+	runSyncTestGit(t, repoRoot, "add", "README.md")
+	runSyncTestGit(t, repoRoot, "commit", "-m", "Initial commit")
+	return repoRoot
+}
+
+func runSyncTestGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, output)
+	}
+}


### PR DESCRIPTION
### Summary

Adds a package that tells a linked git worktree apart from the canonical checkout, and uses it in two places: `dots sync` now refuses to run from a worktree, and the background updater now clears abandoned git lock files from submodule git directories.

## Why

A lock file left behind by a crashed git process blocked the updater from ever syncing again, since the existing cleanup only checked the top-level `.git` directory, removed unconditionally with no age check, and never looked inside `.git/modules/<submodule>`, which is where a submodule checkout actually fails.

Separately, sync rewrites the user's home directory from the repository's `home` folder. A run from a linked worktree pointed every managed dotfile at that worktree's branch, and every step that does so is non-critical, so the run reported success while leaving the home directory wrong.

## Change

`gitdir.Resolve` runs `git rev-parse --git-dir` and `--git-common-dir` and reports whether the two differ, which is what a linked worktree looks like. `Info.MainWorktree` and `Info.ModulesDir` derive the canonical checkout path and the submodule git directory root from the result.

Lock clearing now walks the shared git directory and every submodule git directory beneath it, and only removes a lock older than one hour so it never touches a lock a live git process still holds.

Before taking the sync lock, `dots sync` checks the resolved root's git layout and exits with an explanation naming the canonical checkout when it is a worktree. `--allow-worktree` overrides this. Git hooks now resolve their destination and symlink target from the shared git directory, since a worktree's `.git` is a file rather than a directory. A related fix stops the home-directory backup step from deleting a file whose backup failed.