### PR TITLE
Add log rotation and startup log pruning sync steps

### DIFF
--- a/config/dispatch.toml
+++ b/config/dispatch.toml
@@ -7,11 +7,11 @@ workers = [
     { name = "zwc-recompile", enabled = true },
     { name = "ssh-key-load-mac", enabled = true },
 ]
-status_dir = "${XDG_CACHE_HOME}/dotfiles_dispatch.lock"
-lock_file = "${XDG_CACHE_HOME}/dotfiles_dispatch.flock"
-log_path = "${XDG_CACHE_HOME}/dotfiles_dispatch.log"
+status_dir = "${XDG_CACHE_HOME}/dotfiles/dispatch.lock"
+lock_file = "${XDG_CACHE_HOME}/dotfiles/dispatch.flock"
+log_path = "${XDG_CACHE_HOME}/dotfiles/dispatch.log"
 weekly_update_hours = 168
-weekly_update_marker = "${XDG_CACHE_HOME}/dotfiles_weekly_update"
+weekly_update_marker = "${XDG_CACHE_HOME}/dotfiles/weekly_update"
 
 [prefer_cache]
 cache_file = "${XDG_CACHE_HOME}/zsh_prefer_aliases.zsh"

--- a/dots/go.mod
+++ b/dots/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -48,4 +49,5 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	google.golang.org/grpc v1.81.1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 )

--- a/dots/go.sum
+++ b/dots/go.sum
@@ -47,6 +47,8 @@ github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -110,6 +112,8 @@ google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zN
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=

--- a/dots/internal/dispatch/dispatch.go
+++ b/dots/internal/dispatch/dispatch.go
@@ -218,8 +218,11 @@ func RunWorkers(ctx context.Context, selectedWorkers []string) error {
 
 	logPath := util.ResolveConfigPath(dispatchConfig.LogPath, dotfiles)
 	if logPath == "" {
-		logPath = filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles_dispatch.log")
+		logPath = filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles", "dispatch.log")
 	}
+	// A sync the updater starts runs inside this process and holds this log
+	// open, so it must know which log it cannot rotate.
+	_ = os.Setenv("DOTFILES_DISPATCH_LOG", logPath)
 	dispatchLogger, err := telemetry.NewLogger(logPath)
 	if err != nil {
 		return fmt.Errorf("creating dispatch logger: %w", err)
@@ -236,7 +239,7 @@ func RunWorkers(ctx context.Context, selectedWorkers []string) error {
 	}
 	lockPath := util.ResolveConfigPath(dispatchConfig.LockFile, dotfiles)
 	if lockPath == "" {
-		lockPath = filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles_dispatch.flock")
+		lockPath = filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles", "dispatch.flock")
 	}
 	lockFile, err := os.OpenFile(filepath.Clean(lockPath), os.O_CREATE|os.O_RDWR, 0o666)
 	if err != nil {
@@ -257,7 +260,7 @@ func RunWorkers(ctx context.Context, selectedWorkers []string) error {
 
 	statusDir := util.ResolveConfigPath(dispatchConfig.StatusDir, dotfiles)
 	if statusDir == "" {
-		statusDir = filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles_dispatch.lock")
+		statusDir = filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles", "dispatch.lock")
 	}
 	if err := os.MkdirAll(filepath.Clean(statusDir), 0o755); err != nil {
 		return fmt.Errorf("creating status directory: %w", err)
@@ -305,7 +308,7 @@ func logWorkersStart(ctx context.Context, workers []workerEntry, logger *telemet
 
 func notifyDispatchLogPath(logPath string) string {
 	if logPath == "" {
-		return filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles_dispatch.log")
+		return filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles", "dispatch.log")
 	}
 	return logPath
 }

--- a/dots/internal/dispatch/updater/updater.go
+++ b/dots/internal/dispatch/updater/updater.go
@@ -155,7 +155,7 @@ func doWeeklyUpdate(ctx context.Context, dotfiles, weeklyMarkerPath string, disp
 
 	now := strconv.FormatInt(clock.Now().Unix(), 10)
 	if weeklyMarkerPath == "" {
-		weeklyMarkerPath = filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles_weekly_update")
+		weeklyMarkerPath = filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles", "weekly_update")
 	}
 	_ = os.WriteFile(filepath.Clean(weeklyMarkerPath), []byte(now), 0o600)
 	return nil

--- a/dots/internal/perf/perf.go
+++ b/dots/internal/perf/perf.go
@@ -210,14 +210,14 @@ func runHistory(args []string) error {
 		return fmt.Errorf("parse perf history flags: %w", err)
 	}
 
-	records, err := loadRecords()
+	decodeLimit := 0
+	if !*showAll && *last > 0 {
+		decodeLimit = *last
+	}
+	records, total, err := loadRecords(decodeLimit)
 	if err != nil {
 		slog.Error("load startup records", "err", err)
 		return err
-	}
-	total := len(records)
-	if !*showAll && *last > 0 && len(records) > *last {
-		records = records[:*last]
 	}
 
 	if *slowOnly {
@@ -366,7 +366,7 @@ func printUsage() {
 }
 
 func selectRecord(useGlobal bool) (startupRecord, error) {
-	records, err := loadRecords()
+	records, _, err := loadRecords(maxRecordsScanned)
 	if err != nil {
 		return startupRecord{}, err
 	}
@@ -388,20 +388,38 @@ func selectRecord(useGlobal bool) (startupRecord, error) {
 	return records[0], nil
 }
 
-func loadRecords() ([]startupRecord, error) {
+// maxRecordsScanned bounds how many startup logs a single-record lookup will
+// read. The startup directory holds one file per shell, so reading all of them
+// to answer a question about the newest few is wasted work.
+const maxRecordsScanned = 100
+
+// candidate pairs a startup log path with its modification time, so the set can
+// be ordered before any file is read.
+type candidate struct {
+	path    string
+	modTime time.Time
+}
+
+// loadRecords returns the newest startup logs, most recent first, along with
+// how many logs exist in total.
+//
+// Ordering happens on modification time alone, so only the logs the caller
+// actually needs are read and decoded. A limit of zero or less reads all of
+// them.
+func loadRecords(limit int) ([]startupRecord, int, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		slog.Error("resolve home directory", "err", err)
-		return nil, fmt.Errorf("resolve home directory: %w", err)
+		return nil, 0, fmt.Errorf("resolve home directory: %w", err)
 	}
 	pattern := filepath.Join(home, ".cache", "zsh_startup", "*.json")
 	paths, err := filepath.Glob(pattern)
 	if err != nil {
 		slog.Error("list startup logs", "err", err)
-		return nil, fmt.Errorf("list startup logs: %w", err)
+		return nil, 0, fmt.Errorf("list startup logs: %w", err)
 	}
 
-	records := make([]startupRecord, 0, len(paths))
+	candidates := make([]candidate, 0, len(paths))
 	for _, path := range paths {
 		if filepath.Base(path) == "latest.json" {
 			continue
@@ -410,7 +428,23 @@ func loadRecords() ([]startupRecord, error) {
 		if err != nil {
 			continue
 		}
-		raw, err := os.ReadFile(path)
+		candidates = append(candidates, candidate{path: path, modTime: info.ModTime()})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].modTime.Equal(candidates[j].modTime) {
+			return candidates[i].path > candidates[j].path
+		}
+		return candidates[i].modTime.After(candidates[j].modTime)
+	})
+
+	total := len(candidates)
+	if limit > 0 && total > limit {
+		candidates = candidates[:limit]
+	}
+
+	records := make([]startupRecord, 0, len(candidates))
+	for _, item := range candidates {
+		raw, err := os.ReadFile(item.path)
 		if err != nil {
 			continue
 		}
@@ -419,20 +453,13 @@ func loadRecords() ([]startupRecord, error) {
 			continue
 		}
 		records = append(records, startupRecord{
-			Path:    path,
-			ModTime: info.ModTime(),
+			Path:    item.path,
+			ModTime: item.modTime,
 			Raw:     raw,
 			Log:     log,
 		})
 	}
-
-	sort.Slice(records, func(i, j int) bool {
-		if records[i].ModTime.Equal(records[j].ModTime) {
-			return records[i].Path > records[j].Path
-		}
-		return records[i].ModTime.After(records[j].ModTime)
-	})
-	return records, nil
+	return records, total, nil
 }
 
 func currentTTYID() string {

--- a/dots/internal/sync/logrotate/logrotate.go
+++ b/dots/internal/sync/logrotate/logrotate.go
@@ -1,0 +1,233 @@
+// Package logrotate keeps the log and cache directories this binary writes to
+// from growing without bound. It runs as sync steps rather than as part of any
+// write path, so ordinary logging stays a plain append.
+package logrotate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"goodkind.io/.dotfiles/internal/clock"
+	"goodkind.io/.dotfiles/internal/telemetry"
+	"goodkind.io/gklog"
+)
+
+const (
+	// defaultMaxSizeMB is the size a log must exceed before it is rotated.
+	defaultMaxSizeMB = 8
+	// defaultMaxBackups is how many rotated generations of each log to keep.
+	defaultMaxBackups = 3
+	// defaultMaxAgeDays is how long a rotated generation is kept. Zero keeps
+	// each generation until MaxBackups evicts it.
+	defaultMaxAgeDays = 0
+	// bytesPerMB converts the configured megabyte trigger into a byte size.
+	bytesPerMB = 1024 * 1024
+
+	// syssnapPrefix marks the per-shell system snapshots that .zshenv writes.
+	syssnapPrefix = ".syssnap_"
+	// syssnapMaxAge is how old a snapshot must be before it counts as
+	// abandoned. The shell that wrote one consumes it while writing its
+	// startup log, so anything older belongs to a shell that never got there.
+	syssnapMaxAge = time.Hour
+	// startupLogRetention is how many startup logs to keep, newest first.
+	startupLogRetention = 500
+	// startupLogSuffix is the extension of a startup performance log.
+	startupLogSuffix = ".json"
+
+	// dispatchLogEnvVar names the log a background dispatch has open. Dispatch
+	// exports it, and a sync the updater starts runs inside that same process,
+	// so this is how such a run recognises the log it must not rename.
+	dispatchLogEnvVar = "DOTFILES_DISPATCH_LOG"
+)
+
+// DefaultRotationConfig returns the rotation settings used when the dispatch
+// config supplies none.
+func DefaultRotationConfig() gklog.RotationConfig {
+	return gklog.RotationConfig{
+		MaxSizeMB:  defaultMaxSizeMB,
+		MaxBackups: defaultMaxBackups,
+		MaxAgeDays: defaultMaxAgeDays,
+		Compress:   nil,
+		LocalTime:  nil,
+	}
+}
+
+// Rotate rotates every log this binary writes that has grown past the
+// configured trigger.
+//
+// A log this process currently has open is left alone. Rotation renames the
+// live file, and the open descriptor would keep pointing at the renamed one,
+// so the rest of this run's output would land in the file that was just
+// retired. Every other log is safe to rotate.
+func Rotate(ctx context.Context, rotation gklog.RotationConfig, logger *telemetry.Logger) error {
+	maxSizeMB := rotation.MaxSizeMB
+	if maxSizeMB <= 0 {
+		maxSizeMB = defaultMaxSizeMB
+	}
+	triggerBytes := int64(maxSizeMB) * bytesPerMB
+
+	rotated := make([]string, 0)
+	deferred := make([]string, 0)
+	failed := make([]string, 0)
+	for _, logPath := range telemetry.KnownLogPaths() {
+		info, err := os.Stat(filepath.Clean(logPath))
+		if err != nil || info.Size() <= triggerBytes {
+			continue
+		}
+		if isOpenByThisProcess(logPath) {
+			deferred = append(deferred, filepath.Base(logPath))
+			continue
+		}
+		if err := rotateOne(ctx, logPath, rotation); err != nil {
+			failed = append(failed, filepath.Base(logPath))
+			continue
+		}
+		rotated = append(rotated, fmt.Sprintf("%s (%d MB)", filepath.Base(logPath), info.Size()/bytesPerMB))
+	}
+
+	if len(rotated) > 0 {
+		logger.InfoContext(ctx, "  rotated: "+strings.Join(rotated, ", "))
+	} else {
+		logger.InfoContext(ctx, "  no logs past the size trigger")
+	}
+	if len(deferred) > 0 {
+		logger.InfoContext(ctx, "  in use by this run, left for a later sync: "+strings.Join(deferred, ", "))
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("rotating logs: %s", strings.Join(failed, ", "))
+	}
+	return nil
+}
+
+// isOpenByThisProcess reports whether logPath is a log this process is writing
+// to right now. Two are possible: the log this command opened, and the
+// dispatch log when this command runs as part of a background dispatch.
+func isOpenByThisProcess(logPath string) bool {
+	target := filepath.Clean(logPath)
+	for _, envName := range []string{"DOTFILES_LOG", dispatchLogEnvVar} {
+		value := os.Getenv(envName)
+		if value != "" && filepath.Clean(value) == target {
+			return true
+		}
+	}
+	return false
+}
+
+// rotateOne renames one log aside and starts a fresh file in its place. The
+// rotator also prunes older generations according to rotation.
+func rotateOne(ctx context.Context, logPath string, rotation gklog.RotationConfig) error {
+	writer := gklog.NewLumberjackWriterWithConfig(logPath, rotation)
+	if err := writer.Rotate(); err != nil {
+		slog.WarnContext(ctx, "logrotate: rotateOne: rotating log", "path", logPath, "err", err)
+		return fmt.Errorf("rotating %s: %w", logPath, err)
+	}
+	if err := writer.Close(); err != nil {
+		slog.WarnContext(ctx, "logrotate: rotateOne: closing rotator", "path", logPath, "err", err)
+	}
+	return nil
+}
+
+// PruneStartupLogs bounds the shell startup cache directory.
+//
+// It removes abandoned per-shell snapshots and keeps only the newest
+// [startupLogRetention] startup logs. The directory is read in a single pass,
+// since it can hold tens of thousands of entries and a glob over it is slow.
+func PruneStartupLogs(ctx context.Context, logger *telemetry.Logger) error {
+	startupDir := filepath.Join(os.Getenv("HOME"), ".cache", "zsh_startup")
+	entries, err := os.ReadDir(filepath.Clean(startupDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		slog.WarnContext(ctx, "logrotate: PruneStartupLogs: reading startup dir", "path", startupDir, "err", err)
+		return fmt.Errorf("reading startup log directory: %w", err)
+	}
+
+	now := clock.Now()
+	startupLogs := make([]startupLog, 0, len(entries))
+	removedSnapshots := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(name, syssnapPrefix):
+			if now.Sub(info.ModTime()) < syssnapMaxAge {
+				continue
+			}
+			path, ok := containedPath(startupDir, name)
+			if !ok {
+				continue
+			}
+			if err := os.Remove(path); err == nil {
+				removedSnapshots++
+			}
+		case strings.HasSuffix(name, startupLogSuffix):
+			startupLogs = append(startupLogs, startupLog{name: name, modTime: info.ModTime()})
+		}
+	}
+
+	removedLogs := removeOldestStartupLogs(ctx, startupDir, startupLogs)
+	logger.InfoContext(ctx, fmt.Sprintf("  removed %d abandoned snapshot(s), %d old startup log(s)", removedSnapshots, removedLogs))
+	return nil
+}
+
+// startupLog pairs a startup log's directory entry name with the time it was
+// written. The name is kept rather than a full path so the containment check
+// runs at the point of removal.
+type startupLog struct {
+	name    string
+	modTime time.Time
+}
+
+// removeOldestStartupLogs keeps the newest [startupLogRetention] logs and
+// removes the rest, returning how many it removed.
+func removeOldestStartupLogs(ctx context.Context, startupDir string, logs []startupLog) int {
+	if len(logs) <= startupLogRetention {
+		return 0
+	}
+	sort.Slice(logs, func(i int, j int) bool {
+		return logs[i].modTime.After(logs[j].modTime)
+	})
+	removed := 0
+	failures := 0
+	for _, log := range logs[startupLogRetention:] {
+		path, ok := containedPath(startupDir, log.name)
+		if !ok {
+			failures++
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			failures++
+			continue
+		}
+		removed++
+	}
+	if failures > 0 {
+		slog.WarnContext(ctx, "logrotate: removeOldestStartupLogs: some logs could not be removed", "dir", startupDir, "failures", failures)
+	}
+	return removed
+}
+
+// containedPath joins name onto dir and reports whether the result stays
+// inside dir. Directory entry names never contain a separator, so this can
+// only reject a name the filesystem should not have produced.
+func containedPath(dir string, name string) (string, bool) {
+	cleanDir := filepath.Clean(dir)
+	joined := filepath.Clean(filepath.Join(cleanDir, name))
+	if filepath.Dir(joined) != cleanDir {
+		return "", false
+	}
+	return joined, true
+}

--- a/dots/internal/sync/logrotate/logrotate_test.go
+++ b/dots/internal/sync/logrotate/logrotate_test.go
@@ -1,0 +1,320 @@
+package logrotate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"goodkind.io/.dotfiles/internal/telemetry"
+)
+
+// TestRotateOnlyTouchesLogsPastTheTrigger confirms rotation is size driven, so
+// an ordinary small log is left alone while an oversized one is renamed aside
+// and restarted.
+func TestRotateOnlyTouchesLogsPastTheTrigger(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	oversized := filepath.Join(home, ".cache", "dotfiles", "dispatch.log")
+	small := filepath.Join(home, ".cache", "dotfiles", "sync.log")
+	writeLog(t, oversized, 2*bytesPerMB)
+	writeLog(t, small, 1024)
+
+	logger, _ := newTestLogger(t)
+	rotation := DefaultRotationConfig()
+	rotation.MaxSizeMB = 1
+
+	if err := Rotate(context.Background(), rotation, logger); err != nil {
+		t.Fatalf("Rotate returned error: %v", err)
+	}
+	waitForCompressedBackup(t, filepath.Dir(oversized), "dispatch")
+
+	oversizedInfo, err := os.Stat(oversized)
+	if err != nil {
+		t.Fatalf("stat rotated log: %v", err)
+	}
+	if oversizedInfo.Size() != 0 {
+		t.Fatalf("live log size = %d, want 0 after rotation", oversizedInfo.Size())
+	}
+	if backups := backupCount(t, filepath.Dir(oversized), "dispatch"); backups != 1 {
+		t.Fatalf("backup count = %d, want 1", backups)
+	}
+
+	smallInfo, err := os.Stat(small)
+	if err != nil {
+		t.Fatalf("stat small log: %v", err)
+	}
+	if smallInfo.Size() != 1024 {
+		t.Fatalf("small log size = %d, want 1024 (it should not have rotated)", smallInfo.Size())
+	}
+}
+
+// TestRotateReportsAFailedRotation confirms a rotation failure is not
+// swallowed. A rotation step that silently continued on error would report
+// success to the sync runner even though a log was never rotated.
+func TestRotateReportsAFailedRotation(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores directory write permissions, so this cannot fail")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cacheDir := filepath.Join(home, ".cache")
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	logDir := filepath.Join(cacheDir, "dotfiles")
+	oversized := filepath.Join(logDir, "dispatch.log")
+	writeLog(t, oversized, 2*bytesPerMB)
+
+	// Rotation renames the log within its parent directory, which needs
+	// write permission on that directory rather than on the file itself.
+	if err := os.Chmod(logDir, 0o500); err != nil {
+		t.Fatalf("removing write permission on %s: %v", logDir, err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(logDir, 0o755) })
+
+	logger, _ := newTestLogger(t)
+	rotation := DefaultRotationConfig()
+	rotation.MaxSizeMB = 1
+
+	err := Rotate(context.Background(), rotation, logger)
+	if err == nil {
+		t.Fatal("Rotate returned nil for a log it could not rename, want an error")
+	}
+	if !strings.Contains(err.Error(), "dispatch.log") {
+		t.Fatalf("Rotate error = %v, want it to name the log that failed to rotate", err)
+	}
+}
+
+// TestRotateLeavesLogsThisRunHasOpen covers the case that made the first
+// attempt at this step a no-op in practice: the updater runs a sync inside the
+// dispatch process, so the dispatch log is open the whole time. Renaming it
+// would send the rest of the run's output into the retired file.
+//
+// Everything else must still rotate, since skipping the whole step was what
+// stopped any log from ever being rotated on that path.
+func TestRotateLeavesLogsThisRunHasOpen(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	dispatchLog := filepath.Join(home, ".cache", "dotfiles", "dispatch.log")
+	ownLog := filepath.Join(home, ".cache", "dotfiles", "sync.log")
+	otherLog := filepath.Join(home, ".cache", "dotfiles", "dots.log")
+	writeLog(t, dispatchLog, 2*bytesPerMB)
+	writeLog(t, ownLog, 2*bytesPerMB)
+	writeLog(t, otherLog, 2*bytesPerMB)
+
+	t.Setenv("DOTFILES_DISPATCH_LOG", dispatchLog)
+	t.Setenv("DOTFILES_LOG", ownLog)
+
+	logger, logPath := newTestLogger(t)
+	rotation := DefaultRotationConfig()
+	rotation.MaxSizeMB = 1
+
+	if err := Rotate(context.Background(), rotation, logger); err != nil {
+		t.Fatalf("Rotate returned error: %v", err)
+	}
+	waitForCompressedBackup(t, filepath.Dir(otherLog), "dots")
+
+	assertSize(t, dispatchLog, 2*bytesPerMB, "the dispatch log is open and must not rotate")
+	assertSize(t, ownLog, 2*bytesPerMB, "this run's own log is open and must not rotate")
+	assertSize(t, otherLog, 0, "an idle oversized log must rotate")
+
+	if backups := backupCount(t, filepath.Dir(otherLog), "dots"); backups != 1 {
+		t.Fatalf("backup count for the idle log = %d, want 1", backups)
+	}
+
+	if err := logger.Close(); err != nil {
+		t.Fatalf("closing logger: %v", err)
+	}
+	logged := readFile(t, logPath)
+	if !strings.Contains(logged, "in use by this run") {
+		t.Fatalf("log does not name the logs it left alone: %s", logged)
+	}
+}
+
+// TestPruneStartupLogsRemovesAbandonedSnapshotsAndOldLogs confirms the sweep
+// keeps a shell that is still running, keeps the newest startup logs, and
+// removes everything else.
+func TestPruneStartupLogsRemovesAbandonedSnapshotsAndOldLogs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	startupDir := filepath.Join(home, ".cache", "zsh_startup")
+	if err := os.MkdirAll(startupDir, 0o755); err != nil {
+		t.Fatalf("creating startup dir: %v", err)
+	}
+
+	now := time.Now()
+	abandonedSnapshot := filepath.Join(startupDir, syssnapPrefix+"111")
+	liveSnapshot := filepath.Join(startupDir, syssnapPrefix+"222")
+	writeAt(t, abandonedSnapshot, now.Add(-2*time.Hour))
+	writeAt(t, liveSnapshot, now.Add(-time.Minute))
+
+	// One more log than the retention limit, each a minute older than the last.
+	totalLogs := startupLogRetention + 5
+	logNames := make([]string, 0, totalLogs)
+	for i := range totalLogs {
+		name := filepath.Join(startupDir, formatLogName(i))
+		writeAt(t, name, now.Add(-time.Duration(i)*time.Minute))
+		logNames = append(logNames, name)
+	}
+
+	// A file that is neither a snapshot nor a startup log must survive.
+	pathCache := filepath.Join(startupDir, "path_cache.zsh")
+	writeAt(t, pathCache, now.Add(-72*time.Hour))
+
+	logger, _ := newTestLogger(t)
+	if err := PruneStartupLogs(context.Background(), logger); err != nil {
+		t.Fatalf("PruneStartupLogs returned error: %v", err)
+	}
+
+	assertMissing(t, abandonedSnapshot)
+	assertPresent(t, liveSnapshot)
+	assertPresent(t, pathCache)
+
+	for i, name := range logNames {
+		if i < startupLogRetention {
+			assertPresent(t, name)
+		} else {
+			assertMissing(t, name)
+		}
+	}
+}
+
+// TestPruneStartupLogsAcceptsAMissingDirectory confirms a host that has never
+// run an interactive shell does not fail the sync step.
+func TestPruneStartupLogsAcceptsAMissingDirectory(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	logger, _ := newTestLogger(t)
+	if err := PruneStartupLogs(context.Background(), logger); err != nil {
+		t.Fatalf("PruneStartupLogs returned error: %v", err)
+	}
+}
+
+func formatLogName(index int) string {
+	return "20260807_" + string(rune('a'+index/26)) + string(rune('a'+index%26)) + "_ttys000.json"
+}
+
+func writeLog(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("creating log dir: %v", err)
+	}
+	if err := os.WriteFile(path, make([]byte, size), 0o600); err != nil {
+		t.Fatalf("writing log %s: %v", path, err)
+	}
+}
+
+func writeAt(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("setting mod time on %s: %v", path, err)
+	}
+}
+
+// waitForCompressedBackup blocks until dir holds exactly one backup with the
+// given prefix and it is compressed.
+//
+// lumberjack.Logger.Rotate renames the oversized log aside synchronously, but
+// compression and removal of the uncompressed copy happen afterward in a
+// background goroutine it never waits on: the compressed file is written
+// first and the plain one removed only once that succeeds, so both can exist
+// briefly. Waiting for a lone .gz match, rather than any .gz match, is what
+// closes that window. Without waiting at all, a test can return and
+// t.TempDir's cleanup can race the goroutine, removing the directory while it
+// is still being written to.
+func waitForCompressedBackup(t *testing.T, dir string, prefix string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		entries, err := os.ReadDir(dir)
+		if err == nil {
+			matches := 0
+			compressed := 0
+			for _, entry := range entries {
+				name := entry.Name()
+				if !strings.HasPrefix(name, prefix+"-") {
+					continue
+				}
+				matches++
+				if strings.HasSuffix(name, ".gz") {
+					compressed++
+				}
+			}
+			if matches == 1 && compressed == 1 {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for exactly one compressed backup with prefix %q in %s", prefix, dir)
+}
+
+func backupCount(t *testing.T, dir string, prefix string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	count := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, prefix+"-") {
+			count++
+		}
+	}
+	return count
+}
+
+func assertSize(t *testing.T, path string, want int, why string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if info.Size() != int64(want) {
+		t.Fatalf("%s size = %d, want %d: %s", filepath.Base(path), info.Size(), want, why)
+	}
+}
+
+func newTestLogger(t *testing.T) (*telemetry.Logger, string) {
+	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "test.log")
+	logger, err := telemetry.NewLogger(logPath)
+	if err != nil {
+		t.Fatalf("creating logger: %v", err)
+	}
+	t.Cleanup(func() { _ = logger.Close() })
+	return logger, logPath
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(content)
+}
+
+func assertPresent(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to survive, stat err = %v", path, err)
+	}
+}
+
+func assertMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be removed, stat err = %v", path, err)
+	}
+}

--- a/dots/internal/sync/sync.go
+++ b/dots/internal/sync/sync.go
@@ -15,6 +15,7 @@ import (
 	"goodkind.io/.dotfiles/internal/runner"
 	"goodkind.io/.dotfiles/internal/sync/compilation"
 	"goodkind.io/.dotfiles/internal/sync/corpus"
+	"goodkind.io/.dotfiles/internal/sync/logrotate"
 	"goodkind.io/.dotfiles/internal/sync/platform"
 	"goodkind.io/.dotfiles/internal/sync/platform/debian"
 	"goodkind.io/.dotfiles/internal/sync/platform/macos"
@@ -374,6 +375,16 @@ func runCompilationSteps(dotfiles string, logger *telemetry.Logger, step syncSte
 	}
 	if err := step("Creating hushlogin", false, func(ctx context.Context) error {
 		return compilation.CreateHushLogin(ctx, logger)
+	}); err != nil {
+		return err
+	}
+	if err := step("Rotating logs", false, func(ctx context.Context) error {
+		return logrotate.Rotate(ctx, logrotate.DefaultRotationConfig(), logger)
+	}); err != nil {
+		return err
+	}
+	if err := step("Pruning startup logs", false, func(ctx context.Context) error {
+		return logrotate.PruneStartupLogs(ctx, logger)
 	}); err != nil {
 		return err
 	}

--- a/dots/internal/telemetry/telemetry.go
+++ b/dots/internal/telemetry/telemetry.go
@@ -55,6 +55,45 @@ func ConfigureDefaultSlogFromEnv() {
 	slog.SetDefault(slog.New(handler))
 }
 
+// cacheLogNames are the log files this binary opens under the dotfiles cache
+// directory. Each is resolved independently at its own entry point, so this
+// list exists for maintenance rather than for resolution.
+var cacheLogNames = []string{
+	"sync.log",
+	"dots.log",
+	"install.log",
+	"uninstall.log",
+	"cursor.log",
+}
+
+// KnownLogPaths returns every log file this binary appends to. Maintenance
+// that operates on logs as a set, such as rotation, uses this so it cannot
+// drift from the entry points that open them.
+func KnownLogPaths() []string {
+	paths := make([]string, 0, len(cacheLogNames)+1)
+	paths = append(paths, dispatchLogPath())
+	for _, name := range cacheLogNames {
+		paths = append(paths, filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles", name))
+	}
+	return paths
+}
+
+// dispatchLogPath returns the dispatch log's real path. DOTFILES_DISPATCH_LOG
+// names it exactly when a dispatch process is running, since dispatch resolves
+// its own path from config rather than from this default. Only when that
+// variable is unset does this fall back to the default the dispatch config
+// itself falls back to.
+func dispatchLogPath() string {
+	if configured := os.Getenv("DOTFILES_DISPATCH_LOG"); configured != "" {
+		return configured
+	}
+	cacheDir := os.Getenv("XDG_CACHE_HOME")
+	if cacheDir == "" {
+		cacheDir = filepath.Join(os.Getenv("HOME"), ".cache")
+	}
+	return filepath.Join(cacheDir, "dotfiles", "dispatch.log")
+}
+
 // Logger provides structured logging to both a JSON log file and a TTY-aware stdout/stderr.
 type Logger struct {
 	mu         sync.Mutex

--- a/dots/internal/telemetry/telemetry_test.go
+++ b/dots/internal/telemetry/telemetry_test.go
@@ -9,6 +9,41 @@ import (
 	"time"
 )
 
+// TestKnownLogPathsHonorsDotfilesDispatchLog confirms KnownLogPaths reports
+// the dispatch process's real log path when DOTFILES_DISPATCH_LOG names it,
+// rather than reconstructing a default that can point somewhere else. Dispatch
+// resolves its own log path from config, not from this default, so the
+// default is only a fallback for when no dispatch process is running.
+func TestKnownLogPathsHonorsDotfilesDispatchLog(t *testing.T) {
+	homeDirectory := t.TempDir()
+	t.Setenv("HOME", homeDirectory)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(homeDirectory, ".cache"))
+
+	configured := filepath.Join(homeDirectory, "elsewhere", "dispatch.log")
+	t.Setenv("DOTFILES_DISPATCH_LOG", configured)
+
+	paths := KnownLogPaths()
+	if paths[0] != configured {
+		t.Fatalf("KnownLogPaths()[0] = %s, want %s", paths[0], configured)
+	}
+}
+
+// TestKnownLogPathsFallsBackWithoutDotfilesDispatchLog confirms the default
+// construction still applies when no dispatch process is running.
+func TestKnownLogPathsFallsBackWithoutDotfilesDispatchLog(t *testing.T) {
+	homeDirectory := t.TempDir()
+	t.Setenv("HOME", homeDirectory)
+	cacheDir := filepath.Join(homeDirectory, ".cache")
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+	t.Setenv("DOTFILES_DISPATCH_LOG", "")
+
+	paths := KnownLogPaths()
+	want := filepath.Join(cacheDir, "dotfiles", "dispatch.log")
+	if paths[0] != want {
+		t.Fatalf("KnownLogPaths()[0] = %s, want %s", paths[0], want)
+	}
+}
+
 func TestNotifyWritesTimestampedNotification(t *testing.T) {
 	homeDirectory := t.TempDir()
 	logPath := filepath.Join(homeDirectory, ".cache", "dotfiles", "sync.log")

--- a/dots/internal/uninstall/uninstall.go
+++ b/dots/internal/uninstall/uninstall.go
@@ -260,6 +260,9 @@ func removeCacheFiles() {
 		"dotfiles_update_error",
 		"dotfiles_update_success",
 		"dotfiles_debug_enabled",
+		// Pre-rename names, still cleaned up on machines that ran the older
+		// layout where these lived directly under .cache instead of
+		// .cache/dotfiles.
 		"dotfiles_dispatch.flock",
 		"dotfiles_dispatch.log",
 		"dotfiles_weekly_update",
@@ -267,6 +270,15 @@ func removeCacheFiles() {
 		_ = removeIfExists(filepath.Join(os.Getenv("HOME"), ".cache", name))
 	}
 	_ = removeIfExists(filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles_dispatch.lock"))
+
+	for _, name := range []string{
+		"dispatch.flock",
+		"dispatch.log",
+		"weekly_update",
+	} {
+		_ = removeIfExists(filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles", name))
+	}
+	_ = removeIfExists(filepath.Join(os.Getenv("HOME"), ".cache", "dotfiles", "dispatch.lock"))
 }
 
 func removeHushlogin(ctx context.Context) {

--- a/home/.zshenv
+++ b/home/.zshenv
@@ -120,21 +120,28 @@ _PERF_LAP=$EPOCHREALTIME
 # Capture system snapshot at startup for diagnosing pre-zshrc slowness.
 # Runs in a subshell so it never blocks the shell startup path.
 # Outer { } 2>/dev/null suppresses nice(5) and mkdir errors in sandboxed envs.
-{
-    (
-        snap_file="${HOME}/.cache/zsh_startup/.syssnap_$$"
-        mkdir -p "${HOME}/.cache/zsh_startup"
-        {
-            printf "# syssnap pid=%d time=%s\n" "$$" "$(date '+%Y-%m-%d %H:%M:%S.%3N %Z')"
-            printf "\n## top CPU processes\n"
-            ps -Ao pid,pcpu,pmem,comm -r 2>/dev/null | head -15
-            printf "\n## load average\n"
-            sysctl -n vm.loadavg 2>/dev/null || uptime
-            printf "\n## disk activity (iostat)\n"
-            iostat -d disk0 2>/dev/null | head -6
-            printf "\n## path_helper entries\n"
-            ls /etc/paths.d/ 2>/dev/null
-            printf "\n## TERM_PROGRAM=%s\n" "${TERM_PROGRAM:-unset}"
-        } > "$snap_file" 2>/dev/null
-    ) &!
-} 2>/dev/null
+#
+# The gate below must stay identical to the one in _write_startup_log
+# (zshrc/core/perf.zsh), which is the only code that reads this file and deletes
+# it. A shell that writes a snapshot the consumer will never look at leaves it
+# behind forever, so any drift between the two tests leaks one file per shell.
+if [[ -t 1 || "${ZSH_PERF:-}" == "1" ]]; then
+    {
+        (
+            snap_file="${HOME}/.cache/zsh_startup/.syssnap_$$"
+            mkdir -p "${HOME}/.cache/zsh_startup"
+            {
+                printf "# syssnap pid=%d time=%s\n" "$$" "$(date '+%Y-%m-%d %H:%M:%S.%3N %Z')"
+                printf "\n## top CPU processes\n"
+                ps -Ao pid,pcpu,pmem,comm -r 2>/dev/null | head -15
+                printf "\n## load average\n"
+                sysctl -n vm.loadavg 2>/dev/null || uptime
+                printf "\n## disk activity (iostat)\n"
+                iostat -d disk0 2>/dev/null | head -6
+                printf "\n## path_helper entries\n"
+                ls /etc/paths.d/ 2>/dev/null
+                printf "\n## TERM_PROGRAM=%s\n" "${TERM_PROGRAM:-unset}"
+            } > "$snap_file" 2>/dev/null
+        ) &!
+    } 2>/dev/null
+fi

--- a/zshrc/core/perf.zsh
+++ b/zshrc/core/perf.zsh
@@ -77,6 +77,9 @@ function _perf_first_precmd() {
 }
 precmd_functions=(_perf_first_precmd $precmd_functions)
 
+# The gate below must stay identical to the one guarding the syssnap writer in
+# home/.zshenv. This function is the only code that reads a syssnap and deletes
+# it, so a shell that writes one without reaching here leaks the file.
 function _write_startup_log() {
     if [[ ! -t 1 && "${ZSH_PERF:-}" != "1" ]]; then
         return 0

--- a/zshrc/core/startup.zsh
+++ b/zshrc/core/startup.zsh
@@ -35,13 +35,13 @@ function _dotfiles_install_in_progress() {
 
 # Show transient "running now" state from background dispatch.
 function _dotfiles_show_dispatch_banner() {
-    if [[ ! -d ~/.cache/dotfiles_dispatch.lock ]]; then
+    if [[ ! -d ~/.cache/dotfiles/dispatch.lock ]]; then
         return 0
     fi
 
     local update_type=""
-    if [[ -f ~/.cache/dotfiles_dispatch.lock/status ]]; then
-        update_type=$(<~/.cache/dotfiles_dispatch.lock/status)
+    if [[ -f ~/.cache/dotfiles/dispatch.lock/status ]]; then
+        update_type=$(<~/.cache/dotfiles/dispatch.lock/status)
     fi
     if [[ "$update_type" == "weekly" ]]; then
         print -P "%F{blue}↻ weekly update running in background%f"


### PR DESCRIPTION
Stacked on: https://github.com/agoodkind/.dotfiles/pull/144

### Summary

Two new sync steps keep the log files and the shell startup cache from growing without bound.

## Why

Nothing rotated any of the six logs this binary writes, and one reached 109 MB. The shell startup cache leaked an unread snapshot file from every non-interactive shell, and had grown past 100,000 entries.

## Change

"Rotating logs" renames an oversized log aside and starts a fresh one, skipping any log the running process still has open so a sync started by the background updater cannot cut off its own dispatch log mid-run. "Pruning startup logs" removes abandoned snapshots and caps how many startup logs are kept. The shell-side snapshot writer is now gated on the same condition its one reader already uses, so a shell that will never read its own snapshot stops writing one.