### PR TITLE
Document sync maintenance steps and worktree refusal in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,18 +188,6 @@ portable find/test expressions.
 | `dots perf history`      | Show startup performance history                                                    |
 
 
-## Git Operations on This Repository
-
-**Do not use `git push` to push changes in this repository.** The dotfiles repo
-uses a bare-repo / worktree setup where the working tree is `~/.dotfiles` but
-the git directory is stored elsewhere. The `config` shell alias wraps the
-correct `git --git-dir` invocation.
-
-Use `config push` instead of `git push` for any push operation on `.dotfiles`.
-All other git read operations (`git status`, `git diff`, `git log`, etc.) work
-normally when run from inside `~/.dotfiles`; only push (and any operation that
-writes to the remote) requires `config`.
-
 ### Agent worktree placement
 
 When creating a git worktree for isolated work, prefer a path-based directory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,11 +112,49 @@ file path if available, then deletes the file.
 unless `DOTFILES_LOG` is set.
 - Startup performance logs are written to `~/.cache/zsh_startup/*.json` and
 inspected via `zsh_perf` / `dots perf`.
+- One list in the telemetry package names every log the binary appends to.
+Maintenance reads that list, so it cannot miss a log an entry point opens.
+
+### Log and Cache Maintenance
+
+Two sync steps stop the log and startup cache directories growing without
+limit. Writing a log stays a plain append, so the logging path is unchanged.
+
+"Rotating logs" renames an oversized log aside and starts a fresh one. It
+skips any log the running process still has open. A skipped log rotates on
+the next sync that does not hold it.
+
+The `updater` worker runs the sync pipeline inside the dispatch process. Such
+a run holds the dispatch log open throughout. A sync you run by hand rotates
+that log instead.
+
+"Pruning startup logs" deletes abandoned shell snapshots and caps how many
+startup logs are kept.
+
+`.zshenv` writes one snapshot per shell. Only `_write_startup_log` reads a
+snapshot and deletes it. Both are gated on the same test, and the two tests
+must stay identical. A shell that writes a snapshot no reader consumes leaks
+that file.
 
 ### Manual `sync.sh` Runs
 
 `sync.sh` is a thin wrapper around `dots sync`, so interactive sync
 output comes from the Go command directly rather than shell-side tee helpers.
+
+### Syncing from a Linked Worktree
+
+`dots sync` refuses to run from a linked git worktree. It exits non-zero
+before it takes the sync lock.
+
+Sync rewrites `$HOME` from the repository's `home` directory. A run from a
+worktree therefore points every managed dotfile at that worktree's branch.
+Those steps are non-critical, so without the refusal the run would still
+report success.
+
+Pass `--allow-worktree` to sync a worktree on purpose.
+
+The same layout check tells the git hooks step where the shared git directory
+is. A worktree's `.git` is a file rather than a directory.
 
 ## Work vs. Personal Separation
 


### PR DESCRIPTION
Stacked on: https://github.com/agoodkind/.dotfiles/pull/145

### Summary

Documents the two new sync maintenance steps and the linked-worktree refusal, and removes an instruction that no longer matches how this repository is set up.

## Change

`AGENTS.md` now describes log rotation, startup log pruning, and the worktree refusal added in this stack. The section instructing agents to push through a `config` alias instead of plain `git push` is removed; this repository is an ordinary checkout with an ordinary remote, and that section described a layout that no longer exists here.