### PR TITLE
Include paths.d directory mtime in path cache staleness test

### DIFF
--- a/dots/internal/dispatch/pathcache/pathcache.go
+++ b/dots/internal/dispatch/pathcache/pathcache.go
@@ -8,10 +8,51 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"goodkind.io/.dotfiles/internal/cmdexec"
 	"goodkind.io/.dotfiles/internal/telemetry"
 )
+
+// pathSourceDir holds the drop-in files path_helper reads.
+const pathSourceDir = "/etc/paths.d"
+
+// systemPathFile is the base path list path_helper reads.
+const systemPathFile = "/etc/paths"
+
+// cacheIsStale reports whether a cache written at cacheModTime must be rebuilt.
+//
+// The consumer is home/.zshenv, which sources the cache only when
+// `$cache -nt /etc/paths.d` holds. That test compares against the directory
+// inode, whose modification time changes when an entry is added, removed, or
+// renamed, independently of the files that remain inside. Checking only the
+// surviving children therefore misses a deletion, and the two sides can wedge:
+// zsh rejects a cache that this worker considers current, and nothing rebuilds
+// it. Including the directory itself keeps this test a superset of the shell's.
+//
+// A source counts as newer, and therefore triggers a rebuild, whenever its
+// modification time is not strictly before the cache's. Equal modification
+// times count as newer for this same reason: the shell's -nt requires the
+// cache to be strictly newer than every source, so an equal timestamp already
+// makes the shell reject the cache, and this worker must rebuild it too.
+func cacheIsStale(cacheModTime time.Time, baseFile string, sourceDir string) bool {
+	sources := []string{baseFile, sourceDir}
+	if entries, err := os.ReadDir(sourceDir); err == nil {
+		for _, entry := range entries {
+			sources = append(sources, filepath.Join(sourceDir, entry.Name()))
+		}
+	}
+	for _, source := range sources {
+		info, err := os.Stat(filepath.Clean(source))
+		if err != nil {
+			continue
+		}
+		if !info.ModTime().Before(cacheModTime) {
+			return true
+		}
+	}
+	return false
+}
 
 // Rebuild regenerates the macOS path_helper cache and writes it to disk.
 func Rebuild(ctx context.Context, dispatchLogger *telemetry.Logger) error {
@@ -34,26 +75,7 @@ func Rebuild(ctx context.Context, dispatchLogger *telemetry.Logger) error {
 	cacheFile := filepath.Join(cacheDir, "path_cache.zsh")
 
 	cacheInfo, err := os.Stat(filepath.Clean(cacheFile))
-	needsRebuild := err != nil
-	if !needsRebuild {
-		systemPathInfo, systemErr := os.Stat("/etc/paths")
-		if systemErr == nil && systemPathInfo.ModTime().After(cacheInfo.ModTime()) {
-			needsRebuild = true
-		}
-	}
-	if !needsRebuild {
-		entries, err := os.ReadDir("/etc/paths.d")
-		if err == nil {
-			for _, entry := range entries {
-				entryPath := filepath.Join("/etc/paths.d", entry.Name())
-				info, err := os.Stat(entryPath)
-				if err == nil && info.ModTime().After(cacheInfo.ModTime()) {
-					needsRebuild = true
-					break
-				}
-			}
-		}
-	}
+	needsRebuild := err != nil || cacheIsStale(cacheInfo.ModTime(), systemPathFile, pathSourceDir)
 	if !needsRebuild {
 		dispatchLogger.InfoContext(ctx, "path cache up to date, skipping")
 		return nil

--- a/dots/internal/dispatch/pathcache/pathcache_test.go
+++ b/dots/internal/dispatch/pathcache/pathcache_test.go
@@ -1,0 +1,108 @@
+package pathcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// shellRejectsCache mirrors the test in home/.zshenv, which sources the cache
+// only when `$cache -nt $sourceDir` holds. zsh's -nt requires the cache to be
+// strictly newer than the directory inode.
+func shellRejectsCache(cacheModTime time.Time, sourceDirModTime time.Time) bool {
+	return !cacheModTime.After(sourceDirModTime)
+}
+
+// TestCacheIsStaleCoversEveryCaseTheShellRejects locks the contract between
+// this worker and its shell consumer. Any state in which zsh refuses to source
+// the cache must also make this worker rebuild it, or the two wedge and the
+// cache is never regenerated.
+func TestCacheIsStaleCoversEveryCaseTheShellRejects(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
+	offsets := []time.Duration{-48 * time.Hour, -time.Hour, 0, time.Hour, 48 * time.Hour}
+
+	for _, cacheOffset := range offsets {
+		for _, dirOffset := range offsets {
+			for _, childOffset := range offsets {
+				for _, baseFileOffset := range offsets {
+					cacheModTime := base.Add(cacheOffset)
+					sourceDir := t.TempDir()
+					baseFile := filepath.Join(t.TempDir(), "paths")
+
+					writeFileWithModTime(t, baseFile, base.Add(baseFileOffset))
+					writeFileWithModTime(t, filepath.Join(sourceDir, "homebrew"), base.Add(childOffset))
+					// The directory time is set last, since writing a child
+					// updates it.
+					setModTime(t, sourceDir, base.Add(dirOffset))
+
+					goSaysStale := cacheIsStale(cacheModTime, baseFile, sourceDir)
+					shellRejects := shellRejectsCache(cacheModTime, base.Add(dirOffset))
+
+					if shellRejects && !goSaysStale {
+						t.Fatalf("shell rejects the cache but the worker keeps it: cache=%v dir=%v child=%v base=%v",
+							cacheOffset, dirOffset, childOffset, baseFileOffset)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestCacheIsStaleDetectsDeletedDropIn reproduces the state this machine was
+// stuck in: an entry was removed from the drop-in directory, which bumped the
+// directory's own time while leaving every surviving child older than the
+// cache. Checking only the children misses it.
+func TestCacheIsStaleDetectsDeletedDropIn(t *testing.T) {
+	t.Parallel()
+
+	cacheModTime := time.Date(2026, time.July, 5, 8, 46, 0, 0, time.UTC)
+	childModTime := time.Date(2026, time.June, 24, 19, 29, 0, 0, time.UTC)
+	dirModTime := time.Date(2026, time.July, 10, 17, 40, 0, 0, time.UTC)
+
+	sourceDir := t.TempDir()
+	baseFile := filepath.Join(t.TempDir(), "paths")
+	writeFileWithModTime(t, baseFile, childModTime)
+	writeFileWithModTime(t, filepath.Join(sourceDir, "homebrew"), childModTime)
+	setModTime(t, sourceDir, dirModTime)
+
+	if !cacheIsStale(cacheModTime, baseFile, sourceDir) {
+		t.Fatal("cacheIsStale = false, want true: the drop-in directory is newer than the cache")
+	}
+}
+
+// TestCacheIsStaleKeepsAFreshCache confirms the worker does not rebuild on
+// every run once the cache is genuinely newer than every source.
+func TestCacheIsStaleKeepsAFreshCache(t *testing.T) {
+	t.Parallel()
+
+	sourceModTime := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	cacheModTime := sourceModTime.Add(time.Hour)
+
+	sourceDir := t.TempDir()
+	baseFile := filepath.Join(t.TempDir(), "paths")
+	writeFileWithModTime(t, baseFile, sourceModTime)
+	writeFileWithModTime(t, filepath.Join(sourceDir, "homebrew"), sourceModTime)
+	setModTime(t, sourceDir, sourceModTime)
+
+	if cacheIsStale(cacheModTime, baseFile, sourceDir) {
+		t.Fatal("cacheIsStale = true, want false: the cache is newer than every source")
+	}
+}
+
+func writeFileWithModTime(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("PATH=\"/usr/bin\"\n"), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	setModTime(t, path, modTime)
+}
+
+func setModTime(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("setting mod time on %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
### Summary

The background worker that rebuilds the cached `PATH` now agrees with the shell script that reads it about when that cache is stale.

## Why

The shell consumer accepts the cache only when it is newer than the `/etc/paths.d` directory itself. The worker checked only the files inside that directory, never the directory's own modification time. Removing an entry from `/etc/paths.d` bumps the directory's time without touching any surviving file, so the two sides could disagree forever: the shell would keep rejecting a cache the worker considered current.

## Change

The staleness check now also compares against the `/etc/paths.d` directory's own modification time, and every comparison switched from "strictly newer" to "not older than" to match the shell's own test exactly.