### PR TITLE
Disqualify unit tests alone as material PR verification in `pr` skill

### DIFF
--- a/corpus/skills/pr/SKILL.md.tmpl
+++ b/corpus/skills/pr/SKILL.md.tmpl
@@ -129,6 +129,7 @@ Writing rules:
 - Do not narrate literal code changes, the PR description provides high-level context for the change, and the PR diff carries the code change.
 - Do not add irrelevant adjacent context just because it is available.
 - Include a `## Testing` section only when actual material verification was run. Material verification includes meaningful commands, simulator checks, deployed checks, screenshots or videos, smoke tests, and other concrete evidence. If you are unsure whether the evidence is material, ask before adding `## Testing`. DO NOT ADD non-material checks like "lints passed", "rg found x", or anything that isn't directly related to the behavior of the change itself.
+- Unit tests alone do NOT qualify as material verification. Do not include them in the PR narration.
 - Do not mention unavailable test output, unrun tests, or missing verification unless it materially changes review risk.
 - Keep implementation detail at the system level, not line-by-line.
 


### PR DESCRIPTION
### Summary

The `pr` skill now states that unit tests alone do not qualify as material verification.

Agents should not list unit test runs in PR narration or in a `## Testing` section when that is the only evidence.

## Change

The Writing rules section in `corpus/skills/pr/SKILL.md.tmpl` adds one bullet after the material-verification rule.

The new bullet says unit tests alone do NOT qualify as material verification and must not appear in PR narration.

Made with [Cursor](https://cursor.com)