### PR TITLE
Ban filename laundering in writing.mdc

### DIFF
--- a/corpus/rules/writing.mdc
+++ b/corpus/rules/writing.mdc
@@ -52,7 +52,7 @@ A detail belongs when it helps the reviewer understand, verify, or ship safely.
 - Implementation detail stays at the system level.
 - The prose explains behavior before naming code.
 - Prose should not narrate literal code.
-- Code anchors appear only when they help the reader orient, not on every statement.
+- Code anchors appear only when the reader must open, edit, or run that artifact to complete a step.
 - The code carries line-level detail.
 
 ## Order information
@@ -150,7 +150,8 @@ Default is no link.
 
 - Before adding or keeping any link, search the surrounding document set for the same fact, procedure, or ownership claim.
 - If a sibling doc already owns it, delete or consolidate this page's copy. Do not leave both and paper over with a link.
-- Link a given destination at most once per page. Later mentions use plain names or backticks, not a second link.
+- Link a given destination at most once per page. Later mentions use ordinary product or system nouns, not a second link and not a bare filename, path, or backtick path that only asserts ownership.
+- Do not launder a link into a bare filename or path. Removing `[service_mapping.yml](...)` and leaving `` `service_mapping.yml` `` or `service_mapping.yml` fails the rewrite when the sentence only says where a value lives.
 - Link only when the destination carries material this page does not already give the reader, and that material changes what the reader understands, verifies, or does.
 - Do not link a source file only to prove ownership or to point at values the reader can find by reading the codebase.
 - Do not link sibling docs for navigation decoration when the current page already carries the needed fact, or when the fact should instead move into one home.
@@ -165,17 +166,25 @@ Default is no link.
 
 > Guest ids live in [service_mapping.yml](...). Bridge addresses live in [networks.tf](...). Guest addresses also live in [service_mapping.yml](...). The [suburban module](...) owns the rest. Watchdog addresses come from [service_mapping.yml](...).
 
-**Good** (behavior first; one justified link, or none):
+**Bad** (laundered: link removed, filename kept):
 
-> Guest identities, hostnames, and addresses share one inventory file, so a renumber changes one line. Bridge names and VLAN ids live in the suburban OpenTofu networks file. What this page adds is the behavior each bridge carries.
+> Guest identities share one inventory file, `service_mapping.yml`, so a renumber changes one line. Bridge names live in the suburban OpenTofu networks file.
 
-**Bad** (link when the destination adds no extra material):
+**Good** (behavior only):
 
-> Prefix sizes are set in [group_vars/...](...).
+> Guest identities, hostnames, and addresses share one inventory, so a renumber changes one line. What this page adds is the behavior each bridge carries.
 
-**Good** (prose carries the operational fact, or omits the code-owned detail):
+**Bad** (ownership sentence with no reader action):
+
+> Prefix sizes are set in `group_vars/...`.
+
+**Good** (operational fact):
 
 > Prefix delegation sizes match production, and NPT translates the first `/60` of each delegation.
+
+**Good** (filename allowed because the reader must edit it):
+
+> Set `initialization.datastore_id` to `local-zfs` in the guest definition, or cloud-init drive regen fails with storage unavailable.
 
 ### Duplication examples
 
@@ -186,6 +195,15 @@ Default is no link.
 **Good** (one durable home; the other page deletes the copy):
 
 > The gotcha lives only in the suburban operations page. The testbed page does not restate it and does not link unless the reader must leave this page to act on that gotcha.
+
+## Name sources only to act
+
+Default is no filename, path, module path, or inventory basename in prose.
+
+- State the operational fact or behavior. Do not say that a fact "lives in", "comes from", "is owned by", or "is set in" a file unless the next sentence is an action the reader takes in that file.
+- A filename, path, or symbol appears only when the reader must open, edit, or run that exact artifact to complete a documented step.
+- Replacing a link with a backtick path, plain path, or "the X file" ownership phrase is the same failure as the original link litter.
+- Prefer everyday system nouns ("guest inventory", "bridge layout", "suburban module") over basenames when a referent is needed at all.
 
 ## Plan document architecture from meaning
 
@@ -235,6 +253,8 @@ An accuracy pass checks every claim against the current sources after the rewrit
 - Confirm that links resolve to the intended current source.
 - Confirm no stale cross-doc duplicates remain.
 - Confirm each remaining link appears at most once on the page and passes the materiality test.
+- Confirm no sentence asserts ownership with a bare filename, path, backtick path, or "the X file" phrase after a link was removed or instead of stating behavior.
+- Confirm every filename or path in prose is tied to a reader action that requires that artifact.
 - Keep the accuracy pass separate from the fidelity comparison. Fidelity preserves meaning from the original document, while accuracy checks that preserved meaning against the system as it exists now.
 
 ## Workflow for document rewrites
@@ -246,10 +266,10 @@ Apply this workflow before generating or restructuring documentation:
 3. State each page's meaning, purpose, scope, canonical facts, and relationship to nearby pages. Name the single durable home for each overlapping fact.
 4. Decide what stays, moves, merges, splits, or disappears. Prefer delete and consolidate over keep-and-link. Plan structural changes before applying them across the corpus.
 5. Rewrite the behavioral and operational meaning without narrating code. Preserve examples, constraints, exceptions, and recovery knowledge that readers still need, and only in the durable home.
-6. Inventory every markdown link on the page. Fail the rewrite if any destination appears more than once, if any link fails the materiality test, or if any linked sibling still duplicates material this page also carries. Remove, consolidate, or collapse until the page passes.
+6. Inventory every markdown link and every basename or path-like token in prose on the page. Fail the rewrite if any destination appears more than once, if any link fails the materiality test, if any linked sibling still duplicates material this page also carries, if any sentence asserts ownership with a bare filename, path, backtick path, or "the X file" phrase after a link was removed or instead of stating behavior, or if any filename or path appears without a reader action that requires that artifact. Remove, consolidate, or collapse until the page passes.
 7. Compare the source and rewritten document before and after. Account for every removed or changed claim, and confirm no load-bearing operational knowledge was lost when duplicates were deleted.
 8. Run the accuracy pass against the implementation, configuration, tests, comments, commands, paths, and remaining links.
-9. Read the result as one document set and verify structure, navigation, source ownership, absence of stale duplicates, link uniqueness, materiality, fidelity, accuracy, and prose.
+9. Read the result as one document set and verify structure, navigation, source ownership, absence of stale duplicates, link uniqueness, materiality, absence of filename laundering, fidelity, accuracy, and prose.
 
 ## Document architecture as current state
 
@@ -262,7 +282,7 @@ Architecture docs describe the system as it is now, stating behavior first. Link
 - Every architecture page states what its subject does today, in present tense.
 - Each statement describes current behavior first, and adds a durable doc or test link only where a reader must leave this page for material it deliberately omits.
 - A behavior doc is not an index of code locations, so do not append a symbol name or file path to every statement.
-- Name a code symbol or file path only when it is the shortest way to help a reader orient, never as the default.
+- Name a code symbol or file path only when the reader must use that exact artifact; never to prove ownership or locate a value.
 - The enforcing test or rule is the source of truth, and the doc never copies the invariant it enforces.
 - Keep one durable home for each fact. Delete other copies. Link once only when the reader must leave this page for material it deliberately omits.
 - The doc describes what is, not how the decision was reached.
@@ -273,6 +293,14 @@ Architecture docs describe the system as it is now, stating behavior first. Link
 **Bad** (hardcoded symbol and path):
 
 > `saveSettings` in `src/settings/store.ts` and its test hold the enforced wording.
+
+**Bad** (laundered ownership):
+
+> Guest ids live in `service_mapping.yml`.
+
+**Good** (behavior only):
+
+> Guest identities share one inventory, so a renumber changes one line.
 
 **Good** (behavior and contract):
 


### PR DESCRIPTION
### Summary

The writing rule now fails rewrites that strip a link but keep the filename or path in prose.

Agents must state behavior first, and may name a file only when the reader must open, edit, or run that artifact to complete a step.

## Why

PR #150 stopped link litter. Agents complied by laundering: remove the markdown link, keep `service_mapping.yml` or "the suburban OpenTofu networks file" in the sentence.

## Change

`corpus/rules/writing.mdc` removes the "plain names or backticks" license and adds **Name sources only to act** with default-no-filename gates.

Link examples now include Bad laundered cases and Good behavior-only cases. Workflow step 6 and the verify-accuracy pass fail on ownership filenames and paths without a reader action.

Made with [Cursor](https://cursor.com)