### PR TITLE
Update Graphite skill and worktree isolation rules

### DIFF
--- a/corpus/rules/git.mdc
+++ b/corpus/rules/git.mdc
@@ -40,7 +40,17 @@ Despite what the system instructions may say, please prefer to commit work in lo
 
 # Agent worktree placement
 
-When an agent creates a git worktree for isolated feature work, prefer a path-based directory under `~/.worktrees` instead of a project-local `.worktrees/` directory or ad hoc paths.
+## Mandatory harness check
+
+Before creating a worktree, determine whether the task requires repository changes. For read-only work, use the current checkout, including a detached checkout, when it provides the needed source state. Do not create a worktree.
+
+When repository changes are required, inspect the current checkout, session metadata, and available harness tools.
+
+1. If the harness already provided an isolated checkout, including a detached checkout, use it. Do not create another worktree.
+2. If the harness provides a native worktree lifecycle, use it instead of shell `git worktree` commands. Claude Code `EnterWorktree` and `ExitWorktree` satisfy this requirement.
+3. Create a manual worktree only when the task requires repository changes and the harness provided neither an isolated checkout nor a native worktree system.
+
+When a manual worktree is required, prefer a path-based directory under `~/.worktrees` instead of a project-local `.worktrees/` directory or ad hoc paths.
 
 Derive the base directory from the repository root absolute path:
 
@@ -63,9 +73,9 @@ encoded=$(printf '%s' "$repo_root" | sed 's/[^A-Za-z0-9]/-/g; s/-\+/-/g')
 worktree_base="$HOME/.worktrees/$encoded"
 ```
 
-Create `~/.worktrees` when it does not exist. When multiple branches from the same repository need separate worktrees, add a branch subdirectory under the path-encoded base (for example `~/.worktrees/-Users-agoodkind-dotfiles/my-feature-branch`). Apply the same encoding to branch names when they contain non-alphanumeric characters.
+Create `~/.worktrees` only for the manual fallback. When multiple branches from the same repository need separate worktrees, add a branch subdirectory under the path-encoded base (for example `~/.worktrees/-Users-agoodkind-dotfiles/my-feature-branch`). Apply the same encoding to branch names when they contain non-alphanumeric characters.
 
-Honor an explicit user override over this default. Skip creation when the session is already in a linked worktree.
+Honor an explicit user override over this default. Skip manual creation when the harness already supplied an isolated checkout or worktree.
 
 # Worktree and branch cleanup
 

--- a/corpus/skills/graphite/SKILL.md.tmpl
+++ b/corpus/skills/graphite/SKILL.md.tmpl
@@ -1,11 +1,15 @@
 ---
 name: graphite
-description: Create, adopt, split, submit, merge, and babysit stacked pull requests with Graphite (gt) via MCP. Use when the user mentions Graphite, gt, stacked PRs, split-to-prs with Graphite, adopting an existing branch chain, gt merge, or merge conflicts on a live stack.
+description: Create, adopt, split, submit, merge, and babysit dependent pull request stacks with Graphite (gt) via MCP. Use only for two or more dependent PRs, including split-to-prs with Graphite, adopting an existing branch chain, gt merge, or merge conflicts on a live stack.
 ---
 
 # Graphite Stacked PRs
 
+**MANDATORY: DO NOT USE GRAPHITE FOR NON-STACKED PRS**
+
 Graphite manages **stacks**: dependent PRs where each branch builds on the one below instead of trunk directly.
+
+Use the normal PR workflow for one independent PR. Graphite initialization, availability, or a mention of Graphite does not override this rule.
 
 ```text
 main <- pr-1 <- pr-2 <- pr-3
@@ -19,7 +23,7 @@ main <- pr-1 <- pr-2 <- pr-3
 
 ## MCP First
 
-Use the Graphite MCP server as the **primary** interface for every `gt` operation. MCP preserves repo `cwd`, argv, and command history across turns.
+Use the Graphite MCP server as the **primary** interface for every `gt` operation on a stack. Pass the repository `cwd` and command argv explicitly on every call.
 
 **Cursor:** `run_gt_cmd` on `user-Graphite`.
 
@@ -45,7 +49,8 @@ Run this before declaring a repo "not gt init" or falling back to plain-git stac
 
 ### Hard rules
 
-- **When this skill is invoked**, stack work goes through Graphite MCP. Do not fall back to plain-git branches, manual `git push`, or "PR2 base = PR1 branch" workflows unless the user explicitly opts out after a failed detection sequence.
+- **Scope gate:** use this skill only after confirming that the task contains two or more dependent PRs. One independent PR uses the normal PR workflow, even when the repository is Graphite-initialized.
+- **When this skill is invoked for a confirmed stack**, stack work goes through Graphite MCP. Do not fall back to plain-git branches, manual `git push`, or "PR2 base = PR1 branch" workflows unless the user explicitly opts out after a failed detection sequence.
 - **Canonical init probe (gt command):** MCP `["state", "--no-interactive"]` from the target worktree `cwd`. `gt state` displays repository state. Success means the output identifies the trunk branch (for example a line or entry naming `main` with trunk metadata). That means Graphite is enabled, even when there are no stacked branches yet.
 - **Non-mutating file probe (shell fallback only):** when MCP is unavailable and the agent must avoid auto-init side effects:
 
@@ -58,8 +63,8 @@ That file is where `gt init` stores trunk config. Use `--git-common-dir` so link
 - **`gt log short` is not an init check.** It visualizes stacks. A Graphite-enabled repo with no stacks still prints only trunk (`◉  main`). That is normal.
 - **`gt trunk` is not the init probe.** It requires a tracked branch context and can error on untracked branches. Use `gt state` instead.
 - **Banned init heuristics:** repo-root `.graphite_repo_config`, `git rev-parse --git-path graphite_repo_config` (wrong filename), worktree `--git-dir` for config lookup, branch-count in `gt log`, or declaring "not gt init" without `gt state` output.
-- **When not initialized:** run `["init", "--trunk", "<trunk>", "--no-interactive"]`, then `["auth"]` if needed, then re-run `["state", "--no-interactive"]`. Most `gt` commands (including `gt state`) auto-init uninitialized repos; explicit `gt init` is still preferred when the agent knows init is required.
-- **User override:** if the user names Graphite, `gt`, or invokes this skill, treat Graphite as required. Never announce "not gt init" and switch to plain git in the same turn without showing `gt state` output first.
+- **When not initialized:** run `["init", "--trunk", "<trunk>", "--no-interactive"]`, then `["auth"]` if needed, then re-run `["state", "--no-interactive"]`.
+- **Mentions are not overrides:** naming Graphite or `gt` does not authorize Graphite for one independent PR. Use Graphite only for a confirmed dependent stack.
 
 ## Preflight (every task)
 
@@ -84,21 +89,24 @@ Use this section whenever stack work runs in a feature worktree while trunk stay
    - `git branch -f <trunk> ...`
    - `git reset --hard <other-ref>` while checked out on `<trunk>`, or any command that moves `refs/heads/<trunk>`
 2. **Snapshots use `refs/backup/*` only**, never `refs/heads/*`.
-3. **Compare and rebase against `origin/<trunk>`**, not local `<trunk>`, when the feature worktree is active and trunk lives in a different checkout.
+3. **Compare the stack base against `origin/<trunk>`** when trunk lives in another checkout. Before restacking, update local trunk from its clean, idle owning worktree.
 4. **All stack git/gt/make writes** use an explicit worktree path (`run_gt_cmd` `cwd`, or `git -C <worktree>`). **`gh` writes** must run with the shell cwd in the target worktree (or after `cd <worktree>`), since `gh` has no path flag. Shell cwd resets to the primary checkout between tool calls.
 
 Moving `refs/heads/<trunk>` out from under another checkout leaves that checkout's HEAD at the new commit while its index and working tree stay at the old one. `git status` there then reports the entire trunk diff as staged changes even though no file contents were edited.
 
 ### Safe restack when trunk advanced
 
-```bash
-git -C <worktree> fetch origin
-# MCP from <worktree> cwd:
-# args: ["restack", "--branch", "<bottom-branch>", "--upstack", "--no-interactive"]
-# then: ["submit", "--stack", "--no-interactive"]
+1. Fetch `origin` and compare local trunk with `origin/<trunk>`.
+2. If trunk is current, run the scoped restack below.
+3. If trunk is stale and checked out elsewhere, confirm that its owning worktree is clean and idle. Update trunk from that worktree with `git merge --ff-only origin/<trunk>`.
+4. If the owning worktree is dirty or active, stop for coordination. A fetch alone does not update local trunk, so restacking would still use stale trunk.
+
+```text
+args: ["restack", "--branch", "<bottom-branch>", "--upstack", "--no-interactive"]
+args: ["submit", "--stack", "--no-interactive"]
 ```
 
-Use `["sync", "--no-interactive"]` only when trunk is checked out in the same worktree you are driving. Otherwise rely on `git fetch origin` plus scoped `gt restack`.
+Use `["sync", "--no-interactive"]` only when trunk is checked out in the same worktree you are driving. Graphite 1.8.4 and later may update trunk even when another worktree owns it.
 
 ## Command Map
 
@@ -107,18 +115,18 @@ Use `["sync", "--no-interactive"]` only when trunk is checked out in the same wo
 | probe repo init and state | `["state", "--no-interactive"]` |
 | inspect stack | `["log", "short"]` or `["log"]` |
 | new slice on current branch | `["create", "--message", "..."]` |
-| amend tip and restack upstack | `["modify", "--all"]` |
+| amend staged changes and restack upstack | `["modify"]` |
 | add a new commit on tip | `["modify", "--commit", "--message", "..."]` |
 | adopt existing branch | `["track", "<branch>", "--parent", "<parent>"]` |
 | preview submit | `["submit", "--stack", "--dry-run", "--no-interactive"]` |
 | push and open/update PRs | `["submit", "--stack", "--no-interactive"]` |
 | rebase stack onto parents | `["restack", "--no-interactive"]` |
 | refresh trunk and stacks | `["sync", "--no-interactive"]` |
-| route tip fixes into stack | `["absorb", "--dry-run"]` then `["absorb", "--all", "--force"]` |
+| route staged fixes into stack | `["absorb", "--dry-run"]` then `["absorb", "--force"]` |
 | resume after conflict | `["continue"]` |
 | preview stack merge | `["merge", "--dry-run", "--no-interactive"]` |
 | merge stack bottom-up | `["merge", "--no-interactive"]` |
-| auto-merge when requirements met | `["submit", "--stack", "--merge-when-ready", "--always", "--no-interactive"]` |
+| auto-merge while submitting changed branches | `["submit", "--stack", "--merge-when-ready", "--no-interactive"]` |
 
 Always pass `--no-interactive` when the flag exists.
 
@@ -197,7 +205,7 @@ args: ["submit", "--stack", "--no-interactive"]
 
 7. **Draft and review each PR.** Check out each branch bottom to top. The `pr` skill reads the current branch, so check out the PR branch before invoking it. For each branch, invoke {{.Skill "pr"}} to draft and review the title and body with the user. Apply the reviewed title and body through the `pr` skill edit path (`gh pr edit`), not create. The PR already exists from `gt submit`. After all stack PRs have numbers, read them bottom to top. When the numbers are non-sequential, append ` (PR x/N)` to each title through the `pr` skill edit path, per **Stack position in titles** in {{.Skill "split-to-prs"}}.
 
-8. **Mark PRs ready** when reviewers are required. Non-interactive submit often creates drafts and Copilot skips drafts:
+8. **Mark PRs ready** when reviewers are required. Non-interactive submit creates new PRs as drafts unless `--publish` is passed. Existing PRs keep their current state:
 
 ```bash
 gh pr ready <number>   # for each PR in the stack
@@ -293,16 +301,16 @@ Graphite adds stack-specific state that plain PR babysitting misses.
 
 3. Check **every PR in the stack** for `isDraft`, `mergeStateStatus`, and failing checks.
 
-4. Re-read unresolved review threads on **every PR in the stack**. Copilot, Bugbot, and similar re-comment on every push, so new threads can appear after checks pass. When `required_review_thread_resolution` is active, unresolved threads block merge even when CI is green.
+4. Re-read unresolved review threads on **every PR in the stack**. Configured automated reviewers may review new pushes, so new threads can appear after checks pass. When `required_review_thread_resolution` is active, unresolved threads block merge even when CI is green.
 
-5. When the only blocker is CI time (no real failure, threads resolved, not draft), arm merge-when-ready once from the stack tip with `gt submit --stack --merge-when-ready --always` (see **Auto-merge instead of a manual merge** below). Do not restack, submit again, force-push, amend, or close/reopen just to re-run checks that are pending or already green.
+5. When the only blocker is CI time, follow **Auto-merge instead of a manual merge** below. Do not restack, force-push, amend, or close/reopen just to re-run checks that are pending or already green.
 
 ### Trunk moved under you (other agents merged to main)
 
 When `mergeStateStatus` is `BEHIND` or trunk advanced while your stack is open:
 
 1. Prefer a **scoped restack** of your stack, not a repo-wide sync, when other worktrees are active. Never `git update-ref refs/heads/<trunk>` or otherwise move the local trunk ref when trunk is checked out in another worktree.
-2. Run `git -C <worktree> fetch origin`, then MCP: `["sync", "--no-interactive"]` only after confirming `git worktree list` shows no unrelated mid-flight work and trunk is checked out in `<worktree>`. Otherwise restack just your stack:
+2. Fetch `origin`. If trunk is stale, update it from its clean, idle owning worktree. Stop for coordination when that worktree is dirty or active. Then restack just your stack:
 
 ```text
 args: ["restack", "--branch", "<bottom-branch>", "--upstack", "--no-interactive"]
@@ -324,8 +332,8 @@ Common after Graphite or GitHub merges PRs 1..N while N+1..M remain open. Upper 
 
 1. Check out that branch (git checkout is fine for file edits).
 2. Apply fixes, stage named paths.
-3. MCP: `["modify", "--all"]` (amend) or `["modify", "--commit", "--message", "..."]`.
-4. If fixes belong in a lower stack commit, use `["absorb", "--dry-run"]` first, then `["absorb", "--all", "--force"]`.
+3. MCP: `["modify"]` (amend staged changes) or `["modify", "--commit", "--message", "..."]`.
+4. If fixes belong in a lower stack commit, use `["absorb", "--dry-run"]` first, then `["absorb", "--force"]`.
 5. `["submit", "--stack", "--no-interactive"]`.
 6. Resolve review threads per babysit. Re-run checks.
 
@@ -372,20 +380,20 @@ If lower PRs already merged and upper PRs are DIRTY, restack onto current trunk 
 
 ### Merge paths (prefer in this order)
 
-1. **Graphite merge-when-ready via MCP:** default when the user asks to babysit to merge and CI is still running with no real failure. Arms the stack without re-running checks (see **Auto-merge instead of a manual merge** below).
+1. **Graphite merge-when-ready:** default when the user asks to babysit to merge and CI is still running with no real failure. Use CLI while submitting changed branches. Use the Graphite web toggle when the stack is unchanged (see **Auto-merge instead of a manual merge** below).
 2. **Graphite web UI:** open the stack and use **Merge Stack** or **Merge when ready**. Best when a human wants visibility into merge order.
-3. **`gt merge` via MCP:** when every PR in the stack is already green, approved, and thread-clean. Single-shot; does not wait for CI.
+3. **`gt merge` via MCP:** when every PR in the stack is already green, approved, and thread-clean. Current help exposes no wait or watch flag.
 4. **`gh pr merge`:** only when Graphite is unavailable, the repo is not `gt init`, or branch policy needs a GitHub-only flag such as `--admin`. Merge bottom-up one PR at a time if you must use `gh`. Never use `gh pr merge --auto` on a Graphite stack; GitHub native auto-merge conflicts with Graphite merge-when-ready.
 
 ### Do not re-trigger CI to merge
 
-When only waiting on CI, arm `gt` merge-when-ready once with `gt submit --stack --merge-when-ready --always`, then stop. Do not loop `gt merge`, restack, submit again, force-push, amend, or close/reopen to re-run checks.
+When only waiting on CI, enable merge-when-ready once, then stop. Use the CLI while submitting changed branches. Use the Graphite web toggle when the stack is unchanged. Do not loop `gt merge`, restack, force-push, amend, or close/reopen to re-run checks.
 
-Re-runs cost CI credits. macOS bootstrap jobs are especially expensive. Merge-when-ready lands the stack when requirements are met without new check runs.
+Unnecessary pushes may rerun CI and consume credits. Merge-when-ready lands the stack when requirements are met.
 
 Re-trigger CI only for a real in-scope failure, or a required check that genuinely never fired (a trigger miss). Never re-trigger checks that are pending or already green.
 
-Fewer pushes also means fewer new automated review threads, since Copilot and Bugbot re-comment on every push.
+Fewer pushes also avoid new review threads when automated reviewers are configured to review each push.
 
 ### Merge with MCP
 
@@ -402,30 +410,32 @@ args: ["merge", "--dry-run", "--no-interactive"]
 args: ["merge", "--no-interactive"]
 ```
 
-4. `gt merge` merges PRs bottom-up through Graphite. Graphite handles re-parenting upstack PRs as lower PRs land. Per `gt merge --help`, `gt merge` is single-shot: it has no watch or wait mode. When any PR still has pending CI or unresolved threads, `gt merge` merges nothing further and returns. Re-running it while CI is pending changes nothing. Wait for terminal green on every PR, then run `gt merge` once, or arm merge-when-ready instead.
+4. `gt merge` merges PRs bottom-up through Graphite. Graphite handles re-parenting upstack PRs as lower PRs land. Current `gt merge --help` exposes no watch or wait mode. Wait for terminal green on every PR before running it, or enable merge-when-ready instead.
 5. After merge, refresh local state:
 
 ```text
 args: ["sync", "--no-interactive"]
 ```
 
-`gt sync` fast-forwards trunk and offers to delete merged local branches.
+`gt sync` synchronizes branches, restacks where possible, and prompts to delete merged or closed branches. It may overwrite local trunk to match remote.
 
 ### Auto-merge instead of a manual merge
 
 Default path when the user asks to babysit to merge and CI is still in flight with no real failure. This is the CLI equivalent of Graphite's web **Merge when ready** dialog with **Enable for downstack** (arm the whole stack from the tip).
 
-`gt submit` is idempotent and no-ops when nothing changed, so `--merge-when-ready` alone never arms on an unchanged stack. Add `--always` to force the submit operation to run even when the stack is unchanged, so the merge-when-ready mark actually applies:
+Use the CLI flag while `gt submit` is already submitting changed branches:
 
 ```text
-args: ["submit", "--stack", "--merge-when-ready", "--always", "--no-interactive"]
+args: ["submit", "--stack", "--merge-when-ready", "--no-interactive"]
 ```
 
-`--stack` covers downstack PRs. Graphite merges in stack order when checks, approvals, and thread resolution complete, without new check runs.
+For an unchanged stack, use the Graphite web merge-when-ready toggle. Official help defines `--always` as pushing unchanged branches; it does not document that flag as required to enable merge-when-ready.
 
-When CI is still running with no real failure, arm merge-when-ready with `--always` and stop. Do not alternate between merge-when-ready and manual `gt merge`.
+`gt submit` includes the current branch and its downstack ancestors by default. `--stack` also includes upstack descendants. Graphite merges in stack order when checks, approvals, and thread resolution complete.
 
-After arming merge-when-ready, keep triaging incoming review threads until every PR is `MERGED`. Automated reviewers re-comment on every push, and unresolved threads block merge even when CI is green.
+When CI is still running with no real failure, enable merge-when-ready once and stop. Do not alternate between merge-when-ready and manual `gt merge`.
+
+After arming merge-when-ready, keep triaging incoming review threads until every PR is `MERGED`. Configured automated reviewers may review new pushes, and unresolved threads block merge when conversation resolution is required.
 
 Use manual `gt merge` only when every PR is already green, approved, and thread-clean. Merge-when-ready is not a substitute for fixing a blocked stack (real CI failure, conflicts, or unresolved threads that need code changes).
 
@@ -473,10 +483,10 @@ Prefer `["continue"]` over `git rebase --continue`. Avoid `["abort"]` in agent s
 | branches created outside `gt` | invisible to `gt log` | `gt track` before submit |
 | submit without dry-run on existing PRs | duplicate PRs | dry-run first; expect Sync/New parent |
 | fresh stack from trunk when an open PR covers the work | orphans the PR number and review history | follow **Reuse before recreate** in {{.Skill "split-to-prs"}}, or ask |
-| ignore draft state after submit | Copilot and other bots skip drafts | `gh pr ready` on each PR |
-| stale trunk | submit and restack block | `git fetch origin` plus scoped `gt restack`; never `git update-ref refs/heads/<trunk>` when trunk is checked out elsewhere |
-| `git update-ref refs/heads/<trunk>` while trunk checked out elsewhere | skews that checkout; entire trunk looks staged/dirty | `git fetch origin` plus `gt restack` onto `origin/<trunk>` |
-| repo-wide `gt sync` with shared worktrees | restacks or deletes other agents' branches | scoped restack; check worktree list |
+| ignore draft state after submit | new PRs remain drafts unless published or marked ready | `gh pr ready` on each PR after its body is reviewed |
+| stale trunk | submit and restack block | update trunk from its clean, idle owning worktree, then run scoped `gt restack` |
+| `git update-ref refs/heads/<trunk>` while trunk checked out elsewhere | skews that checkout; entire trunk looks staged/dirty | update trunk from its owning worktree with `git merge --ff-only origin/<trunk>` |
+| repo-wide `gt sync` with shared worktrees | may update trunk across worktrees and affect unowned branches | update trunk from its owner, then use scoped restack |
 | `git branch -D` when user authorized `gt delete` | ghost Graphite metadata | `gt delete` or `gt sync` when safe |
 | manual rebase of one stack branch | desyncs upstack parents | `gt modify` or `gt restack` |
 | merge DIRTY upstack PR after partial merge | conflicts from duplicate commits | restack onto current trunk first |
@@ -485,9 +495,9 @@ Prefer `["continue"]` over `git rebase --continue`. Avoid `["abort"]` in agent s
 | force-push outside `gt submit` | Graphite loses sync with remote | `gt submit` after restack |
 | babysit only the tip PR | miss blocked lower PRs | check whole stack each loop |
 | CI-only watcher after arming merge-when-ready | checks go green but merge stalls on new review threads | exit when PRs are MERGED; re-read threads each loop |
-| re-trigger CI on passing or pending PRs | burns CI credits; adds new bot threads per push | arm merge-when-ready `--always`, then wait |
-| loop `gt merge` while CI pending | single-shot command merges nothing and returns | arm merge-when-ready or wait for green then one `gt merge` |
-| `gh pr merge --auto` on a Graphite stack | conflicts with Graphite merge-when-ready | `gt submit --stack --merge-when-ready --always` |
+| re-trigger CI on passing or pending PRs | burns CI credits and may add new automated review threads | enable merge-when-ready once, then wait |
+| loop `gt merge` while CI pending | current help exposes no wait or watch mode | enable merge-when-ready or wait for green then run `gt merge` |
+| `gh pr merge --auto` on a Graphite stack | conflicts with Graphite merge-when-ready | use the CLI flag during a changed submit or the web toggle for an unchanged stack |
 | `gh pr merge` on a Graphite stack | skips Graphite merge orchestration; DIRTY upstack PRs | `gt merge` or Graphite UI after babysit |
 | merge before dry-run | wrong PRs may merge | `gt merge --dry-run` first |
 | auto-generated PR bodies from submit | reviewers get commit-message stubs | {{.Skill "pr"}} per PR before marking ready |
@@ -511,7 +521,7 @@ gt state --no-interactive
 gt log short
 gt submit --stack --dry-run --no-interactive
 gt submit --stack --no-interactive
-gt submit --stack --merge-when-ready --always --no-interactive
+gt submit --stack --merge-when-ready --no-interactive
 gt merge --dry-run --no-interactive
 gt merge --no-interactive
 gt sync --no-interactive
@@ -523,8 +533,7 @@ No pipes, redirection, or `head`/`tail` on `gt` output.
 
 ## Caveats
 
-- `gt submit` may refuse to force-push when remote changed since last submit. Restack, then submit again.
-- Dotfiles uses bare-repo `config push`. Graphite targets normal GitHub repos with `gt init`, not dotfiles itself.
+- `gt submit` blocks overwriting branches changed remotely since the last submit or get. Reconcile remote changes with `gt get` or `gt sync` before resubmitting.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

Limit Graphite to dependent pull request stacks and replace stale command guidance with verified behavior.

## Change

Require normal pull request delivery for independent changes.

Accept harness-provided isolated checkouts and native worktree lifecycles before manual worktree creation.

## Verification

- `make check`
- `go test ./...`