### PR TITLE
Deduplicate pull request workflow skills (PR 2/2)

### DIFF
--- a/corpus/skills/babysit/SKILL.md.tmpl
+++ b/corpus/skills/babysit/SKILL.md.tmpl
@@ -1,11 +1,13 @@
 ---
 name: babysit
-description: Keep a PR merge-ready by triaging comments, resolving conflicts, and fixing CI. Merge when the user asks. Clean up branches and worktrees after merge, supersession, or explicit cleanup request. On unresolved session end, back up to git, save durable memory, and remove the worktree.
+description: Use when a pull request needs review-thread triage, CI repair, conflict resolution, merge monitoring, an explicitly requested merge, or terminal cleanup.
 ---
 
 # Babysit PR
 
 Get this PR to a merge-ready state. Run the verification commands below, fix what is in scope, and loop until every ruleset requirement is satisfied. Babysit alone stops at merge-ready. Merge, terminal cleanup, and unresolved handoff run only when the sections below say to.
+
+Follow {{.Rule "git"}} for fetches, branch comparisons, signed commits, worktree safety, and containment-based cleanup. Use {{.Skill "graphite"}} only for a confirmed dependent pull request stack.
 
 ## 1. Identify the PR and read merge state
 
@@ -48,7 +50,7 @@ Only `active` rules are returned. Rules in `evaluate` or `disabled` enforcement 
 
 Resolve merge conflicts while preserving intent on both the PR branch and the base branch. If intents truly conflict, abort the merge and ask the user for clarification before continuing.
 
-If `mergeStateStatus` is `BEHIND`, update the branch from base before re-checking CI, since another PR may have already fixed a failing check. When babysitting a Graphite stack in a feature worktree, restack via {{.Skill "graphite"}} (`gt restack` / `gt submit`). Never fast-forward or `git update-ref` local `refs/heads/<trunk>` if trunk is checked out in another worktree.
+If `mergeStateStatus` is `BEHIND`, update the branch from base before re-checking CI, since another PR may have already fixed a failing check. Follow {{.Rule "git"}} for safe base and worktree handling. For a dependent Graphite stack, follow {{.Skill "graphite"}} for restacking and submission.
 
 ## 4. Triage inline review comments
 
@@ -121,7 +123,7 @@ Resolve only after the change is genuinely addressed. When `required_review_thre
 
 ## 6. Fix CI within PR scope
 
-Fix CI failures caused by changes within this PR's scope. Publish each scoped CI or review-thread fix as soon as it is locally verified, then re-run `gh pr checks`. Use the repository-specific push command from local instructions, such as `config push` when a repo requires it. Batch only the threads already present in the current poll. Do not hold a completed fix for possible future comments.
+Fix CI failures caused by changes within this PR's scope. Publish each scoped CI or review-thread fix as soon as it is locally verified, then re-run `gh pr checks`. Use the repository-specific push workflow from local instructions. Batch only the threads already present in the current poll. Do not hold a completed fix for possible future comments.
 
 Never edit CI workflows or unrelated code just to make failures pass. Report back when that would be required.
 
@@ -144,11 +146,15 @@ Run this section only when the user explicitly asks to merge (for example "merge
 
 **Preconditions:** section 7 requirements are satisfied, or only CI time remains with no real failure and threads resolved.
 
-**Paths:**
+### Admin bypass authorization
 
-- **gt available** (`gt` on PATH and `gt state` output identifies the trunk branch per {{.Skill "graphite"}}, or Graphite MCP loaded): follow {{.Skill "graphite"}} **Task: Merge a Graphite stack**. Dry-run then `gt merge`, or `gt submit --stack --merge-when-ready --always` when only CI is pending. Never use `gh pr merge --auto`; GitHub native auto-merge conflicts with Graphite.
-- **gt unavailable and repo is not Graphite-initialized:** `gh pr merge --merge` or `--squash` per repo policy when fully green; `gh pr merge --auto` only when the sole blocker is CI time.
-- **gt unavailable and repo is Graphite-initialized:** do not use `gh pr merge --auto`. Merge manually with `gh pr merge --merge` (or `--squash`) bottom-up one PR at a time after all checks pass.
+Treat `admin merge` or `admin bypass` as a request for confirmation, not authorization. Ask through the native harness question tool required by {{.Skill "ask-questions"}}. Use `--admin` only after the user confirms that question for the current merge. Never infer the request from "merge", "land", "ship", urgency, available administrator rights, prior turns, or prior pull requests. If the native question tool is unavailable or the user does not confirm, do not use `--admin`. The confirmation expires after that merge attempt.
+
+### Merge paths
+
+- **Dependent Graphite stack:** follow {{.Skill "graphite"}} task **Merge a Graphite stack**. That skill owns stack order, merge-when-ready, dry-run behavior, and Graphite commands.
+- **One pull request:** use `gh pr merge --merge` or `--squash` per repository policy when fully green. Use `gh pr merge --auto` only when the sole blocker is CI time.
+- **Confirmed admin merge:** use `gh pr merge --admin` with the repository's allowed merge method only after the request and confirmation above.
 
 Loop `gh pr view --json state` until `state` is `MERGED` or superseded `CLOSED` (see section 9). When auto-merge is armed, keep triaging new review threads on each loop.
 
@@ -171,27 +177,19 @@ gh pr view --json state,mergedAt,headRefName,baseRefName
 git worktree list
 ```
 
-**Cleanup sequence** (respect trunk worktree rules from {{.Skill "graphite"}} section Worktrees and trunk refs):
+**Cleanup sequence:**
 
 1. **Record** `headRefName`, feature worktree path (if any), PR `state`, and which checkout owns trunk (`git worktree list`).
 2. **Remote branch:** delete only when the PR is `MERGED` or superseded `CLOSED`. When the user asked to clean up while the PR is still `OPEN`, skip remote branch deletion unless the user explicitly confirmed abandoning the PR (deleting the remote branch closes an open PR). Use `git push origin --delete <branch>` or `gh api` delete-ref when deletion is allowed.
-3. **Remove feature worktree** when babysitting ran in a dedicated worktree, `git status --porcelain` is empty, and no open branches still need it:
-   ```bash
-   git worktree remove <path>
-   git worktree prune
-   ```
-   Use `--force` only when the tree is dirty and the user approved. Stop and surface uncommitted work instead of removing a dirty tree.
-4. **Local branch:**
-   - Graphite-authorized repos: `gt delete <branch>` or scoped `gt sync --no-interactive` when trunk is checked out in the same worktree and no other agents are mid-stack.
-   - Plain git: `git branch -d <branch>` from a checkout that is not that branch when the PR is terminal or the user confirmed abandoning an open PR (use `-D` only with explicit user approval).
-5. **Reconcile trunk worktree:** from the checkout that **owns** trunk (never from a feature worktree):
+3. **Local worktree and branch:** follow the fixed containment classification and removal mechanics in {{.Rule "git"}}. For Graphite stacks, use the deletion or synchronization path in {{.Skill "graphite"}} instead of deleting tracked branches with plain Git.
+4. **Reconcile trunk worktree:** from the checkout that **owns** trunk (never from a feature worktree):
    ```bash
    git -C <trunk-worktree> fetch origin
    git -C <trunk-worktree> merge --ff-only origin/<trunk>
    ```
    Do not `git update-ref refs/heads/<trunk>` when trunk is checked out elsewhere.
 
-**Graphite stacks:** repeat for every merged or closed branch in the stack (bottom-up order), then one trunk reconcile from the trunk-owning worktree.
+**Graphite stacks:** follow {{.Skill "graphite"}} for stack cleanup order, then reconcile trunk once from its owning worktree.
 
 Report: PR URL(s), branches deleted (remote/local), trunk commit after reconcile, worktree removed (or skipped and why).
 

--- a/corpus/skills/pr/SKILL.md.tmpl
+++ b/corpus/skills/pr/SKILL.md.tmpl
@@ -1,11 +1,13 @@
 ---
 name: pr
-description: Create or revise a pull request.
+description: Use when the user asks to create, update, reword, or review one pull request.
 ---
 
 # Create Or Revise Pull Request
 
 Use this workflow when the user asks to create, update, reword, or review a pull request description. Follow the steps in order. Do not skip the existing-PR check unless the user explicitly asks for a drafting-only exercise.
+
+Follow {{.Rule "git"}} for fetches, remote-tracking comparisons, signed commits, staging, and pushes. Apply {{.Rule "writing"}} and {{.Skill "make-readable"}} to every title, body, and final message. Use {{.Skill "split-to-prs"}} for any multi-PR split or stack decision.
 
 ## Step 1: Check Existing PR State
 
@@ -26,15 +28,11 @@ You are working from the current branch. Choose exactly one path for that branch
 
 ### Split or stack context
 
-When the user asked to split work into multiple PRs or a stack, and an open PR already covers that work, follow **Reuse before recreate** in {{.Skill "split-to-prs"}}.
-
-- Do not open new PRs that abandon the existing one unless the user chose **Replace and close** or **Leave untouched** in the approved plan.
-- When repurposing is approved, update the existing PR title and body to match the bottom slice only. Stack new PRs on top of that branch.
-- If the disposition is unclear, stop and ask before creating any PR.
+Do not decide the disposition of an existing pull request inside this skill. Follow **Reuse before recreate** in {{.Skill "split-to-prs"}}, then return here after the split plan identifies the branch this pull request should describe.
 
 ## Step 2: Read The Branch
 
-Find the target branch from the workspace or repository context. Prefer the remote-tracking ref, such as `origin/main`.
+Find the target branch from the workspace or repository context. Follow {{.Rule "git"}} and use its remote-tracking ref, such as `origin/main`.
 
 Run:
 
@@ -77,6 +75,7 @@ Use this title format:
 Rules:
 
 - Start with the ticket in square brackets when a ticket exists.
+- For a small ad-hoc, out-of-scope, or untracked change with no ticket, omit both the title prefix and the `Ticket:` line. Do not use `[NO TICKET]` or another placeholder.
 - State what changed, not why it matters.
 - Keep the title specific to the behavior, surface area, or system.
 - Use backticks only around code symbols. Leave plain prose unwrapped.
@@ -113,6 +112,8 @@ Adjust section names and order when that makes the PR easier to scan. Useful alt
 
 Use section boundaries to separate different jobs. `### Summary` should orient the reviewer to the change. Motivation or background should be separate when it is load-bearing or too large to fit naturally in the summary. Mechanics should be separate when they would make the summary dense.
 
+Apply {{.Rule "writing"}} and {{.Skill "make-readable"}} in addition to the pull request-specific rules below.
+
 Writing rules:
 
 - Write PR prose as if it must pass review against Apple Human Interface Guidelines writing guidance: use simple plain language, fit the reviewer's context, write for accessibility, avoid jargon unless it is necessary, and leave no ambiguous claims.
@@ -147,6 +148,13 @@ Media rules:
 - If screenshots, videos, or before/after comparisons belong in the PR body, apply the `pr-media` skill.
 - Use a before/after table when the visual change is easier to review side by side.
 
+Comparison rules:
+
+- Prefer a before-and-after table when a change has directly comparable behavior, contracts, workflows, or visuals. Use the table when it lets the reviewer answer a real question faster than prose.
+- Make each row synthesize a reviewer-visible consequence, risk, or invariant. Do not inventory changed files, symbols, or line-level implementation.
+- Skip the table when it would only restate the diff or repeat the surrounding prose.
+- For visual changes, pair the media with short outcome-focused captions so the reviewer knows what to inspect.
+
 ## Examples
 
 Use these as drafting patterns, not as fixed templates.
@@ -178,7 +186,7 @@ The event includes the reason for the update, the changed fields, the previous a
 ### No Noisy Testing Section
 
 ```markdown
-Title: [NO TICKET] Update PR skill workflow for existing PR state
+Title: [ACME-310] Update PR skill workflow for existing PR state
 
 ### Summary
 
@@ -195,6 +203,22 @@ Open-PR handling is explicit, so agents ask before editing an existing open PR u
 
 Do not add `## Testing` unless material verification actually ran for the behavior of the change.
 
+### Small Untracked Follow-Up
+
+```markdown
+Title: Clear stale retry warning after recovery
+
+### Summary
+
+A recovered request no longer leaves a warning visible after the retry succeeds.
+
+## Change
+
+The page clears the warning when a retry returns a result, so the status matches the recovered request.
+```
+
+This small follow-up has no ticket. The title and body omit ticket placeholders instead of inventing tracking context.
+
 ### Linked Text
 
 Prefer:
@@ -209,6 +233,65 @@ Avoid:
 ```markdown
 Ticket: [`AGENCY-11414`](https://agency.ticket.net/browse/AGENCY-11414)
 ```
+
+### User-Visible Behavior Comparison
+
+```markdown
+Title: Preserve catalog sort after clearing filters
+
+### Summary
+
+Clearing Acme catalog filters now preserves the selected sort order. People can broaden the results without losing their preferred ordering.
+
+## Change
+
+| Reviewer question | Before | After |
+| --- | --- | --- |
+| What does `Clear filters` reset? | Filters and sort order. | Filters only. |
+| What must the person repeat? | The person selects the sort order again. | Nothing. The selected order remains active. |
+| What remains unchanged? | The catalog refreshes with the cleared filter set. | The catalog still refreshes with the cleared filter set. |
+```
+
+This table explains the user consequence. It does not list the changed screens, handlers, or state fields.
+
+### System Contract Comparison
+
+```markdown
+Title: [ACME-218] Publish warehouse inventory changes
+
+### Summary
+
+Warehouse displays now receive inventory changes through an event contract instead of polling a full snapshot.
+
+## Change
+
+| Contract question | Before | After |
+| --- | --- | --- |
+| What is the integration source? | Displays poll the inventory snapshot endpoint. | Displays handle the `inventory.changed` event. |
+| When is a change observable? | Displays discover changes on their next poll. | The warehouse service publishes after an inventory change commits. |
+| What context crosses the boundary? | Displays receive the full inventory snapshot. | Displays receive the item, location, quantity delta, and resulting quantity. |
+```
+
+This table defines the boundary reviewers must validate. It does not repeat publisher class names or serialization changes from the diff.
+
+### Visual Comparison
+
+```markdown
+Title: Explain why upload is disabled
+
+### Summary
+
+The Acme upload dialog now tells people to select a file before the disabled `Upload` action becomes available.
+
+## Demo
+
+| Before | After |
+| --- | --- |
+| ![Before Acme upload dialog](https://example.com/acme-upload-before.png) | ![After Acme upload dialog](https://example.com/acme-upload-after.png) |
+| The disabled action gives no recovery guidance. | Helper text explains that selecting a file enables `Upload`. |
+```
+
+This table tells the reviewer what changed visually and what outcome to inspect. It does not narrate spacing, color, or component edits already visible in the diff.
 
 ## Step 6: Show The Draft
 

--- a/corpus/skills/split-to-prs/SKILL.md.tmpl
+++ b/corpus/skills/split-to-prs/SKILL.md.tmpl
@@ -1,24 +1,19 @@
 ---
 name: split-to-prs
-description: Split current work into small reviewable PRs. Prefer Graphite stacks when gt or the Graphite MCP is available. Use when the user asks to split a chat, set of changes, branch, or PR.
+description: Use when the user asks to split a chat, change set, branch, or pull request into multiple reviewable pull requests.
 ---
 
 # Split to PRs
 
 Turn one pile of work into a few small PRs.
 
-## Graphite first
+Follow {{.Rule "git"}} for fetches, comparisons, worktree safety, staging, signed commits, pushes, and cleanup. Use {{.Skill "pr"}} for every pull request title, body, and GitHub write.
 
-When Graphite is available, prefer a stacked split over plain git branches.
+## Choose independent or dependent pull requests
 
-Graphite is available when any of these hold:
+Default to independent sibling branches from trunk. Use Graphite only when two or more slices have a real dependency and therefore require a stack. Graphite availability or repository initialization does not turn independent pull requests into a stack.
 
-- the Graphite MCP `run_gt_cmd` tool is loaded in the session
-- `gt` is on PATH and the repo passes Graphite init detection in {{.Skill "graphite"}} (`gt state` output identifies the trunk branch)
-
-For planning, stay in this skill. For execution, follow {{.Skill "graphite"}} task **Split work into a Graphite stack**. That skill owns MCP usage, `gt create`, dry-run submit, draft-ready handling, and stack verification.
-
-Use the plain git path in section 3 only when Graphite is unavailable and the user does not want to set it up.
+For a dependent stack, plan here and execute through {{.Skill "graphite"}} task **Split work into a Graphite stack**. For independent pull requests, use the plain Git path in section 3.
 
 ## Reuse before recreate
 
@@ -42,13 +37,11 @@ Example: `[AGENCY-11267] Add plaid relink URL (PR 2/3)`
 
 - Do not create branches, commit, push, or open PRs until the user approves the split plan.
 - When an open PR exists, follow **Reuse before recreate** above.
-- Never discard user work. No destructive git commands (`reset --hard`, `clean -fdx`, branch deletion, force-push, history rewrite) without explicit approval.
+- Follow {{.Rule "git"}} for all repository mutations and worktree handling.
 - A recoverable snapshot preserves work. It does not require leaving an existing open PR untouched after a split request.
 - Always save a recoverable snapshot before moving work around. This often starts from dirty work on `main`, so do not assume there is already a safe branch.
-- When work happens in a feature worktree, record the primary checkout path and treat local `refs/heads/<trunk>` as read-only. Never move trunk refs from the feature worktree when trunk is checked out elsewhere.
 - Snapshot refs must stay under `refs/backup/`, never `refs/heads/`.
-- Stage only named files or hunks. No `git add .` or `git add -A`.
-- Every PR title and body comes from {{.Skill "pr"}}, reviewed with the user per PR. Do not use ad hoc text or default commit-message bodies.
+- Every pull request title, body, and GitHub write follows {{.Skill "pr"}}.
 
 ## 1. Check the state
 
@@ -66,7 +59,7 @@ For each PR number returned, run `gh pr view <number> --json body,title,url,stat
 
 Record every open PR number, branch, and URL. If the user mentioned a PR by number, confirm it with `gh pr view <number>`.
 
-Note whether Graphite is available (see above).
+Classify the approved slices as independent or dependent. Do not use Graphite availability as the classification.
 
 When `git worktree list` shows more than one checkout, record which path owns trunk before proposing slices:
 
@@ -74,7 +67,7 @@ When `git worktree list` shows more than one checkout, record which path owns tr
 git worktree list
 ```
 
-For trunk and ref safety during Graphite execution, follow **Worktrees and trunk refs** in {{.Skill "graphite"}}.
+Follow {{.Rule "git"}} for trunk and worktree safety. A dependent stack also follows {{.Skill "graphite"}}.
 
 ## 2. Propose the split
 
@@ -92,10 +85,10 @@ State the disposition of every existing open PR explicitly. Use one of these lab
 
 State which execution path you will use after approval:
 
-- **Graphite** when Graphite is available. Use stacked branches when slices depend on each other. Use parallel `gt create` branches off trunk when slices are independent.
-- **Plain git branches** only when Graphite is unavailable or the user opts out.
+- **Graphite stack** only when the slices depend on each other.
+- **Plain Git sibling branches** when the slices are independent, or when Graphite is unavailable or declined for a dependent stack.
 
-Ask for approval before starting. In Claude Code call `AskUserQuestion`. In Codex call `request_user_input`. In Cursor call `AskQuestion`. When none is available, present the plan in plain text and wait for approval.
+Ask for approval through the native harness question tool required by {{.Skill "ask-questions"}} before starting.
 
 When one or more existing open PRs were detected, the approval question must include these options in this order. Repeat the question for each open PR when more than one exists:
 
@@ -105,13 +98,13 @@ When one or more existing open PRs were detected, the approval question must inc
 
 ## 3. Execute the split
 
-### Graphite path (preferred)
+### Graphite path for a dependent stack
 
 After approval, switch to {{.Skill "graphite"}} and run **Split work into a Graphite stack** with the approved plan. Do not reimplement those steps here.
 
-### Plain git path (fallback)
+### Plain Git path for independent pull requests
 
-Use only when Graphite is unavailable.
+Use this path for independent slices. Also use it when Graphite is unavailable or declined for a dependent split.
 
 If there is uncommitted work, save a recoverable snapshot without changing the working tree:
 
@@ -124,8 +117,8 @@ fi
 
 For each approved slice:
 
-1. Create a branch from the right base, stage and commit only the planned files or hunks, then push.
-2. Stay on that branch (or check it out). The `pr` skill reads the current branch. Invoke {{.Skill "pr"}} to draft the title and body, review with the user, and open the PR through the canonical Step 1 through Step 8 flow.
+1. Follow {{.Rule "git"}} to create the sibling branch from the remote trunk, stage the approved slice, create a signed commit, verify it, and push it.
+2. Check out that branch and invoke {{.Skill "pr"}}. That skill owns the title, body, existing-PR handling, user-visible draft, and GitHub write.
 
 ## 4. Report back
 


### PR DESCRIPTION
Depends on: https://github.com/agoodkind/.dotfiles/pull/158

### Summary

This change gives `split-to-prs`, `pr`, and `babysit` distinct ownership. Repeated Git, writing, and Graphite instructions now use corpus references.

## Change

`split-to-prs` chooses independent branches or a dependent stack. `pr` owns one pull request’s content and GitHub write. `babysit` owns readiness, merge, and cleanup.

The split approval and admin merge confirmation paths now reference `ask-questions`, which owns native harness question routing.

An admin merge requires the user to say `admin merge` or `admin bypass`, followed by confirmation through the native harness question tool.