### PR TITLE
Add skill body embedding cycle detection

### DIFF
--- a/docs/superpowers/plans/2026-08-11-skill-body-embedding.md
+++ b/docs/superpowers/plans/2026-08-11-skill-body-embedding.md
@@ -22,15 +22,14 @@ Reject invalid input before writing rendered files.
 
 **Files:**
 - Modify: [skills_test.go](../../../dots/internal/sync/compilation/skills_test.go)
-- Modify: [source_set_render_test.go](../../../dots/internal/sync/compilation/source_set_render_test.go)
 
 **Interfaces:**
 - Consumes: `RenderSkillDirsFromSourceSet(CorpusSourceSet, string, SkillRefStyle) error`
 - Produces: coverage for `{{.SkillBody "name"}}` and typed cycle errors
 
-- [ ] Add a test that embeds a templated skill body and omits its front matter.
-- [ ] Add direct skill, nested skill, rule, and cross-type cycle tests.
-- [ ] Run `go test ./internal/sync/compilation` from `dots` and confirm the new tests fail for missing behavior.
+- [x] Add a test that embeds a templated skill body and omits its front matter.
+- [x] Add direct skill, nested skill, rule, and cross-type cycle tests.
+- [x] Run `go test ./internal/sync/compilation` from `dots` and confirm the new tests fail for missing behavior.
 
 ### Task 2: Implement shared expansion
 
@@ -42,10 +41,10 @@ Reject invalid input before writing rendered files.
 - Consumes: `CorpusSourceSet.Rules`, `CorpusSourceSet.Skills`, and the root skill name
 - Produces: `RuleBody(string) string`, `SkillBody(string) string`, and typed cycle errors
 
-- [ ] Replace rule-only expansion state with typed expansion nodes and one body renderer.
-- [ ] Extract the embedded `SKILL.md` or `SKILL.md.tmpl` body without front matter.
-- [ ] Seed expansion with the root skill so recursive inclusion fails immediately.
-- [ ] Run `go test ./internal/sync/compilation` from `dots` and confirm all focused tests pass.
+- [x] Replace rule-only expansion state with typed expansion nodes and one body renderer.
+- [x] Extract the embedded `SKILL.md` or `SKILL.md.tmpl` body without front matter.
+- [x] Seed expansion with the root skill so recursive inclusion fails immediately.
+- [x] Run `go test ./internal/sync/compilation` from `dots` and confirm all focused tests pass.
 
 ### Task 3: Verify the compiler
 
@@ -56,8 +55,8 @@ Reject invalid input before writing rendered files.
 - Consumes: the completed compiler change
 - Produces: formatted, tested repository state
 
-- [ ] Run `gofmt` on modified Go files.
-- [ ] Run `make check` from `dots`.
-- [ ] Run the repository check target from the root when it differs from `dots/Makefile`.
-- [ ] Review `git diff --check` and the complete diff.
-- [ ] Commit the verified change with the required signed commit and trailer.
+- [x] Run `gofmt` on modified Go files.
+- [x] Run `make check` from `dots`.
+- [x] Run the repository check target from the root when it differs from `dots/Makefile`.
+- [x] Review `git diff --check` and the complete diff.
+- [x] Commit the verified change with the required signed commit and trailer.

--- a/docs/superpowers/plans/2026-08-11-skill-body-embedding.md
+++ b/docs/superpowers/plans/2026-08-11-skill-body-embedding.md
@@ -1,0 +1,63 @@
+# Skill Body Embedding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `SkillBody` embedding with shared rule and skill cycle detection.
+
+**Architecture:** Extend skill rendering with one typed body expansion engine. The engine strips skill front matter, expands nested templates, and reports the active cycle path.
+
+**Tech Stack:** Go, `text/template`, Go tests.
+
+## Global Constraints
+
+Keep reference rendering unchanged.
+
+Use one implementation for rule and skill expansion.
+
+Reject invalid input before writing rendered files.
+
+---
+
+### Task 1: Specify body expansion behavior
+
+**Files:**
+- Modify: [skills_test.go](../../../dots/internal/sync/compilation/skills_test.go)
+- Modify: [source_set_render_test.go](../../../dots/internal/sync/compilation/source_set_render_test.go)
+
+**Interfaces:**
+- Consumes: `RenderSkillDirsFromSourceSet(CorpusSourceSet, string, SkillRefStyle) error`
+- Produces: coverage for `{{.SkillBody "name"}}` and typed cycle errors
+
+- [ ] Add a test that embeds a templated skill body and omits its front matter.
+- [ ] Add direct skill, nested skill, rule, and cross-type cycle tests.
+- [ ] Run `go test ./internal/sync/compilation` from `dots` and confirm the new tests fail for missing behavior.
+
+### Task 2: Implement shared expansion
+
+**Files:**
+- Modify: [source_set_render.go](../../../dots/internal/sync/compilation/source_set_render.go)
+- Modify: [compilation.go](../../../dots/internal/sync/compilation/compilation.go)
+
+**Interfaces:**
+- Consumes: `CorpusSourceSet.Rules`, `CorpusSourceSet.Skills`, and the root skill name
+- Produces: `RuleBody(string) string`, `SkillBody(string) string`, and typed cycle errors
+
+- [ ] Replace rule-only expansion state with typed expansion nodes and one body renderer.
+- [ ] Extract the embedded `SKILL.md` or `SKILL.md.tmpl` body without front matter.
+- [ ] Seed expansion with the root skill so recursive inclusion fails immediately.
+- [ ] Run `go test ./internal/sync/compilation` from `dots` and confirm all focused tests pass.
+
+### Task 3: Verify the compiler
+
+**Files:**
+- Modify only files required by failing checks.
+
+**Interfaces:**
+- Consumes: the completed compiler change
+- Produces: formatted, tested repository state
+
+- [ ] Run `gofmt` on modified Go files.
+- [ ] Run `make check` from `dots`.
+- [ ] Run the repository check target from the root when it differs from `dots/Makefile`.
+- [ ] Review `git diff --check` and the complete diff.
+- [ ] Commit the verified change with the required signed commit and trailer.

--- a/docs/superpowers/specs/2026-08-11-skill-body-embedding-design.md
+++ b/docs/superpowers/specs/2026-08-11-skill-body-embedding-design.md
@@ -1,0 +1,9 @@
+# Skill Body Embedding Design
+
+The corpus compiler will inline skill bodies through `{{.SkillBody "name"}}`.
+
+`SkillBody` removes the embedded skill's front matter and expands its template in the caller's output context. Existing `RuleBody`, `Rule`, `Rules`, and `Skill` behavior remains unchanged.
+
+One expansion engine will resolve rule and skill bodies. It will track typed nodes such as `skill:a` and `rule:b`. Re-entering an active node will fail with the complete cycle path.
+
+Rendering will reject missing bodies, invalid names, direct cycles, same-type cycles, and cross-type cycles before writing output. Focused tests will prove successful nesting and each failure class.

--- a/dots/internal/sync/compilation/compilation.go
+++ b/dots/internal/sync/compilation/compilation.go
@@ -224,7 +224,7 @@ func skillRenderConflict(target string) string {
 }
 
 func hasUsableSkillFrontmatter(content string) bool {
-	frontmatter, err := parseSkillFrontmatter(content)
+	frontmatter, _, err := parseSkillDocument(content)
 	if err != nil {
 		return false
 	}
@@ -237,22 +237,23 @@ type skillFrontmatterYAML struct {
 	Description string `yaml:"description"`
 }
 
-func parseSkillFrontmatter(content string) (skillFrontmatterYAML, error) {
+func parseSkillDocument(content string) (skillFrontmatterYAML, string, error) {
 	var result skillFrontmatterYAML
 	if !strings.HasPrefix(content, "---\n") {
-		return result, fmt.Errorf("missing opening frontmatter delimiter")
+		return result, "", fmt.Errorf("missing opening frontmatter delimiter")
 	}
 	endMarker := "\n---\n"
 	frontmatterEnd := strings.Index(content[4:], endMarker)
 	if frontmatterEnd == -1 {
-		return result, fmt.Errorf("missing closing frontmatter delimiter")
+		return result, "", fmt.Errorf("missing closing frontmatter delimiter")
 	}
 	rawFrontmatter := content[4 : 4+frontmatterEnd]
 	if err := yaml.Unmarshal([]byte(rawFrontmatter), &result); err != nil {
-		slog.Warn("compilation: parseSkillFrontmatter yaml failed", "err", err)
-		return result, fmt.Errorf("parsing skill front matter: %w", err)
+		slog.Warn("compilation: parseSkillDocument yaml failed", "err", err)
+		return result, "", fmt.Errorf("parsing skill front matter: %w", err)
 	}
-	return result, nil
+	bodyStart := 4 + frontmatterEnd + len(endMarker)
+	return result, content[bodyStart:], nil
 }
 
 func skillRenderConflictsError(conflicts []string) error {

--- a/dots/internal/sync/compilation/skills_test.go
+++ b/dots/internal/sync/compilation/skills_test.go
@@ -381,6 +381,192 @@ func TestRenderSkillDirsRuleBodyTransclusion(t *testing.T) {
 	}
 }
 
+func TestRenderSkillDirsSkillBodyTransclusion(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(
+		t,
+		filepath.Join(root, "rules", "writing.mdc"),
+		"---\ndescription: writing\n---\nWriting guidance.\n",
+	)
+	skillsDir := filepath.Join(root, "skills")
+	writeTestFile(
+		t,
+		filepath.Join(skillsDir, "shared", "SKILL.md.tmpl"),
+		"---\nname: shared\ndescription: shared guidance\n---\n\nShared body.\n\n{{.RuleBody \"writing\"}}\n",
+	)
+	writeTestFile(
+		t,
+		filepath.Join(skillsDir, "root", "SKILL.md.tmpl"),
+		"---\nname: root\ndescription: root guidance\n---\n\nRoot body.\n\n{{.SkillBody \"shared\"}}\n",
+	)
+
+	dst := filepath.Join(t.TempDir(), "skills")
+	if err := RenderSkillDirs(skillsDir, dst, SkillRefMDC); err != nil {
+		t.Fatalf("RenderSkillDirs: %v", err)
+	}
+	rendered, err := os.ReadFile(filepath.Join(dst, "root", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading rendered skill: %v", err)
+	}
+	got := string(rendered)
+	if !strings.Contains(got, "Shared body.\n\nWriting guidance.") {
+		t.Errorf("rendered skill missing expanded skill and rule bodies:\n%s", got)
+	}
+	if strings.Contains(got, "name: shared") || strings.Contains(got, "description: shared guidance") {
+		t.Errorf("rendered skill retained embedded front matter:\n%s", got)
+	}
+	if strings.Count(got, GeneratedAgentHTMLMarker) != 1 {
+		t.Errorf("expected exactly one generated marker, got %d in:\n%s", strings.Count(got, GeneratedAgentHTMLMarker), got)
+	}
+	if strings.Contains(got, "{{") {
+		t.Errorf("rendered skill still contains unexpanded token:\n%s", got)
+	}
+}
+
+func TestRenderSkillDirsSkillBodyPreservesMarkdownWhitespace(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	writeTestFile(
+		t,
+		filepath.Join(skillsDir, "plain", "SKILL.md"),
+		"---\nname: plain\ndescription: plain guidance\n---\n    Keep {{ example }} literal.\n\nPlain hard break.  \n",
+	)
+	writeTestFile(
+		t,
+		filepath.Join(skillsDir, "templated", "SKILL.md.tmpl"),
+		"---\nname: templated\ndescription: templated guidance\n---\n    Link to {{.Skill \"root\"}}.\n\nTemplated hard break.  \n",
+	)
+	writeTestFile(
+		t,
+		filepath.Join(skillsDir, "root", "SKILL.md.tmpl"),
+		"---\nname: root\ndescription: root guidance\n---\n\nBefore plain\n{{.SkillBody \"plain\"}}After plain\n\nBefore templated\n{{.SkillBody \"templated\"}}After templated\n",
+	)
+
+	dst := filepath.Join(t.TempDir(), "skills")
+	if err := RenderSkillDirs(skillsDir, dst, SkillRefMDC); err != nil {
+		t.Fatalf("RenderSkillDirs: %v", err)
+	}
+	rendered, err := os.ReadFile(filepath.Join(dst, "root", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading rendered skill: %v", err)
+	}
+	got := string(rendered)
+	wantPlain := "Before plain\n    Keep {{ example }} literal.\n\nPlain hard break.  \nAfter plain"
+	if !strings.Contains(got, wantPlain) {
+		t.Errorf("rendered skill changed plain Markdown whitespace\nwant substring: %q\ngot:\n%s", wantPlain, got)
+	}
+	wantTemplated := "Before templated\n    Link to [root](../root/SKILL.md).\n\nTemplated hard break.  \nAfter templated"
+	if !strings.Contains(got, wantTemplated) {
+		t.Errorf("rendered skill changed templated Markdown whitespace\nwant substring: %q\ngot:\n%s", wantTemplated, got)
+	}
+}
+
+func TestRenderSkillDirsBodyEmbeddingRejectsCycles(t *testing.T) {
+	testCases := []struct {
+		name      string
+		rootSkill string
+		rules     map[string]string
+		skills    map[string]string
+		wantCycle string
+	}{
+		{
+			name:      "direct skill cycle",
+			rootSkill: "a",
+			skills: map[string]string{
+				"a": "{{.SkillBody \"a\"}}",
+			},
+			wantCycle: "skill:a -> skill:a",
+		},
+		{
+			name:      "nested skill cycle",
+			rootSkill: "a",
+			skills: map[string]string{
+				"a": "{{.SkillBody \"b\"}}",
+				"b": "{{.SkillBody \"a\"}}",
+			},
+			wantCycle: "skill:a -> skill:b -> skill:a",
+		},
+		{
+			name:      "nested rule cycle",
+			rootSkill: "root",
+			rules: map[string]string{
+				"a": "{{.RuleBody \"b\"}}",
+				"b": "{{.RuleBody \"a\"}}",
+			},
+			skills: map[string]string{
+				"root": "{{.RuleBody \"a\"}}",
+			},
+			wantCycle: "rule:a -> rule:b -> rule:a",
+		},
+		{
+			name:      "cross type cycle",
+			rootSkill: "a",
+			rules: map[string]string{
+				"bridge": "{{.SkillBody \"a\"}}",
+			},
+			skills: map[string]string{
+				"a": "{{.RuleBody \"bridge\"}}",
+			},
+			wantCycle: "skill:a -> rule:bridge -> skill:a",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			for name, body := range testCase.rules {
+				content := "---\ndescription: test rule\n---\n" + body + "\n"
+				writeTestFile(t, filepath.Join(root, "rules", name+".mdc"), content)
+			}
+			skillsDir := filepath.Join(root, "skills")
+			for name, body := range testCase.skills {
+				content := "---\nname: " + name + "\ndescription: test skill\n---\n\n" + body + "\n"
+				writeTestFile(t, filepath.Join(skillsDir, name, "SKILL.md.tmpl"), content)
+			}
+
+			dst := filepath.Join(t.TempDir(), "skills")
+			err := RenderSkillDirs(skillsDir, dst, SkillRefMDC)
+			if err == nil {
+				t.Fatal("expected RenderSkillDirs to fail on cyclic body embedding, got nil")
+			}
+			if !strings.Contains(err.Error(), testCase.wantCycle) {
+				t.Errorf("expected cycle %q in error, got: %v", testCase.wantCycle, err)
+			}
+			if _, statErr := os.Stat(filepath.Join(dst, testCase.rootSkill, "SKILL.md")); !os.IsNotExist(statErr) {
+				t.Errorf("expected no rendered root skill, stat error: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestRenderSkillDirsSkillBodyRejectsInvalidNames(t *testing.T) {
+	testCases := []struct {
+		name      string
+		reference string
+		wantError string
+	}{
+		{name: "missing", reference: "missing", wantError: "unknown skill body"},
+		{name: "traversal", reference: "../secrets", wantError: "invalid skill body name"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			skillsDir := filepath.Join(root, "skills")
+			content := "---\nname: root\ndescription: test skill\n---\n\n{{.SkillBody \"" + testCase.reference + "\"}}\n"
+			writeTestFile(t, filepath.Join(skillsDir, "root", "SKILL.md.tmpl"), content)
+
+			err := RenderSkillDirs(skillsDir, filepath.Join(t.TempDir(), "skills"), SkillRefMDC)
+			if err == nil {
+				t.Fatal("expected RenderSkillDirs to reject invalid SkillBody reference, got nil")
+			}
+			if !strings.Contains(err.Error(), testCase.wantError) {
+				t.Errorf("expected %q in error, got: %v", testCase.wantError, err)
+			}
+		})
+	}
+}
+
 func TestRenderSkillDirsRuleBodyMissing(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "rules", "code.mdc"), "---\ndescription: c\n---\ncode body\n")
@@ -416,27 +602,6 @@ func TestRenderSkillDirsRuleBodyRejectsTraversal(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid rule body name") {
 		t.Errorf("expected invalid rule body name in error, got: %v", err)
-	}
-}
-
-func TestRenderSkillDirsRuleBodyRejectsCycles(t *testing.T) {
-	root := t.TempDir()
-	rulesDir := filepath.Join(root, "rules")
-	writeTestFile(t, filepath.Join(rulesDir, "loop-a.mdc"), "---\ndescription: a\n---\n{{.RuleBody \"loop-b\"}}\n")
-	writeTestFile(t, filepath.Join(rulesDir, "loop-b.mdc"), "---\ndescription: b\n---\n{{.RuleBody \"loop-a\"}}\n")
-	skillsDir := filepath.Join(root, "skills")
-	writeTestFile(
-		t,
-		filepath.Join(skillsDir, "broken", "SKILL.md.tmpl"),
-		"---\nname: broken\ndescription: d\n---\n\n{{.RuleBody \"loop-a\"}}\n",
-	)
-	dst := filepath.Join(t.TempDir(), "skills")
-	err := RenderSkillDirs(skillsDir, dst, SkillRefMDC)
-	if err == nil {
-		t.Fatal("expected RenderSkillDirs to fail on cyclic rule body transclusion, got nil")
-	}
-	if !strings.Contains(err.Error(), "cyclic rule body transclusion") {
-		t.Errorf("expected cyclic transclusion in error, got: %v", err)
 	}
 }
 

--- a/dots/internal/sync/compilation/source_set_render.go
+++ b/dots/internal/sync/compilation/source_set_render.go
@@ -31,7 +31,7 @@ func RenderSkillDirsFromSourceSet(sourceSet CorpusSourceSet, dst string, refStyl
 	conflicts := make([]string, 0)
 	for _, skillName := range skillNames {
 		activeSkills[skillName] = struct{}{}
-		plan, err := renderSourceSkillPlan(sourceSet.Skills[skillName], filepath.Join(dst, skillName), refStyle, sourceSet.Rules, ruleNames)
+		plan, err := renderSourceSkillPlan(sourceSet.Skills[skillName], filepath.Join(dst, skillName), refStyle, sourceSet, ruleNames)
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func ValidateSkillDirsFromSourceSet(sourceSet CorpusSourceSet, dst string, refSt
 	conflicts := make([]string, 0)
 	for _, skillName := range skillNames {
 		targetDir := filepath.Join(dst, skillName)
-		plan, err := renderSourceSkillPlan(sourceSet.Skills[skillName], targetDir, refStyle, sourceSet.Rules, ruleNames)
+		plan, err := renderSourceSkillPlan(sourceSet.Skills[skillName], targetDir, refStyle, sourceSet, ruleNames)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func validateSkillPlanPaths(targetDir string, plan renderedSkillPlan) error {
 	return nil
 }
 
-func renderSourceSkillPlan(skill SkillSource, dst string, style SkillRefStyle, rules map[string]RuleSource, ruleNames []string) (renderedSkillPlan, error) {
+func renderSourceSkillPlan(skill SkillSource, dst string, style SkillRefStyle, sourceSet CorpusSourceSet, ruleNames []string) (renderedSkillPlan, error) {
 	plan := renderedSkillPlan{
 		name:      skill.Name,
 		files:     make(map[string]string),
@@ -134,7 +134,11 @@ func renderSourceSkillPlan(skill SkillSource, dst string, style SkillRefStyle, r
 		output := skill.Files[fileName]
 		if base, ok := strings.CutSuffix(cleanName, ".tmpl"); ok {
 			outputName = base
-			rendered, err := renderSourceSkillTemplate(output, style, rules, ruleNames, fileName)
+			rootSkillName := ""
+			if filepath.ToSlash(cleanName) == "SKILL.md.tmpl" {
+				rootSkillName = skill.Name
+			}
+			rendered, err := renderSourceSkillTemplate(output, style, sourceSet, ruleNames, fileName, rootSkillName)
 			if err != nil {
 				return renderedSkillPlan{}, err
 			}
@@ -155,10 +159,32 @@ func renderSourceSkillPlan(skill SkillSource, dst string, style SkillRefStyle, r
 
 type sourceSkillTemplateData struct {
 	style     SkillRefStyle
-	rules     map[string]RuleSource
+	sourceSet CorpusSourceSet
 	ruleNames []string
 	execErr   *error
-	expanding map[string]struct{}
+	stack     []sourceBodyRef
+	active    map[sourceBodyRef]int
+}
+
+type sourceBodyKind string
+
+const (
+	sourceBodyRule  sourceBodyKind = "rule"
+	sourceBodySkill sourceBodyKind = "skill"
+)
+
+type sourceBodyRef struct {
+	kind sourceBodyKind
+	name string
+}
+
+type sourceBody struct {
+	content    string
+	isTemplate bool
+}
+
+func (r sourceBodyRef) String() string {
+	return string(r.kind) + ":" + r.name
 }
 
 func (d *sourceSkillTemplateData) Rules() string            { return renderRulesList(d.style, d.ruleNames) }
@@ -166,36 +192,98 @@ func (d *sourceSkillTemplateData) Rule(name string) string  { return renderRuleL
 func (d *sourceSkillTemplateData) Skill(name string) string { return renderSkillSiblingLink(name) }
 
 func (d *sourceSkillTemplateData) RuleBody(name string) string {
-	if name == "" || name == "." || name == ".." || strings.Contains(name, "/") || strings.Contains(name, string(filepath.Separator)) {
-		d.setError(fmt.Errorf("invalid rule body name %q", name))
+	return d.renderBody(sourceBodyRef{kind: sourceBodyRule, name: name})
+}
+
+func (d *sourceSkillTemplateData) SkillBody(name string) string {
+	return d.renderBody(sourceBodyRef{kind: sourceBodySkill, name: name})
+}
+
+func (d *sourceSkillTemplateData) renderBody(ref sourceBodyRef) string {
+	if err := validateSourceBodyRef(ref); err != nil {
+		d.setError(err)
 		return ""
 	}
-	rule, ok := d.rules[name]
-	if !ok {
-		d.setError(fmt.Errorf("unknown rule body %q", name))
+	if cycleStart, exists := d.active[ref]; exists {
+		cycle := append(append([]sourceBodyRef(nil), d.stack[cycleStart:]...), ref)
+		cycleNames := make([]string, 0, len(cycle))
+		for _, cycleRef := range cycle {
+			cycleNames = append(cycleNames, cycleRef.String())
+		}
+		d.setError(fmt.Errorf("body embedding cycle: %s", strings.Join(cycleNames, " -> ")))
 		return ""
 	}
-	if _, exists := d.expanding[name]; exists {
-		d.setError(fmt.Errorf("cyclic rule body transclusion for %q", name))
-		return ""
-	}
-	d.expanding[name] = struct{}{}
-	defer delete(d.expanding, name)
-	body := strings.TrimSpace(rule.Body)
-	if !strings.Contains(body, "{{") {
-		return body
-	}
-	parsed, err := template.New(name + ".mdc").Parse(body)
+	body, err := d.readBody(ref)
 	if err != nil {
-		d.setError(fmt.Errorf("parsing rule body template %q: %w", name, err))
+		d.setError(err)
+		return ""
+	}
+	d.push(ref)
+	defer d.pop(ref)
+	if !body.isTemplate || !strings.Contains(body.content, "{{") {
+		return body.content
+	}
+	parsed, err := template.New(ref.String()).Parse(body.content)
+	if err != nil {
+		d.setError(fmt.Errorf("parsing %s body template: %w", ref, err))
 		return ""
 	}
 	var buffer bytes.Buffer
 	if err := parsed.Execute(&buffer, d); err != nil {
-		d.setError(fmt.Errorf("executing rule body template %q: %w", name, err))
+		d.setError(fmt.Errorf("executing %s body template: %w", ref, err))
 		return ""
 	}
-	return strings.TrimSpace(buffer.String())
+	return buffer.String()
+}
+
+func validateSourceBodyRef(ref sourceBodyRef) error {
+	name := ref.name
+	if name == "" || name == "." || name == ".." || strings.Contains(name, "/") || strings.Contains(name, string(filepath.Separator)) {
+		return fmt.Errorf("invalid %s body name %q", ref.kind, name)
+	}
+	return nil
+}
+
+func (d *sourceSkillTemplateData) readBody(ref sourceBodyRef) (sourceBody, error) {
+	switch ref.kind {
+	case sourceBodyRule:
+		rule, ok := d.sourceSet.Rules[ref.name]
+		if !ok {
+			return sourceBody{}, fmt.Errorf("unknown rule body %q", ref.name)
+		}
+		return sourceBody{content: rule.Body, isTemplate: true}, nil
+	case sourceBodySkill:
+		skill, ok := d.sourceSet.Skills[ref.name]
+		if !ok {
+			return sourceBody{}, fmt.Errorf("unknown skill body %q", ref.name)
+		}
+		content, ok := skill.Files["SKILL.md.tmpl"]
+		isTemplate := ok
+		if !ok {
+			content, ok = skill.Files["SKILL.md"]
+		}
+		if !ok {
+			return sourceBody{}, fmt.Errorf("skill body %q has no SKILL.md source", ref.name)
+		}
+		_, body, err := parseSkillDocument(content)
+		if err != nil {
+			slog.Warn("compilation: parsing embedded skill body", "skill", ref.name, "err", err)
+			return sourceBody{}, fmt.Errorf("parsing skill body %q: %w", ref.name, err)
+		}
+		return sourceBody{content: body, isTemplate: isTemplate}, nil
+	default:
+		return sourceBody{}, fmt.Errorf("unknown body kind %q", ref.kind)
+	}
+}
+
+func (d *sourceSkillTemplateData) push(ref sourceBodyRef) {
+	d.active[ref] = len(d.stack)
+	d.stack = append(d.stack, ref)
+}
+
+func (d *sourceSkillTemplateData) pop(ref sourceBodyRef) {
+	delete(d.active, ref)
+	d.stack = d.stack[:len(d.stack)-1]
 }
 
 func (d *sourceSkillTemplateData) setError(err error) {
@@ -204,7 +292,7 @@ func (d *sourceSkillTemplateData) setError(err error) {
 	}
 }
 
-func renderSourceSkillTemplate(content string, style SkillRefStyle, rules map[string]RuleSource, ruleNames []string, name string) (string, error) {
+func renderSourceSkillTemplate(content string, style SkillRefStyle, sourceSet CorpusSourceSet, ruleNames []string, name string, rootSkillName string) (string, error) {
 	parsed, err := template.New(name).Parse(content)
 	if err != nil {
 		slog.Warn("compilation: parsing skill template", "name", name, "err", err)
@@ -213,10 +301,14 @@ func renderSourceSkillTemplate(content string, style SkillRefStyle, rules map[st
 	var execErr error
 	data := &sourceSkillTemplateData{
 		style:     style,
-		rules:     rules,
+		sourceSet: sourceSet,
 		ruleNames: ruleNames,
 		execErr:   &execErr,
-		expanding: make(map[string]struct{}),
+		stack:     make([]sourceBodyRef, 0),
+		active:    make(map[sourceBodyRef]int),
+	}
+	if rootSkillName != "" {
+		data.push(sourceBodyRef{kind: sourceBodySkill, name: rootSkillName})
 	}
 	var buffer bytes.Buffer
 	if err := parsed.Execute(&buffer, data); err != nil {


### PR DESCRIPTION
### Summary

The corpus compiler can now inline reusable skill bodies without copying their front matter.

## Change

`SkillBody` and `RuleBody` use one expansion path. Typed cycle tracking rejects direct, nested, and cross type recursion before rendered files are written.

Templated skill bodies expand nested directives. Plain Markdown skill bodies remain literal.